### PR TITLE
docs: phase-by-phase dashboard wireframes for the UI/UX pass

### DIFF
--- a/docs/wireframes/README.md
+++ b/docs/wireframes/README.md
@@ -1,0 +1,115 @@
+# Dashboard wireframes
+
+Phase-by-phase wireframes for the UI/UX pass tracked in #15. Each page shows the dashboard as it
+would look after one shippable phase, with numbered callouts and a change ledger keyed to the
+task IDs from the source proposal.
+
+## Viewing
+
+These are self-contained HTML files. Open `index.html` in a browser and follow the links, or:
+
+```bash
+open docs/wireframes/index.html
+```
+
+GitHub will not render them in the browser, so clone or download the folder to view.
+
+| File | Covers |
+|---|---|
+| [`index.html`](index.html) | Current dashboard redrawn, the three structural gaps, the phase ladder, and every open question answered |
+| [`phase-0-foundation.html`](phase-0-foundation.html) | Design tokens, urgency bands, badge pass preview, density, greyscale proof |
+| [`phase-1-thesis.html`](phase-1-thesis.html) | Score chip, breakdown popover, one ranked list grouped by actionability, status key |
+| [`phase-2-speed-and-control.html`](phase-2-speed-and-control.html) | Focused row, shortcut sheet, local triage, query grammar, command palette |
+| [`phase-3-shape-of-a-day.html`](phase-3-shape-of-a-day.html) | Per-source freshness, sprint progress, the four-step planning ritual, Today planned, wrap up |
+| [`phase-4-finish.html`](phase-4-finish.html) | Microcopy, the scoring reference, empty and error states, 1024 / 375 layouts |
+| `wireframe.css` | Shared stylesheet. Document chrome and a faithful copy of the app's dark tokens |
+
+The document uses two registers deliberately: warm ink and a serif face is the reviewer talking,
+cool black and sans is the product. The gold thread is the only element that crosses between them,
+because inside the product it marks Today, and nothing else.
+
+## Phases
+
+Dependency order matters. Every phase is a state the dashboard can live in indefinitely.
+
+| Phase | Tasks | Outcome |
+|---|---|---|
+| 0. Foundation | P0 | One colour system, a 4px grid, urgency no longer carried by colour alone |
+| 1. Make the thesis visible | P1, P2, P4, P10 items 1 to 5 | Numeric score on every row with its arithmetic one keypress away, one full-width ranked list grouped by obligation |
+| 2. Speed and control | P3, P5, P6, P12 | Keyboard-first, locally triageable, sliceable, instant |
+| 3. The shape of a day | P7, P9, P8 | Deliberate choosing, honest capacity, trustworthy freshness |
+| 4. Finish | P11, P10 items 6 to 9 | Copy, the transparency surface, responsive and accessibility floor |
+
+If only one phase ever ships, phase 1 is the one. It closes the gap between what the README claims
+and what the interface shows.
+
+## What the wireframes settled
+
+The source proposal left nine product decisions open. All nine are answered on `index.html`. The
+three that matter most, because the codebase already had an opinion:
+
+**Score bands needed no deriving.** `getPriorityTier()` in `lib/scoring.ts` already cuts at 60, 40
+and 25, aligned with `NEEDS_ATTENTION_THRESHOLD`, and the maximum achievable score is 105
+(`approved_unmerged` 45, plus due 25, plus unresolved conversations 20, plus stale 15). The chip
+inherits the tier that already sorts the list, so its colour and the sort order cannot disagree.
+
+**Ad-hoc placement was already solved, invisibly.** `getGroupedItems()` exempts
+`source === 'adhoc'` from the 25-point threshold. Keep the exemption and the shared formula, and
+make the exemption visible with a `Kept visible` marker, rather than giving ad-hoc a privileged
+always-visible group. Ranking by origin is the thing P2 exists to delete.
+
+**Two sort rules are invisible today and must be disclosed.** `sortByUrgency()` promotes every
+in-progress item above everything else regardless of score, and the ad-hoc threshold exemption
+overrides the number on screen. A scoring reference that lists only the point table would be
+technically accurate and practically a lie, so phase 4 documents both.
+
+## Deliberate deviations from the proposal
+
+**`approved_unmerged` goes in "Waiting on you", not "Moving without you".** It is the highest
+scoring reason in the whole formula at 45 points. The repo already believes it is the most urgent
+thing that can happen to you, and it is urgent precisely because the ball is now in your court to
+merge. Filing it as informational would put the top-scoring reason in the quiet group.
+
+**The section is titled "Signals, 19" with a "12 need something from you" sub-line.** Folding the
+old "Everything else, 9" card into the ranked list would otherwise make the headline count jump
+from 10 to 19 and read as new work arriving. Two numbers, two denominators.
+
+**"Lower priority" lands in phase 1, not phase 4.** P2 creates the label and P11 renames it.
+Renaming a label you created in the same pass costs nothing.
+
+## What the wireframes found in the code
+
+Four things the source proposal could not know from a screenshot:
+
+- `TIER_DOT_CLASS.medium` is `bg-primary`. Indigo currently carries urgency, status and
+  interactivity at once, which is a stronger version of the critique than the screenshot suggests.
+- `adoStatusVariant()` has no branch for `Blocked`, so it falls through to `outline`, the calmest
+  treatment available. Phase 0 contains a genuine bug fix, not just a recolour.
+- `ShutdownDialog.tsx` already builds most of P7's wrap-up ritual: completed today, still open,
+  total hours logged, carry to tomorrow. What it lacks is the plan it was measured against, an
+  estimate comparison, and a name that says what it does. It is currently reached from a link
+  called "Review my day" sitting in the Today header, where a planning control belongs.
+- Rows must stay one fixed-height line. At the 960px content column that gives titles about 78
+  characters, comfortably past the 60-character floor the proposal sets, against roughly 30 in
+  today's source columns.
+
+## Guardrails these wireframes hold to
+
+From #15, checked on every page:
+
+- One row grammar: one primary action, one overflow menu, one inline badge. The pin button moves
+  into the overflow menu, which reduces the row rather than adding to it.
+- Parked stays a dimmed sub-list inside In progress, never a duplicate section.
+- Today and In progress stay disjoint buckets.
+- The sprint header stays an ambient single-row status line, not a card.
+
+The one guardrail these wireframes knowingly exceed is scope. #15 calls this a polish pass, but its
+own guardrails point at P2, which deletes the source-column layout outright. Source as container is
+not in the guardrails, and removing it is what buys the full titles, the strict score order, and the
+400px of reclaimed space that everything else depends on.
+
+## Source
+
+`ariadne-ui-ux-proposal.md` v1.0, dated 2026-08-14, with `ariadne-market-research.html` as its
+companion. Both live outside the repo. Comparators studied: Graphite, Octobox, GitHub Inbox,
+Linear, Sunsama, Motion, Reclaim, Glance, Raycast GitHub, LinearB.

--- a/docs/wireframes/index.html
+++ b/docs/wireframes/index.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ariadne — wireframes for issue #15</title>
+<link rel="stylesheet" href="wireframe.css">
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <p class="kicker">Ariadne · issue #15 · wireframes</p>
+  <h1>Following the <em>thread</em><br>through five phases</h1>
+  <p class="standfirst">Ariadne already ranks your work with a formula you can read end to end. The
+  interface hides it behind a six-pixel dot. These wireframes walk the dashboard from where it is
+  today to where the proposal points it — one shippable phase at a time.</p>
+  <p class="meta">
+    Source <b>ariadne-ui-ux-proposal.md v1.0</b> · Baseline <b>Sprint 4 dashboard, empty Today</b><br>
+    Register: warm ink and serif is the reviewer talking · cool black and sans is the product
+  </p>
+</header>
+
+<main class="thread">
+
+  <!-- ================================================================== -->
+  <section class="phase node" id="baseline">
+    <p class="eyebrow">Baseline<span class="sep">/</span><span class="tasks">what ships today</span></p>
+    <h2>Where the dashboard is now</h2>
+    <p>Redrawn from the current build so every later phase has something exact to diverge from. Three
+    problems are marked; each one anchors a phase.</p>
+
+    <figure class="frame">
+      <figcaption><span>Dashboard · today</span><span class="w">1440px viewport · 960px content column</span></figcaption>
+      <div class="stage">
+        <div class="ui">
+
+          <div class="topbar">
+            <span class="logo"><span class="glyph">✳</span> Ariadne</span>
+            <span class="spacer"></span>
+            <span class="search">⌕ Search work items, PRs, people…</span>
+            <span class="spacer"></span>
+            <span class="iconbtn">▥</span><span class="iconbtn">⚙</span><span class="iconbtn">☀</span>
+          </div>
+
+          <div class="statusline">
+            <b>Sprint 4</b><span class="dot">·</span>0/17 done<span class="dot">·</span>13 days left
+            <span class="dot">·</span>Last synced: just now
+            <span class="spacer"></span>
+            <span class="iconbtn">＋</span>
+            <span class="btn primary">⟳ Refresh</span>
+          </div>
+
+          <div class="sec">
+            <div class="card">
+              <div class="sec-head" style="padding-bottom:6px">Today <span class="count">0</span>
+                <span class="right" style="color:#a1a1aa">Review my day</span></div>
+              <div class="empty"><p style="margin:0">Nothing chosen for today — pin something from below.</p></div>
+            </div>
+          </div>
+
+          <div class="sec">
+            <div class="card">
+              <div class="sec-head">In progress <span class="count">3</span><span class="right">⌃</span></div>
+              <div class="row">
+                <span class="src">⑂</span>
+                <span class="titles">
+                  <span class="title">Add granular member/group management permissions and org-level grants</span>
+                  <span class="ctx">pro4all-services-identity</span>
+                </span>
+                <span class="badge old-review">Ready for review</span>
+                <span class="olddot high"></span>
+                <span class="actions"><span class="btn primary">Complete</span><span class="iconbtn">⋯</span></span>
+              </div>
+              <div class="row">
+                <span class="src">⑂</span>
+                <span class="titles">
+                  <span class="title">feat: project shared links actions - revoke, extend, reuse, open link (WI-41448 Phase 2)</span>
+                  <span class="ctx">pro4all-prostream-frontend</span>
+                </span>
+                <span class="badge old-review">Ready for review</span>
+                <span class="olddot med"></span>
+                <span class="actions"><span class="btn primary">Complete</span><span class="iconbtn">⋯</span></span>
+              </div>
+              <div class="row">
+                <span class="src">⑂</span>
+                <span class="titles">
+                  <span class="title">feat: revoke authorization fix, extend, and reuse fields for project shared links (WI-41448 Phase 2)</span>
+                  <span class="ctx">pro4all-services-hyperlink</span>
+                </span>
+                <span class="badge old-review">Ready for review</span>
+                <span class="olddot low"></span>
+                <span class="actions"><span class="btn primary">Complete</span><span class="iconbtn">⋯</span></span>
+              </div>
+              <div class="grouphead" style="padding:14px 0 2px">Paused · 4</div>
+              <div class="row" style="min-height:34px"><span class="titles"><span class="title" style="color:#a1a1aa">[BE+FE] 01. Project admins can view and manage shared links within a project</span></span><span class="btn ghost" style="color:#8179f0">Resume</span></div>
+              <div class="row" style="min-height:34px"><span class="titles"><span class="title" style="color:#a1a1aa">Prostream - Published Excel file loses file extension</span></span><span class="btn ghost" style="color:#8179f0">Resume</span></div>
+              <div class="row" style="min-height:34px"><span class="titles"><span class="title" style="color:#a1a1aa">feat: project shared links overview (WI-41448)</span></span><span class="btn ghost" style="color:#8179f0">Resume</span></div>
+              <div class="row" style="min-height:34px"><span class="titles"><span class="title" style="color:#a1a1aa">Fix: preserve file extension when publishing after Edit Locally (AB#41758)</span></span><span class="btn ghost" style="color:#8179f0">Resume</span></div>
+            </div>
+          </div>
+
+          <div class="sec">
+            <div class="sec-head">Needs attention <span class="count">10</span></div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
+              <div class="card" style="align-self:stretch">
+                <div class="sec-head" style="font-weight:500"><span class="src">⑂</span> GitHub <span class="right"><span class="count">2</span></span></div>
+                <div class="row"><span class="src">⑂</span><span class="titles"><span class="title"><span class="trunc">feat(#39596): option to disable notification digest</span></span><span class="ctx">pro4all-services-identity</span></span><span class="badge old-neutral">Draft</span><span class="olddot crit"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+                <div class="row"><span class="src">⑂</span><span class="titles"><span class="title"><span class="trunc">fix: reassign document owner on user deactivation</span></span><span class="ctx">pro4all-services-dms</span></span><span class="badge old-review">Ready for review</span><span class="olddot med"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+                <div style="height:190px"></div>
+              </div>
+              <div class="card">
+                <div class="sec-head" style="font-weight:500"><span class="src">▤</span> Azure DevOps <span class="right"><span class="count">7</span></span></div>
+                <div class="row"><span class="src">▤</span><span class="titles"><span class="title"><span class="trunc">[BE] Optimistic concurrency on document set updates</span></span></span><span class="badge old-blocked">Blocked</span><span class="olddot high"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+                <div class="row"><span class="src">▤</span><span class="titles"><span class="title"><span class="trunc">Option to Disable User Notifications</span></span></span><span class="badge old-blocked">Blocked</span><span class="olddot high"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+                <div class="row"><span class="src">▤</span><span class="titles"><span class="title"><span class="trunc">Document sets: toast is incorrect after publishing</span></span></span><span class="badge old-neutral">Code Review</span><span class="olddot high"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+                <div class="row"><span class="src">▤</span><span class="titles"><span class="title"><span class="trunc">Prostream - QR stamp fails with rotated pages</span></span></span><span class="badge old-neutral">To Do</span><span class="olddot high"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+                <div class="row"><span class="src">▤</span><span class="titles"><span class="title"><span class="trunc">Prostream - 12Build not working after migration</span></span></span><span class="badge old-progress">In Progress</span><span class="olddot high"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+                <div class="row"><span class="src">▤</span><span class="titles"><span class="title"><span class="trunc">Prostream - users not found in project member picker</span></span></span><span class="badge old-neutral">To Do</span><span class="olddot high"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+                <div class="row"><span class="src">▤</span><span class="titles"><span class="title"><span class="trunc">Prostream - Missing username on published document</span></span></span><span class="badge old-neutral">To Do</span><span class="olddot high"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+              </div>
+            </div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:14px">
+              <div class="card">
+                <div class="sec-head" style="font-weight:500"><span class="src">✉</span> Ad-hoc <span class="right"><span class="count">1</span></span></div>
+                <div class="row"><span class="src">✉</span><span class="titles"><span class="title"><span class="trunc">Create pipeline template for gateway smoke tests</span></span></span><span class="badge old-neutral">Ad-hoc</span><span class="olddot low"></span><span class="actions"><span class="iconbtn">⚲</span><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+              </div>
+              <div></div>
+            </div>
+          </div>
+
+          <div class="sec">
+            <div class="card"><div class="sec-head" style="padding:0">Everything else <span class="count">9</span><span class="right">⌄</span></div></div>
+          </div>
+
+        </div>
+      </div>
+    </figure>
+
+    <ol class="pins">
+      <li><span class="n">A</span><span><b>The thesis is invisible.</b> Urgency arrives as an unlabelled dot. The
+        breakdown exists in <code>scoreBreakdown()</code> and reaches the user only as a hover title on that dot.</span></li>
+      <li><span class="n">B</span><span><b>The organising principle fights the promise.</b> Source is the container,
+        so a Draft PR sits above a Blocked work item, the GitHub card stretches to ~190px of dead space, and titles
+        clip at roughly 30 characters while full-width rows above them show 90.</span></li>
+      <li><span class="n">C</span><span><b>The day has no shape.</b> Today is empty behind a text link while seven
+        items are simultaneously started — three in progress, four paused.</span></li>
+      <li><span class="n">D</span><span><b>Colour does three jobs at once.</b> Indigo means interactive, status
+        <em>and</em> urgency — <code>TIER_DOT_CLASS.medium</code> is literally <code>bg-primary</code>, the same token
+        as the Refresh button. Meanwhile <code>Blocked</code> is the calmest thing on screen, because
+        <code>adoStatusVariant()</code> has no case for it and falls through to <code>outline</code>.</span></li>
+      <li><span class="n">E</span><span><b>Refresh is the loudest element on the page.</b> Maintenance outranks work.</span></li>
+    </ol>
+  </section>
+
+  <!-- ================================================================== -->
+  <section class="phase node" id="ladder">
+    <p class="eyebrow">The ladder<span class="sep">/</span><span class="tasks">five phases, each shippable alone</span></p>
+    <h2>What each phase buys</h2>
+    <p>Dependency order from the proposal, unchanged. Every phase is a state the dashboard can live in
+    indefinitely — no phase leaves the product half-converted.</p>
+
+    <table class="tokens">
+      <thead><tr><th>Phase</th><th>Tasks</th><th>The dashboard becomes</th></tr></thead>
+      <tbody>
+        <tr><td class="name"><a href="phase-0-foundation.html">0 · Foundation</a></td><td class="val">P0</td>
+            <td class="use">Same layout, one colour system. Urgency stops being colour-only, spacing lands on a 4px grid, <code>Blocked</code> stops whispering.</td></tr>
+        <tr><td class="name"><a href="phase-1-thesis.html">1 · Make the thesis visible</a></td><td class="val">P1 P2 P4 P10¹⁻⁵</td>
+            <td class="use">One full-width ranked list grouped by what it wants from you, a numeric score chip on every row, and the arithmetic one keypress away. <b>If only one phase ships, this one.</b></td></tr>
+        <tr><td class="name"><a href="phase-2-speed-and-control.html">2 · Speed and control</a></td><td class="val">P3 P5 P6 P12</td>
+            <td class="use">Keyboard-first: focused row, actions at rest, local triage, a prefix query language, ⌘K over local SQLite.</td></tr>
+        <tr><td class="name"><a href="phase-3-shape-of-a-day.html">3 · The shape of a day</a></td><td class="val">P7 P9 P8</td>
+            <td class="use">A planning ritual with honest capacity, a visible timer, per-source freshness you can trust.</td></tr>
+        <tr><td class="name"><a href="phase-4-finish.html">4 · Finish</a></td><td class="val">P11 P10⁶⁻⁹</td>
+            <td class="use">Copy that never implies the tool decided, a user-facing scoring reference, and a responsive/a11y floor down to 375px.</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note decision">
+      <span class="tag">Scope note</span>
+      Issue #15 calls this a polish pass, not a redesign — but its own guardrails point at
+      <b>P2</b>, which deletes the source-column layout outright. That is the one place these wireframes
+      knowingly exceed the issue: the guardrails say keep one row grammar, keep Parked dimmed inside
+      In&nbsp;progress, keep Today and In&nbsp;progress disjoint, keep the sprint header ambient. All four survive
+      here. What does not survive is <em>source as container</em>, and that was never in the guardrails.
+    </div>
+  </section>
+
+  <!-- ================================================================== -->
+  <section class="phase node" id="decisions">
+    <p class="eyebrow">Decisions<span class="sep">/</span><span class="tasks">proposal §12, answered</span></p>
+    <h2>Nine open questions, closed</h2>
+    <p>The proposal left these for the maintainer. Each is answered here so the wireframes are drawable;
+    each is a decision you can reverse, not an assumption buried in markup.</p>
+
+    <table class="tokens">
+      <thead><tr><th>Question</th><th>Answer used in these wireframes</th></tr></thead>
+      <tbody>
+        <tr><td class="use" style="color:var(--bone)">1 · Score bands</td>
+            <td class="use">Already derivable. Max achievable is <b>105</b> (<code>approved_unmerged</code> 45 + due 25 +
+            unresolved 20 + stale 15). <code>getPriorityTier()</code> already draws lines at 60 / 40 / 25, and
+            <code>NEEDS_ATTENTION_THRESHOLD</code> is 25 — so the four bands are <b>≥60 critical, 40–59 high,
+            25–39 medium, &lt;25 low</b>. No new numbers invented; the chip inherits the tier that already sorts the list.</td></tr>
+        <tr><td class="use" style="color:var(--bone)">2 · Group precedence</td>
+            <td class="use">Yes, <code>Blocked</code> outranks <code>Waiting on you</code> — the verb differs, nudge vs work.
+            But see the deviation on the Phase&nbsp;1 page: <code>approved_unmerged</code> is <em>not</em> "moving without you".</td></tr>
+        <tr><td class="use" style="color:var(--bone)">3 · Ad-hoc placement</td>
+            <td class="use">Already solved, in code, invisibly. <code>getGroupedItems()</code> exempts
+            <code>source === 'adhoc'</code> from the 25-point threshold, so a 10-point ad-hoc item never sinks out of
+            Needs&nbsp;attention. Keep the exemption, keep the shared formula, and make the exemption <em>visible</em> —
+            an ad-hoc row below the threshold carries a <code>Kept visible</code> marker so the user can see a rule was
+            applied. A privileged always-visible group would mean ranking by origin, the exact thing P2 deletes.</td></tr>
+        <tr><td class="use" style="color:var(--bone)">4 · Snooze on activity</td>
+            <td class="use">Yes, returns early — but says so. The snooze menu reads "until activity" as an explicit option
+            and the row carries a <code>Woke early</code> marker, so the surprise is labelled rather than silent.</td></tr>
+        <tr><td class="use" style="color:var(--bone)">5 · Default capacity</td>
+            <td class="use">6h, pre-filled and editable inline in step 4 of the first ritual. Asking on first run is a
+            question with no context behind it; showing the arithmetic gives the answer context.</td></tr>
+        <tr><td class="use" style="color:var(--bone)">6 · Sprint denominator</td>
+            <td class="use">Sprint counters count sprint items only, and the status line says so: "0/17 sprint items done".
+            Non-sprint signals carry no sprint mark, and the header's attention count is labelled with its own
+            denominator rather than sharing one.</td></tr>
+        <tr><td class="use" style="color:var(--bone)">7 · Density default</td>
+            <td class="use">Comfortable (44px). Compact is one toggle away and drawn on the Phase&nbsp;0 page.
+            A tool opened dozens of times a day should not start at its tightest setting.</td></tr>
+        <tr><td class="use" style="color:var(--bone)">8 · Token storage</td>
+            <td class="use">Out of scope for a UI pass, and the README already states the <code>.env</code>-grade
+            tradeoff. Phase 4 surfaces that sentence in Settings instead of hiding it.</td></tr>
+        <tr><td class="use" style="color:var(--bone)">9 · Is P6 too much surface?</td>
+            <td class="use">Inside, but only at the exact grammar listed — nine prefixes, comma OR, leading
+            <code>-</code> negation. It replaces a search box that already exists; it adds no route and no
+            dependency. The cap is the grammar, and the grammar is closed.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="phase node hollow">
+    <p class="eyebrow">Start here</p>
+    <h2>Phase 0 → Foundation</h2>
+    <p>One colour system, a spacing grid, and urgency that survives greyscale.
+    <a href="phase-0-foundation.html">Open Phase 0 →</a></p>
+  </section>
+
+</main>
+
+<nav class="pager">
+  <span><span class="lbl">Contents</span>
+    <a href="#baseline">Baseline</a> ·
+    <a href="#ladder">The ladder</a> ·
+    <a href="#decisions">Decisions</a></span>
+  <span><span class="lbl">Next</span><a href="phase-0-foundation.html">Phase 0 · Foundation →</a></span>
+</nav>
+
+</div>
+</body>
+</html>

--- a/docs/wireframes/phase-0-foundation.html
+++ b/docs/wireframes/phase-0-foundation.html
@@ -1,0 +1,249 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Phase 0 · Foundation — Ariadne wireframes</title>
+<link rel="stylesheet" href="wireframe.css">
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <p class="kicker"><a href="index.html">Ariadne wireframes</a> · phase 0 of 4</p>
+  <h1>Foundation</h1>
+  <p class="standfirst">Nothing moves. One colour system replaces three, urgency stops being carried by
+  colour alone, and every measurement in the interface lands on a 4px grid. This is the phase whose
+  screenshot looks almost identical and whose diff touches every component.</p>
+  <p class="meta">Task <b>P0</b> · Effort <b>S</b> · Depends on <b>nothing</b> · Layout <b>unchanged</b></p>
+</header>
+
+<main class="thread">
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">01<span class="sep">/</span><span class="tasks">the problem stated precisely</span></p>
+    <h2>Three colour systems, one channel</h2>
+    <p>Indigo currently means "you can click this" and "this is the status" at the same time. Gold means
+    brand. And urgency — the product's whole claim — is a 7px dot with four unlabelled states. Meanwhile
+    <code>adoStatusVariant()</code> has no branch for <em>Blocked</em>, so the most urgent state on screen
+    falls through to <code>outline</code>: the calmest treatment available.</p>
+
+    <h4 class="sub">One job per channel</h4>
+    <table class="tokens">
+      <thead><tr><th>Channel</th><th>Owns</th><th>Never</th></tr></thead>
+      <tbody>
+        <tr><td class="name"><span class="sw" style="background:#8179f0"></span> Indigo</td>
+            <td class="use">Interactive only — primary buttons, links, focus rings, selected state</td>
+            <td class="val">Status · urgency</td></tr>
+        <tr><td class="name"><span class="sw" style="background:linear-gradient(90deg,#e5484d,#f5a524,#a1a1aa)"></span> Urgency</td>
+            <td class="use">The <b>numeral</b> and the <b>sort position</b>. Colour reinforces the top two bands only</td>
+            <td class="val">Decoration</td></tr>
+        <tr><td class="name"><span class="sw" style="background:#f9a825"></span> Status</td>
+            <td class="use">Neutral outline by default; semantic fill reserved for states that demand action</td>
+            <td class="val">Brand expression</td></tr>
+        <tr><td class="name"><span class="sw" style="background:#cfa348"></span> Gold</td>
+            <td class="use">The logotype, and the Today thread marker. Brand and meaning coincide in exactly one place</td>
+            <td class="val">General accents</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note decision">
+      <span class="tag">Decision · score bands</span>
+      The proposal's 80/60/30 were placeholders. They don't need deriving — they're already in the repo.
+      <code>lib/scoring.ts</code> tops out at <b>105</b> and <code>getPriorityTier()</code> already cuts at
+      <b>60 / 40 / 25</b>, aligned to <code>NEEDS_ATTENTION_THRESHOLD</code>. The chip inherits the tier
+      that already sorts the list, so the colour a user sees and the order they see it in cannot disagree.
+    </div>
+
+    <h4 class="sub">Urgency bands — derived, not chosen</h4>
+    <table class="tokens">
+      <thead><tr><th>Token</th><th>Range</th><th>Chip</th><th>Reachable by</th></tr></thead>
+      <tbody>
+        <tr><td class="name">--urgency-critical</td><td class="val">≥ 60</td>
+            <td><span class="ui" style="width:auto;min-width:0;padding:0;background:none"><span class="score critical">92</span></span></td>
+            <td class="use">Ready to merge, or any reason stacked with a deadline</td></tr>
+        <tr><td class="name">--urgency-high</td><td class="val">40 – 59</td>
+            <td><span class="ui" style="width:auto;min-width:0;padding:0;background:none"><span class="score high">45</span></span></td>
+            <td class="use">Review requested · mentioned · ready to merge alone</td></tr>
+        <tr><td class="name">--urgency-medium</td><td class="val">25 – 39</td>
+            <td><span class="ui" style="width:auto;min-width:0;padding:0;background:none"><span class="score medium">30</span></span></td>
+            <td class="use">Stale own PR · assigned with a deadline</td></tr>
+        <tr><td class="name">--urgency-low</td><td class="val">&lt; 25</td>
+            <td><span class="ui" style="width:auto;min-width:0;padding:0;background:none"><span class="score low">10</span></span></td>
+            <td class="use">Assigned · authored · ad-hoc. Below the attention threshold</td></tr>
+      </tbody>
+    </table>
+    <p class="dek" style="margin-top:.9rem">Only the top two bands are filled. Medium is an outline, low has
+    no border at all — so the visual weight of the list falls off in the same direction the numbers do.</p>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">02<span class="sep">/</span><span class="tasks">badge pass, previewed</span></p>
+    <h2>Blocked stops whispering</h2>
+    <p>P4 finishes the badge system in Phase 1, but the tokens land here, so the difference is worth seeing
+    at token level first. Same six states, same labels, one legible hierarchy.</p>
+
+    <div class="compare two">
+      <figure class="before">
+        <figcaption>Today</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="display:flex;flex-wrap:wrap;gap:8px;padding:0">
+            <span class="badge old-blocked">Blocked</span>
+            <span class="badge old-review">Ready for review</span>
+            <span class="badge old-progress">In Progress</span>
+            <span class="badge old-neutral">To Do</span>
+            <span class="badge old-neutral">Draft</span>
+            <span class="badge old-neutral">Code Review</span>
+          </div>
+          <p class="dek" style="font-family:var(--sans);font-size:12.5px;margin:14px 0 0">
+            Blocked is the quietest chip on the row. Indigo appears twice, in both cases meaning "status",
+            three pixels from a button where it means "click".</p>
+        </div>
+      </figure>
+      <figure class="after">
+        <figcaption>Phase 0</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="display:flex;flex-wrap:wrap;gap:8px;padding:0">
+            <span class="badge blocked">Blocked</span>
+            <span class="badge review">Ready for review</span>
+            <span class="badge progress">In Progress</span>
+            <span class="badge neutral">To Do</span>
+            <span class="badge neutral">Draft</span>
+            <span class="badge neutral">Code Review</span>
+          </div>
+          <p class="dek" style="font-family:var(--sans);font-size:12.5px;margin:14px 0 0">
+            One filled chip, and it's the one that needs a human. Everything else is an outline or a flat
+            neutral. Indigo has left the row entirely.</p>
+        </div>
+      </figure>
+    </div>
+
+    <div class="note">
+      <span class="tag">Guardrail check</span>
+      <b>One inline badge per row survives.</b> Nothing here adds a chip; the six variants are recoloured, not
+      multiplied. <code>adoStatusVariant()</code> gains one branch — a <code>/block/</code> test returning
+      <code>warning</code> — which is also the bug fix hiding inside this task.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">03<span class="sep">/</span><span class="tasks">the a11y claim, proven</span></p>
+    <h2>The greyscale proof</h2>
+    <p>WCAG 1.4.1 says colour can't be the only carrier of information. The cheapest way to check that is
+    to remove the colour. Here is the same row list twice — the right-hand copy has
+    <code>filter: grayscale(1)</code> and nothing else changed.</p>
+
+    <div class="compare two">
+      <figure class="after">
+        <figcaption>In colour</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="row"><span class="score critical">92</span><span class="src">⑂</span><span class="titles"><span class="title">Ready to merge, unresolved threads, 8 days quiet</span></span><span class="badge review">Approved</span></div>
+            <div class="row"><span class="score high">45</span><span class="src">▤</span><span class="titles"><span class="title">Optimistic concurrency on document set updates</span></span><span class="badge blocked">Blocked</span></div>
+            <div class="row"><span class="score medium">30</span><span class="src">⑂</span><span class="titles"><span class="title">No reviews on your PR for three days</span></span><span class="badge review">Ready for review</span></div>
+            <div class="row"><span class="score low">10</span><span class="src">✉</span><span class="titles"><span class="title">Create pipeline template for gateway smoke tests</span></span><span class="badge neutral">Ad-hoc</span></div>
+          </div>
+        </div>
+      </figure>
+      <figure class="after">
+        <figcaption>Greyscale</figcaption>
+        <div class="stage pad" style="filter:grayscale(1)">
+          <div class="ui fluid" style="padding:0">
+            <div class="row"><span class="score critical">92</span><span class="src">⑂</span><span class="titles"><span class="title">Ready to merge, unresolved threads, 8 days quiet</span></span><span class="badge review">Approved</span></div>
+            <div class="row"><span class="score high">45</span><span class="src">▤</span><span class="titles"><span class="title">Optimistic concurrency on document set updates</span></span><span class="badge blocked">Blocked</span></div>
+            <div class="row"><span class="score medium">30</span><span class="src">⑂</span><span class="titles"><span class="title">No reviews on your PR for three days</span></span><span class="badge review">Ready for review</span></div>
+            <div class="row"><span class="score low">10</span><span class="src">✉</span><span class="titles"><span class="title">Create pipeline template for gateway smoke tests</span></span><span class="badge neutral">Ad-hoc</span></div>
+          </div>
+        </div>
+      </figure>
+    </div>
+    <p class="dek" style="margin-top:1rem">Ranking survives, because it was never the colour doing the work —
+    it was the numeral, the fill weight, and the order. Run the same test on the current dot column and the
+    right-hand copy carries no urgency information at all.</p>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">04<span class="sep">/</span><span class="tasks">density and the data face</span></p>
+    <h2>Two row heights, one grid</h2>
+    <p>All spacing becomes a multiple of 4px, and row height is fixed per mode so content can never reflow
+    it. Everything measured — scores, IDs, durations, ages, counts — moves to a mono face, because it reads
+    as a measurement rather than a word.</p>
+
+    <figure class="frame">
+      <figcaption><span>Comfortable · 44px · default</span><span class="w">7 fields per row, full title</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="row"><span class="score critical">92</span><span class="src">⑂</span>
+            <span class="titles"><span class="title">feat: revoke authorization fix, extend, and reuse fields for project shared links</span>
+            <span class="ctx">pro4all-services-hyperlink<span class="s">·</span>#4821<span class="s">·</span>8d quiet</span></span>
+            <span class="badge review">Approved</span>
+            <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+          <div class="row"><span class="score high">45</span><span class="src">▤</span>
+            <span class="titles"><span class="title">[BE] Optimistic concurrency on document set updates</span>
+            <span class="ctx">WI-41502<span class="s">·</span>Sprint 4<span class="s">·</span>due in 1d</span></span>
+            <span class="badge blocked">Blocked</span>
+            <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+        </div>
+      </div>
+    </figure>
+
+    <figure class="frame">
+      <figcaption><span>Compact · 36px · toggle in Settings</span><span class="w">context collapses to one line</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid compact" style="padding:0">
+          <div class="row"><span class="score critical">92</span><span class="src">⑂</span>
+            <span class="titles"><span class="title">feat: revoke authorization fix, extend, and reuse fields for project shared links <span style="color:#a1a1aa;font-family:var(--mono);font-size:11px">pro4all-services-hyperlink · 8d</span></span></span>
+            <span class="badge review">Approved</span>
+            <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+          <div class="row"><span class="score high">45</span><span class="src">▤</span>
+            <span class="titles"><span class="title">[BE] Optimistic concurrency on document set updates <span style="color:#a1a1aa;font-family:var(--mono);font-size:11px">WI-41502 · due 1d</span></span></span>
+            <span class="badge blocked">Blocked</span>
+            <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+          <div class="row"><span class="score medium">30</span><span class="src">⑂</span>
+            <span class="titles"><span class="title">fix: reassign document owner on user deactivation <span style="color:#a1a1aa;font-family:var(--mono);font-size:11px">pro4all-services-dms · 3d</span></span></span>
+            <span class="badge review">Ready for review</span>
+            <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+        </div>
+      </div>
+    </figure>
+
+    <div class="note decision">
+      <span class="tag">Decision · density default</span>
+      <b>Comfortable.</b> Compact wins on a screenshot and loses on a Tuesday afternoon. A tool opened
+      dozens of times a day shouldn't ship at its tightest setting; the toggle lives in Settings and
+      persists in the <code>settings</code> table.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">05<span class="sep">/</span><span class="tasks">delta</span></p>
+    <h2>What changed</h2>
+    <ul class="ledger">
+      <li class="add"><span class="task">P0</span><span class="op">+</span><span class="body">Four urgency band tokens, derived from the existing <code>getPriorityTier()</code> cuts at 60 / 40 / 25</span></li>
+      <li class="add"><span class="task">P0</span><span class="op">+</span><span class="body">Status tokens: <code>--status-blocked</code>, <code>--status-neutral</code>. <em>Blocked gains a branch in <code>adoStatusVariant()</code></em></span></li>
+      <li class="add"><span class="task">P0</span><span class="op">+</span><span class="body">Mono data face on scores, IDs, durations, ages, counts</span></li>
+      <li class="add"><span class="task">P0</span><span class="op">+</span><span class="body">Density toggle — 44px comfortable / 36px compact, persisted in <code>settings</code></span></li>
+      <li class="mod"><span class="task">P0</span><span class="op">~</span><span class="body">Indigo restricted to interactive elements. <em>Badges lose it entirely</em></span></li>
+      <li class="mod"><span class="task">P0</span><span class="op">~</span><span class="body">Gold restricted to the logotype and the Today marker</span></li>
+      <li class="mod"><span class="task">P0</span><span class="op">~</span><span class="body">All spacing on a 4px grid; row height fixed per mode</span></li>
+      <li class="cut"><span class="task">P0</span><span class="op">−</span><span class="body">Hard-coded hex in components — everything reads a token</span></li>
+    </ul>
+    <p class="dek" style="margin-top:1.25rem">Layout, counts, sections, and row grammar are untouched. The
+    dashboard is byte-for-byte the same shape as the baseline; only the palette underneath it has a spine.</p>
+  </section>
+
+</main>
+
+<nav class="pager">
+  <span><span class="lbl">Previous</span><a href="index.html">← Baseline &amp; decisions</a></span>
+  <span><span class="lbl">Next</span><a href="phase-1-thesis.html">Phase 1 · Make the thesis visible →</a></span>
+</nav>
+
+</div>
+</body>
+</html>

--- a/docs/wireframes/phase-1-thesis.html
+++ b/docs/wireframes/phase-1-thesis.html
@@ -1,0 +1,382 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Phase 1 · Make the thesis visible — Ariadne wireframes</title>
+<link rel="stylesheet" href="wireframe.css">
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <p class="kicker"><a href="index.html">Ariadne wireframes</a> · phase 1 of 4</p>
+  <h1>Make the thesis<br>visible</h1>
+  <p class="standfirst">The formula stops being a source file and becomes the interface. Every row shows its
+  score as a number; one keypress shows the arithmetic. The two source columns collapse into a single ranked
+  list grouped by what each signal wants from you. This is the phase that changes what Ariadne looks like it
+  is for.</p>
+  <p class="meta">Tasks <b>P1 · P2 · P4 · P10 items 1–5</b> · Effort <b>M</b> · Depends on <b>P0</b><br>
+  If only one phase ever ships, ship this one.</p>
+</header>
+
+<main class="thread">
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">01<span class="sep">/</span><span class="tasks">P1 · P2 · P4 together</span></p>
+    <h2>The dashboard after Phase 1</h2>
+    <p>Same data as the baseline — 19 inbox signals — reorganised. Note what the reclaimed 400px of dead
+    space buys: full titles, a visible score on every row, and the sprint context that previously had nowhere
+    to go.</p>
+
+    <figure class="frame">
+      <figcaption><span>Dashboard · phase 1</span><span class="w">1440px viewport · 960px content column · comfortable density</span></figcaption>
+      <div class="stage">
+        <div class="ui">
+
+          <div class="topbar">
+            <span class="logo"><span class="glyph">✳</span> Ariadne</span>
+            <span class="spacer"></span>
+            <span class="search">⌕ Search work items, PRs, people…</span>
+            <span class="spacer"></span>
+            <span class="iconbtn">▥</span><span class="iconbtn">⚙</span><span class="iconbtn">☀</span>
+          </div>
+
+          <div class="statusline">
+            <b>Sprint 4</b><span class="dot">·</span>0/17 sprint items done<span class="dot">·</span>13 days left
+            <span class="dot">·</span>Last synced 0m ago
+            <span class="spacer"></span>
+            <span class="iconbtn">＋</span>
+            <span class="btn primary">⟳ Refresh</span>
+          </div>
+
+          <!-- Today — unchanged this phase, but its rows now carry chips -->
+          <div class="sec">
+            <div class="card">
+              <div class="sec-head" style="padding-bottom:6px">Today <span class="count">0</span>
+                <span class="right" style="color:#a1a1aa">Review my day</span></div>
+              <div class="empty"><p style="margin:0">Nothing chosen for today — pin something from below.</p></div>
+            </div>
+          </div>
+
+          <!-- In progress — unchanged grammar, dots become chips -->
+          <div class="sec">
+            <div class="card">
+              <div class="sec-head">In progress <span class="count">3</span><span class="right">⌃</span></div>
+              <div class="row">
+                <span class="score high">45</span><span class="src">⑂</span>
+                <span class="titles"><span class="title">Add granular member/group management permissions and org-level grants</span>
+                  <span class="ctx">pro4all-services-identity<span class="s">·</span>#1180<span class="s">·</span>6d quiet</span></span>
+                <span class="badge review">Ready for review</span>
+                <span class="actions"><span class="btn primary">Complete</span><span class="iconbtn">⋯</span></span>
+              </div>
+              <div class="row">
+                <span class="score medium">30</span><span class="src">⑂</span>
+                <span class="titles"><span class="title">feat: project shared links actions — revoke, extend, reuse, open link (WI-41448 Phase 2)</span>
+                  <span class="ctx">pro4all-prostream-frontend<span class="s">·</span>#3391<span class="s">·</span>3d quiet</span></span>
+                <span class="badge review">Ready for review</span>
+                <span class="actions"><span class="btn primary">Complete</span><span class="iconbtn">⋯</span></span>
+              </div>
+              <div class="row">
+                <span class="score low">10</span><span class="src">⑂</span>
+                <span class="titles"><span class="title">feat: revoke authorization fix, extend, and reuse fields for project shared links (WI-41448 Phase 2)</span>
+                  <span class="ctx">pro4all-services-hyperlink<span class="s">·</span>#4821<span class="s">·</span>today</span></span>
+                <span class="badge review">Ready for review</span>
+                <span class="actions"><span class="btn primary">Complete</span><span class="iconbtn">⋯</span></span>
+              </div>
+              <div class="grouphead" style="padding:14px 0 2px">Paused · 4</div>
+              <div class="row" style="min-height:34px"><span class="score low" style="opacity:.55">10</span><span class="titles"><span class="title" style="color:#a1a1aa">[BE+FE] 01. Project admins can view and manage shared links within a project</span></span><span class="btn ghost" style="color:#8179f0">Resume</span></div>
+              <div class="row" style="min-height:34px"><span class="score low" style="opacity:.55">10</span><span class="titles"><span class="title" style="color:#a1a1aa">Prostream — Published Excel file loses file extension</span></span><span class="btn ghost" style="color:#8179f0">Resume</span></div>
+              <div class="row" style="min-height:34px"><span class="score medium" style="opacity:.55">25</span><span class="titles"><span class="title" style="color:#a1a1aa">feat: project shared links overview (WI-41448)</span></span><span class="btn ghost" style="color:#8179f0">Resume</span></div>
+              <div class="row" style="min-height:34px"><span class="score low" style="opacity:.55">10</span><span class="titles"><span class="title" style="color:#a1a1aa">Fix: preserve file extension when publishing after Edit Locally (AB#41758)</span></span><span class="btn ghost" style="color:#8179f0">Resume</span></div>
+            </div>
+          </div>
+
+          <!-- THE CHANGE: one ranked list, grouped by obligation -->
+          <div class="sec">
+            <div class="sec-head">Signals <span class="count">19</span>
+              <span class="right">12 need something from you</span></div>
+            <div class="chips">
+              <span class="chip on">All <span class="n">19</span></span>
+              <span class="chip">⑂ GitHub <span class="n">4</span></span>
+              <span class="chip">▤ Azure DevOps <span class="n">14</span></span>
+              <span class="chip">✉ Ad-hoc <span class="n">1</span></span>
+            </div>
+
+            <div class="grouphead">Waiting on you <span class="c">· 9</span><span class="more">Show 4 more ⌄</span></div>
+            <div class="row">
+              <span class="score critical">60</span><span class="src">⑂</span>
+              <span class="titles"><span class="title">feat(#39596): option to disable notification digest for org members</span>
+                <span class="ctx">pro4all-services-identity<span class="s">·</span>#39596<span class="s">·</span>review requested<span class="s">·</span>2 open threads</span></span>
+              <span class="badge neutral">Draft</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row">
+              <span class="score high">55</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Document sets: toast is incorrect after publishing a revision</span>
+                <span class="ctx">WI-41487<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you<span class="s">·</span>11d quiet</span></span>
+              <span class="badge neutral">Code Review</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Prostream — QR stamp fails with rotated pages</span>
+                <span class="ctx">WI-41491<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge neutral">To Do</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Prostream — users not found in the project member picker</span>
+                <span class="ctx">WI-41493<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge neutral">To Do</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Prostream — Missing username on published document footer</span>
+                <span class="ctx">WI-41494<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge neutral">To Do</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+
+            <div class="grouphead">Blocked <span class="c">· 2</span></div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">[BE] Optimistic concurrency on document set updates</span>
+                <span class="ctx">WI-41502<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge blocked">Blocked</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Option to Disable User Notifications</span>
+                <span class="ctx">WI-41455<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge blocked">Blocked</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+
+            <div class="grouphead">Moving without you <span class="c">· 1</span></div>
+            <div class="row">
+              <span class="score medium">30</span><span class="src">⑂</span>
+              <span class="titles"><span class="title">fix: reassign document owner on user deactivation</span>
+                <span class="ctx">pro4all-services-dms<span class="s">·</span>#2214<span class="s">·</span>your PR<span class="s">·</span>3d no reviews</span></span>
+              <span class="badge review">Ready for review</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+
+            <div class="grouphead">Lower priority <span class="c">· 7</span><span class="more">Show 6 more ⌄</span></div>
+            <div class="row">
+              <span class="score low">10</span><span class="src">✉</span>
+              <span class="titles"><span class="title">Create pipeline template for gateway smoke tests</span>
+                <span class="ctx">ad-hoc<span class="s">·</span>from standup<span class="s">·</span>4d old</span></span>
+              <span class="badge local">Kept visible</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </figure>
+
+    <ol class="pins">
+      <li><span class="n">1</span><span><b>Score first, always.</b> Mono numeral in the leading column, banded
+        by the tier that already sorts the list. No unlabelled dot survives anywhere in the app.</span></li>
+      <li><span class="n">2</span><span><b>Group headers are obligations, not categories.</b> "Waiting on you"
+        encodes a debt; "GitHub" encodes a vendor.</span></li>
+      <li><span class="n">3</span><span><b>Source is a filter with a live count.</b> It stays legible per row as
+        the leading icon, which is where it was always doing useful work.</span></li>
+      <li><span class="n">4</span><span><b>Titles get ~78 characters</b> before the ellipsis, against ~30 in the
+        old columns. One line, always — row height is fixed per density mode, so a long title can never reflow
+        the row. Anything clipped carries its full string in <code>title</code> and in the accessible name.</span></li>
+      <li><span class="n">5</span><span><b>Every group collapses after five</b> with "Show N more". No scroll
+        trap, no second column, no stretched empty card.</span></li>
+      <li><span class="n">6</span><span><b>The bottom "Everything else · 9" card is gone.</b> It was the low band
+        of the same list; it is now the fourth group, in rank order, with its threshold rule visible.</span></li>
+      <li><span class="n">7</span><span><b>Actions rest at low emphasis.</b> Start and ⋯ sit quiet until hover or
+        focus — drawn here in their resting state, which is why they look faint.</span></li>
+    </ol>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">02<span class="sep">/</span><span class="tasks">P1 · the flagship pixel</span></p>
+    <h2>Why 60?</h2>
+    <p>Activating the chip — click, <kbd>Enter</kbd>, or <kbd>x</kbd> on the focused row — opens the arithmetic.
+    Every entry comes from <code>scoreBreakdown()</code>, so the popover cannot drift from the sort order without
+    the property test failing.</p>
+
+    <div class="compare two">
+      <figure class="after">
+        <figcaption>A scored signal</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="row" style="border:0;margin-bottom:10px">
+              <span class="score critical">60</span><span class="src">⑂</span>
+              <span class="titles"><span class="title">feat(#39596): option to disable notification digest</span>
+                <span class="ctx">pro4all-services-identity<span class="s">·</span>#39596</span></span>
+            </div>
+            <div class="pop" style="margin-left:6px">
+              <h5>Why 60?</h5>
+              <div class="rule"></div>
+              <div class="line"><span>Review requested</span><span class="pts">+40</span></div>
+              <div class="line"><span>Unresolved conversations</span><span class="pts">+20</span></div>
+              <div class="rule"></div>
+              <div class="line total"><span>Total</span><span class="pts">60</span></div>
+              <p class="foot">Critical band starts at 60. Ties break by oldest activity first.<br>
+                <a href="#">See the whole formula →</a></p>
+            </div>
+          </div>
+        </div>
+      </figure>
+      <figure class="after">
+        <figcaption>A signal that scored almost nothing</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="row" style="border:0;margin-bottom:10px">
+              <span class="score low">10</span><span class="src">✉</span>
+              <span class="titles"><span class="title">Create pipeline template for gateway smoke tests</span>
+                <span class="ctx">ad-hoc<span class="s">·</span>from standup</span></span>
+              <span class="badge local">Kept visible</span>
+            </div>
+            <div class="pop" style="margin-left:6px">
+              <h5>Why 10?</h5>
+              <div class="rule"></div>
+              <div class="line"><span>Ad-hoc request</span><span class="pts">+10</span></div>
+              <div class="line"><span style="color:#a1a1aa">No deadline</span><span class="pts" style="color:#71717a">—</span></div>
+              <div class="line"><span style="color:#a1a1aa">Not stale yet <span class="mono" style="font-size:11px">(4d of 5)</span></span><span class="pts" style="color:#71717a">—</span></div>
+              <div class="rule"></div>
+              <div class="line total"><span>Total</span><span class="pts">10</span></div>
+              <p class="foot">Below the 25-point attention threshold. Ad-hoc requests stay visible anyway —
+                they have no upstream signals to earn points from.<br><a href="#">See the whole formula →</a></p>
+            </div>
+          </div>
+        </div>
+      </figure>
+    </div>
+
+    <div class="note decision">
+      <span class="tag">Decision · the zero state carries the rules</span>
+      The proposal asks that a zero score still explain itself. Going one step further:
+      <b>the popover also names the rules that did not fire</b> — no deadline, not stale yet, 4 days of 5 — and
+      names the exemption keeping the row on screen. A user who reads this popover has learned the whole formula
+      without opening Settings. That is the difference between a transparent tool and a tool with a transparency page.
+    </div>
+
+    <h4 class="sub">Accessibility of the chip</h4>
+    <ul class="ledger">
+      <li class="add"><span class="task">P1</span><span class="op">+</span><span class="body">Chip is a real <code>&lt;button&gt;</code>, accessible name <em>"Urgency 60 of 105, show breakdown"</em></span></li>
+      <li class="add"><span class="task">P1</span><span class="op">+</span><span class="body">Popover is <code>role="dialog"</code> with a labelled heading; focus enters on open and returns to the chip on close</span></li>
+      <li class="add"><span class="task">P1</span><span class="op">+</span><span class="body">Urgency is carried by the numeral, so <code>1.4.1</code> holds with colour removed <em>(see the Phase 0 greyscale proof)</em></span></li>
+      <li class="add"><span class="task">P1</span><span class="op">+</span><span class="body">Chip text contrast ≥ 4.5:1 in all four bands — dark ink on the two filled bands, not white</span></li>
+    </ul>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">03<span class="sep">/</span><span class="tasks">P2 · the one judgement call</span></p>
+    <h2>Which group does a signal land in?</h2>
+    <p>One pure function, total over the <code>Reason</code> union, with precedence resolved in one place.
+    Blocked wins when it collides with Waiting on you, because the required action differs: a nudge, not work.</p>
+
+    <table class="tokens">
+      <thead><tr><th>Group</th><th>Reason / state</th><th>Points</th><th>Why it belongs here</th></tr></thead>
+      <tbody>
+        <tr><td class="name" style="color:#e8e3da">Blocked</td><td class="val">ADO state matches <code>/block/</code></td><td class="val">any</td>
+            <td class="use">Precedence 1 — takes any signal, whatever else applies to it</td></tr>
+        <tr><td class="name" style="color:#e8e3da">Waiting on you</td><td class="val">review_requested · mention · approved_unmerged</td><td class="val">40 · 40 · 45</td>
+            <td class="use">Precedence 2 — a person is waiting for a reply, a review, or a merge</td></tr>
+        <tr><td class="name" style="color:#e8e3da">Moving without you</td><td class="val">stale_own_pr · authored</td><td class="val">30 · 10</td>
+            <td class="use">Precedence 3 — your work, in someone else's queue. Time-sensitive, not actionable</td></tr>
+        <tr><td class="name" style="color:#e8e3da">Lower priority</td><td class="val">assigned · manual · anything below 25</td><td class="val">10</td>
+            <td class="use">Remainder. Collapsed, but exempt rows stay drawn</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note decision">
+      <span class="tag">Deviation from the proposal</span>
+      The proposal files <em>"your PR approved and mergeable"</em> under <b>Moving without you</b>. That is wrong for
+      this codebase. <code>approved_unmerged</code> is the <b>highest-scoring reason in the whole formula at 45</b> —
+      the repo already believes it is the most urgent thing that can happen to you, and it is urgent precisely because
+      it is now waiting on <em>you</em> to merge. Filing it under "moving without you" would put the top-scoring reason
+      in the informational group. It goes in <b>Waiting on you</b>. Ariadne can't merge it for you, but it can stop
+      pretending the ball isn't in your court.
+    </div>
+
+    <div class="note">
+      <span class="tag">Deviation from the proposal</span>
+      The section is titled <b>Signals · 19</b>, not <em>Needs attention · 10</em>. Folding the old
+      "Everything else" card in would otherwise make the headline count jump from 10 to 19 and read as new work
+      arriving. "Signals · 19 / 12 need something from you" gives both numbers their own denominator, which §12
+      question 6 asks for anyway. <em>"Lower priority"</em> is also adopted here rather than in Phase 4 — renaming a
+      label you created ten minutes ago is free.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">04<span class="sep">/</span><span class="tasks">P4 · status legend</span></p>
+    <h2>A colour system users can decode</h2>
+    <p>Badges now have one filled state, and it is the one that needs a human. A small legend sits behind a
+    <kbd>?</kbd> next to the group headers, because a colour system nobody can read is decoration.</p>
+
+    <figure class="frame narrow">
+      <figcaption><span>Status key · popover</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="pop" style="width:auto">
+            <h5>Status key</h5>
+            <div class="rule"></div>
+            <div class="line"><span><span class="badge blocked">Blocked</span></span><span style="flex:2;color:#a1a1aa;font-size:12px">Needs a nudge, not work</span></div>
+            <div class="line"><span><span class="badge review">Ready for review</span></span><span style="flex:2;color:#a1a1aa;font-size:12px">Actionable, normal weight</span></div>
+            <div class="line"><span><span class="badge progress">In Progress</span></span><span style="flex:2;color:#a1a1aa;font-size:12px">Already yours, ambient</span></div>
+            <div class="line"><span><span class="badge neutral">To Do</span></span><span style="flex:2;color:#a1a1aa;font-size:12px">Informational</span></div>
+            <div class="line"><span><span class="badge local">Kept visible</span></span><span style="flex:2;color:#a1a1aa;font-size:12px">A local rule is holding this row here</span></div>
+            <p class="foot">Every state has a label. Nothing on this dashboard is colour alone.</p>
+          </div>
+        </div>
+      </div>
+    </figure>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">05<span class="sep">/</span><span class="tasks">delta</span></p>
+    <h2>What changed</h2>
+    <ul class="ledger">
+      <li class="add"><span class="task">P1</span><span class="op">+</span><span class="body">Score chip on every row, mono, banded, always visible</span></li>
+      <li class="add"><span class="task">P1</span><span class="op">+</span><span class="body">Breakdown popover from <code>scoreBreakdown()</code> — reasons that fired <em>and</em> reasons that didn't</span></li>
+      <li class="add"><span class="task">P1</span><span class="op">+</span><span class="body">Property test: <code>scoreBreakdown().sum === scoreItem()</code> over generated items</span></li>
+      <li class="add"><span class="task">P1</span><span class="op">+</span><span class="body">Documented tiebreak — oldest activity first — stated in the popover and unit-tested</span></li>
+      <li class="add"><span class="task">P2</span><span class="op">+</span><span class="body"><code>lib/grouping.ts</code> — <code>groupOf()</code>, total over <code>Reason</code>, precedence documented in one place</span></li>
+      <li class="add"><span class="task">P2</span><span class="op">+</span><span class="body">Source filter chips with live counts, keyboard-operable</span></li>
+      <li class="add"><span class="task">P2</span><span class="op">+</span><span class="body">Collapse-after-5 per group with "Show N more"; exempt rows always drawn</span></li>
+      <li class="add"><span class="task">P4</span><span class="op">+</span><span class="body">Status key popover behind <kbd>?</kbd> on the group header</span></li>
+      <li class="mod"><span class="task">P2</span><span class="op">~</span><span class="body">Sprint counter reads "0/17 <em>sprint items</em> done" — the denominator is named</span></li>
+      <li class="cut"><span class="task">P1</span><span class="op">−</span><span class="body">The urgency dot and <code>TIER_DOT_CLASS</code>, everywhere</span></li>
+      <li class="cut"><span class="task">P2</span><span class="op">−</span><span class="body"><code>NeedsAttentionBoard</code>'s two-column source layout — deleted, not hidden</span></li>
+      <li class="cut"><span class="task">P2</span><span class="op">−</span><span class="body">The separate "Everything else" card at the page foot</span></li>
+      <li class="mod"><span class="task">P2</span><span class="op">~</span><span class="body">Title clipping moves from ~30 characters to ~78 — past the 60-character floor, on one fixed-height line</span></li>
+      <li class="cut"><span class="task">P4</span><span class="op">−</span><span class="body">Indigo from every badge variant</span></li>
+    </ul>
+
+    <div class="note">
+      <span class="tag">Guardrail check · issue #15</span>
+      One row grammar — <b>kept</b>: score chip, source icon, title, context, one badge, one primary action, one ⋯.
+      The pin button moves into ⋯, which reduces rather than adds. Parked stays a dimmed sub-list inside
+      In&nbsp;progress — <b>kept</b>. Today and In&nbsp;progress stay disjoint — <b>kept</b>. Sprint header stays a single
+      ambient line, not a card — <b>kept</b>. What breaks: <em>source as container</em>. That is P2's entire point.
+    </div>
+  </section>
+
+</main>
+
+<nav class="pager">
+  <span><span class="lbl">Previous</span><a href="phase-0-foundation.html">← Phase 0 · Foundation</a></span>
+  <span><span class="lbl">Next</span><a href="phase-2-speed-and-control.html">Phase 2 · Speed and control →</a></span>
+</nav>
+
+</div>
+</body>
+</html>

--- a/docs/wireframes/phase-2-speed-and-control.html
+++ b/docs/wireframes/phase-2-speed-and-control.html
@@ -1,0 +1,396 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Phase 2 · Speed and control — Ariadne wireframes</title>
+<link rel="stylesheet" href="wireframe.css">
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <p class="kicker"><a href="index.html">Ariadne wireframes</a> · phase 2 of 4</p>
+  <h1>Speed and<br>control</h1>
+  <p class="standfirst">The list becomes something you drive rather than click. A focused row takes single-letter
+  commands, three local triage verbs let you curate without touching upstream, nine query prefixes slice the
+  set, and ⌘K opens over an in-process SQLite file — which is the one place Ariadne can beat every cloud rival
+  outright.</p>
+  <p class="meta">Tasks <b>P3 · P5 · P6 · P12</b> · Effort <b>M×4</b> · Depends on <b>P0 · P2 · P3</b><br>
+  Latency target <b>&lt;100ms</b> keypress to paint · no new runtime dependency</p>
+</header>
+
+<main class="thread">
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">01<span class="sep">/</span><span class="tasks">P3 · P6 · P12 in the header and list</span></p>
+    <h2>The list, driven from the keyboard</h2>
+    <p>The header search field is gone — replaced by a compact ⌘K affordance, which frees the space the sync
+    readout needs in Phase 3. A query bar sits above the list where slicing actually happens. Row three has
+    focus.</p>
+
+    <figure class="frame">
+      <figcaption><span>Dashboard · phase 2</span><span class="w">1440px · comfortable · row 3 focused</span></figcaption>
+      <div class="stage">
+        <div class="ui">
+
+          <div class="topbar">
+            <span class="logo"><span class="glyph">✳</span> Ariadne</span>
+            <span class="spacer"></span>
+            <span class="kbar">⌕ Search or jump to <kbd>⌘K</kbd></span>
+            <span class="iconbtn">▥</span><span class="iconbtn">⚙</span><span class="iconbtn">☀</span>
+          </div>
+
+          <div class="statusline">
+            <b>Sprint 4</b><span class="dot">·</span>0/17 sprint items done<span class="dot">·</span>13 days left
+            <span class="dot">·</span>Last synced 0m ago
+            <span class="spacer"></span>
+            <span class="iconbtn">＋</span>
+            <span class="btn primary">⟳ Refresh</span>
+          </div>
+
+          <div class="sec">
+            <div class="sec-head">Signals <span class="count">12</span>
+              <span class="right">of 19 · filtered</span></div>
+
+            <div style="display:flex;gap:8px;align-items:center;margin-bottom:8px">
+              <span class="querybar" style="flex:1">
+                <span style="color:#71717a">⌕</span>
+                <span><span class="tok">source:</span>ado <span class="tok">score:</span>&gt;25 <span class="neg">-is:snoozed</span></span>
+                <span class="caret"></span>
+                <span class="spacer" style="flex:1"></span>
+                <kbd>/</kbd>
+              </span>
+              <span class="btn outline">Save view</span>
+            </div>
+
+            <div class="chips">
+              <span class="chip">All <span class="n">19</span></span>
+              <span class="chip">⑂ GitHub <span class="n">4</span></span>
+              <span class="chip on">▤ Azure DevOps <span class="n">14</span></span>
+              <span class="chip">✉ Ad-hoc <span class="n">1</span></span>
+              <span style="width:1px;height:18px;background:rgba(255,255,255,.12);margin:0 4px"></span>
+              <span class="chip saved">★ Starred <span class="n">2</span></span>
+              <span class="chip saved">Merge queue <kbd>1</kbd></span>
+              <span class="chip saved">Blocked in sprint <kbd>2</kbd></span>
+              <span class="chip saved">Quiet 5 days+ <kbd>3</kbd></span>
+            </div>
+
+            <div class="grouphead">Waiting on you <span class="c">· 7</span><span class="more">Show 2 more ⌄</span></div>
+            <div class="row">
+              <span class="score high">55</span><span class="src">▤</span>
+              <span class="titles"><span class="title">★ Document sets: toast is incorrect after publishing a revision</span>
+                <span class="ctx">WI-41487<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you<span class="s">·</span>11d quiet</span></span>
+              <span class="badge neutral">Code Review</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Prostream — QR stamp fails with rotated pages</span>
+                <span class="ctx">WI-41491<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge neutral">To Do</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row focused">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Prostream — users not found in the project member picker</span>
+                <span class="ctx">WI-41493<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge neutral">To Do</span>
+              <span class="actions"><span class="btn outline">Start <kbd>↵</kbd></span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Prostream — Missing username on published document footer</span>
+                <span class="ctx">WI-41494<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge neutral">To Do</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+
+            <div class="grouphead">Blocked <span class="c">· 2</span></div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">★ [BE] Optimistic concurrency on document set updates</span>
+                <span class="ctx">WI-41502<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you</span></span>
+              <span class="badge blocked">Blocked</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+            <div class="row">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Option to Disable User Notifications</span>
+                <span class="ctx">WI-41455<span class="s">·</span>Sprint 4<span class="s">·</span>mentioned you<span class="s">·</span>woke early</span></span>
+              <span class="badge blocked">Blocked</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+
+            <div class="grouphead empty">Moving without you <span class="c">· 0 matching this query</span></div>
+            <div class="grouphead">Lower priority <span class="c">· 3</span><span class="more">Show 3 more ⌄</span></div>
+          </div>
+
+          <div style="padding:16px 20px 0"><span class="toast">Snoozed until tomorrow — Prostream QR stamp
+            <span class="btn outline">Undo <kbd>⌘Z</kbd></span></span></div>
+
+        </div>
+      </div>
+    </figure>
+
+    <ol class="pins">
+      <li><span class="n">1</span><span><b>The focused row is marked by shape and colour.</b> A 2px leading bar plus
+        a ring — so it survives greyscale and colour-blindness, and its primary action reveals its binding.</span></li>
+      <li><span class="n">2</span><span><b>Query and chips are one state.</b> Clicking the Azure DevOps chip wrote
+        <code>source:ado</code>; editing the text lights the chip. Two views, one source of truth.</span></li>
+      <li><span class="n">3</span><span><b>Saved views are chips with optional shortcuts.</b> Unlimited, because
+        the store is a local file — GitHub's 15-filter cap exists to protect someone else's infrastructure.</span></li>
+      <li><span class="n">4</span><span><b>An empty group states itself in one muted line</b> and says <em>why</em>
+        it's empty — "0 matching this query", not a blank card.</span></li>
+      <li><span class="n">5</span><span><b>A woken snooze is labelled.</b> "woke early" in the context line, so the
+        item reappearing never looks like a bug.</span></li>
+      <li><span class="n">6</span><span><b>Every triage action is a toast with 10 seconds of undo.</b> The verb in
+        the toast is the verb on the control.</span></li>
+    </ol>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">02<span class="sep">/</span><span class="tasks">P3 · the discoverability contract</span></p>
+    <h2>Everything the keyboard does, on one screen</h2>
+    <p>Keyboard-first design's documented failure is that new users never find the functionality. The answer
+    is <kbd>?</kbd>, generated from <code>lib/keymap.ts</code> — the single place a binding may be declared, so
+    the sheet cannot drift from the app.</p>
+
+    <figure class="frame">
+      <figcaption><span>Shortcut help · <kbd>?</kbd></span><span class="w">modal, focus trapped, Esc restores</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="dialog" style="max-width:640px">
+            <div class="dhead"><h5>Keyboard</h5><span class="step">generated from lib/keymap.ts</span>
+              <span class="spacer" style="flex:1"></span><span class="iconbtn">✕</span></div>
+            <div class="dbody">
+              <div class="keys">
+                <h6>Focused signal</h6>
+                <span class="k"><span class="kk"><kbd>j</kbd><kbd>k</kbd></span><span class="lbl">Move focus down / up</span></span>
+                <span class="k"><span class="kk"><kbd>↵</kbd><kbd>o</kbd></span><span class="lbl">Open upstream in a new tab</span></span>
+                <span class="k"><span class="kk"><kbd>x</kbd></span><span class="lbl">Show the score breakdown</span></span>
+                <span class="k"><span class="kk"><kbd>s</kbd></span><span class="lbl">Star — local only</span></span>
+                <span class="k"><span class="kk"><kbd>e</kbd></span><span class="lbl">Snooze — local only</span></span>
+                <span class="k"><span class="kk"><kbd>d</kbd></span><span class="lbl">Mark done — local only</span></span>
+                <span class="k"><span class="kk"><kbd>t</kbd></span><span class="lbl">Pin to Today</span></span>
+                <span class="k"><span class="kk"><kbd>space</kbd></span><span class="lbl">Start / stop the timer</span></span>
+                <h6>Anywhere</h6>
+                <span class="k"><span class="kk"><kbd>/</kbd></span><span class="lbl">Focus the query bar</span></span>
+                <span class="k"><span class="kk"><kbd>⌘K</kbd></span><span class="lbl">Search or jump to</span></span>
+                <span class="k"><span class="kk"><kbd>P</kbd></span><span class="lbl">Plan the day</span></span>
+                <span class="k"><span class="kk"><kbd>W</kbd></span><span class="lbl">Wrap up the day</span></span>
+                <span class="k"><span class="kk"><kbd>R</kbd></span><span class="lbl">Refresh</span></span>
+                <span class="k"><span class="kk"><kbd>⌘Z</kbd></span><span class="lbl">Undo the last triage</span></span>
+                <span class="k"><span class="kk"><kbd>g</kbd><kbd>d</kbd></span><span class="lbl">Go to dashboard</span></span>
+                <span class="k"><span class="kk"><kbd>g</kbd><kbd>s</kbd></span><span class="lbl">Go to Settings</span></span>
+                <span class="k"><span class="kk"><kbd>?</kbd></span><span class="lbl">This sheet</span></span>
+                <span class="k"><span class="kk"><kbd>esc</kbd></span><span class="lbl">Dismiss, restore focus</span></span>
+              </div>
+            </div>
+            <div class="dfoot"><span style="font-size:12px;color:#a1a1aa">Single letters are inert while you're
+              typing in a field.</span><span class="spacer"></span><span class="btn outline">Close <kbd>esc</kbd></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">03<span class="sep">/</span><span class="tasks">P5 · the invariant under most pressure</span></p>
+    <h2>Three local verbs, and the sentence that has to be on screen</h2>
+    <p>Star, snooze, done. None of them produces a request to GitHub or Azure DevOps. This is the task most
+    likely to drift across INV-2 — "while we're here, mute it upstream" is exactly what Octobox chose — so the
+    reassurance is not buried in a help page. It is in the menu the action lives in.</p>
+
+    <div class="compare two">
+      <figure class="after">
+        <figcaption>Overflow menu · <kbd>⋯</kbd></figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="pop" style="width:270px">
+              <div class="line"><span>Star</span><span class="pts"><kbd>s</kbd></span></div>
+              <div class="line"><span>Snooze…</span><span class="pts"><kbd>e</kbd></span></div>
+              <div class="line"><span>Mark done</span><span class="pts"><kbd>d</kbd></span></div>
+              <div class="rule"></div>
+              <div class="line"><span>Pin to Today</span><span class="pts"><kbd>t</kbd></span></div>
+              <div class="line"><span>Start timer</span><span class="pts"><kbd>space</kbd></span></div>
+              <div class="rule"></div>
+              <div class="line"><span>Open in Azure DevOps ↗</span><span class="pts"><kbd>o</kbd></span></div>
+              <div class="line"><span>Copy WI-41493</span><span class="pts"></span></div>
+              <p class="foot" style="border-top:1px solid rgba(255,255,255,.08);padding-top:9px">
+                Starred, snoozed and done are local. Ariadne never changes anything in GitHub or Azure DevOps.</p>
+            </div>
+          </div>
+        </div>
+      </figure>
+      <figure class="after">
+        <figcaption>Snooze · <kbd>e</kbd></figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="pop" style="width:270px">
+              <h5>Snooze this signal</h5>
+              <div class="rule"></div>
+              <div class="line"><span>Later today</span><span class="pts" style="color:#a1a1aa">17:00</span></div>
+              <div class="line"><span>Tomorrow</span><span class="pts" style="color:#a1a1aa">Fri 09:00</span></div>
+              <div class="line"><span>Next week</span><span class="pts" style="color:#a1a1aa">Mon 09:00</span></div>
+              <div class="line"><span>Until there's activity</span><span class="pts" style="color:#a1a1aa">—</span></div>
+              <p class="foot">Any snooze also ends early if the item changes upstream — that's new information.
+                The row comes back marked <span class="mono" style="color:#e4e4e7">woke early</span>.</p>
+            </div>
+          </div>
+        </div>
+      </figure>
+    </div>
+
+    <div class="note decision">
+      <span class="tag">Decision · snooze predictability</span>
+      §12 question 4 asks whether a snoozed item should return early on new upstream activity. <b>Yes — but the
+      unpredictability is the thing to design, not the behaviour.</b> "Until there's activity" appears as an
+      explicit option so the mechanism is named before it fires, and the returning row carries
+      <code>woke early</code>. A snooze that quietly breaks its own promise is a bug; one that tells you why it
+      broke it is a feature.
+    </div>
+
+    <div class="note">
+      <span class="tag">Guard test, not a code comment</span>
+      A mock provider client that throws on any non-GET, exercised across start, complete, pause, star, snooze,
+      done, plan and wrap-up. Plus a CI grep that fails on a non-GET method string in
+      <code>github-client.ts</code> or <code>ado-client.ts</code>. The claim on the README is only true if
+      something breaks when it stops being true.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">04<span class="sep">/</span><span class="tasks">P6 · a closed grammar</span></p>
+    <h2>Nine prefixes, and no more</h2>
+    <p>The grammar is the cap. It is written down, closed, and the same parser the command palette hands off to
+    — so there is one syntax in the product, not two.</p>
+
+    <table class="tokens">
+      <thead><tr><th>Prefix</th><th>Values</th><th>Example</th></tr></thead>
+      <tbody>
+        <tr><td class="name">source:</td><td class="use">github · ado · adhoc</td><td class="val">source:github,adhoc</td></tr>
+        <tr><td class="name">group:</td><td class="use">waiting · blocked · moving · lower</td><td class="val">group:blocked</td></tr>
+        <tr><td class="name">state:</td><td class="use">blocked · review · todo · progress · draft</td><td class="val">state:review</td></tr>
+        <tr><td class="name">score:</td><td class="use">&gt;n · &lt;n · n..n</td><td class="val">score:40..105</td></tr>
+        <tr><td class="name">repo:</td><td class="use">any repository name</td><td class="val">repo:pro4all-services-dms</td></tr>
+        <tr><td class="name">sprint:</td><td class="use">current · &lt;n&gt;</td><td class="val">sprint:current</td></tr>
+        <tr><td class="name">is:</td><td class="use">starred · snoozed · done · stale</td><td class="val">is:starred</td></tr>
+        <tr><td class="name">stale:</td><td class="use">&gt;nd</td><td class="val">stale:&gt;5d</td></tr>
+        <tr><td class="name">reason:</td><td class="use">the seven keys in <code>REASON_LABEL</code></td><td class="val">reason:approved_unmerged</td></tr>
+        <tr><td class="name" style="color:#8a8379">-anything</td><td class="use">negates the filter that follows</td><td class="val">-is:snoozed</td></tr>
+        <tr><td class="name" style="color:#8a8379">bare words</td><td class="use">match the title</td><td class="val">rotated pages</td></tr>
+      </tbody>
+    </table>
+
+    <figure class="frame">
+      <figcaption><span>Malformed query · never blanks the list</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <span class="querybar invalid" style="max-width:520px">
+            <span style="color:#71717a">⌕</span>
+            <span><span class="tok">source:</span>ado <span style="color:#ff6b70;text-decoration:underline wavy #ff6b70">score:&gt;&gt;25</span></span>
+            <span class="caret"></span>
+          </span>
+          <p style="font-family:var(--sans);font-size:12.5px;color:#ff9a9d;margin:8px 0 0">
+            <b style="font-weight:500">score:&gt;&gt;25</b> — expected a number after <span class="mono">&gt;</span>.
+            Showing the last valid result. <span style="color:#8179f0">Clear the query</span></p>
+        </div>
+      </div>
+    </figure>
+    <p class="dek" style="margin-top:.9rem">The parse error names what failed and what to do. The list keeps
+    showing the last valid result, so a typo never costs you your place. Announced through a polite live region.</p>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">05<span class="sep">/</span><span class="tasks">P12 · the local-data advantage, stated</span></p>
+    <h2>⌘K over an in-process file</h2>
+    <p>Linear's palette feels instant because it searches a local object pool. Ariadne's pool <em>is</em> the
+    database — same process, no network, no cache layer to invalidate. Five categories, closed. Every entry
+    shows its binding, which is how the shortcuts get learned without anyone reading the help sheet.</p>
+
+    <figure class="frame">
+      <figcaption><span>Command palette · <kbd>⌘K</kbd></span><span class="w">query "blo" · 5 categories</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="dialog" style="max-width:540px">
+            <div class="dhead" style="padding:0">
+              <span class="querybar" style="border:0;background:none;height:44px;flex:1;font-size:14px">
+                <span style="color:#71717a">⌕</span><span>blo</span><span class="caret"></span></span>
+              <span style="padding-right:14px"><kbd>esc</kbd></span>
+            </div>
+            <div class="dbody" style="padding:8px 0">
+              <div class="grouphead" style="padding:8px 16px 4px">Signals <span class="c">· 3</span></div>
+              <div class="row" style="padding:0 16px"><span class="score high">40</span><span class="src">▤</span>
+                <span class="titles"><span class="title">[BE] Optimistic concurrency on document set updates</span>
+                <span class="ctx">WI-41502<span class="s">·</span>Blocked</span></span><span class="pts"><kbd>↵</kbd></span></div>
+              <div class="row" style="padding:0 16px"><span class="score high">40</span><span class="src">▤</span>
+                <span class="titles"><span class="title">Option to Disable User Notifications</span>
+                <span class="ctx">WI-41455<span class="s">·</span>Blocked</span></span></div>
+              <div class="grouphead" style="padding:8px 16px 4px">Saved views <span class="c">· 1</span></div>
+              <div class="row" style="padding:0 16px"><span class="src">◆</span><span class="titles"><span class="title">Blocked in sprint</span></span><span><kbd>2</kbd></span></div>
+              <div class="grouphead" style="padding:8px 16px 4px">Filter <span class="c">· hands off to the query bar</span></div>
+              <div class="row" style="padding:0 16px"><span class="src">⌕</span><span class="titles"><span class="title mono" style="font-size:12.5px"><span style="color:#8179f0">group:</span>blocked</span></span></div>
+              <div class="grouphead" style="padding:8px 16px 4px">Go to</div>
+              <div class="row" style="padding:0 16px"><span class="src">⚙</span><span class="titles"><span class="title">Settings</span></span><span><kbd>g</kbd> <kbd>s</kbd></span></div>
+            </div>
+            <div class="dfoot"><span style="font-size:11.5px;color:#a1a1aa" class="mono">19 signals searched
+              locally · no network</span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <div class="note">
+      <span class="tag">Worth saying out loud</span>
+      That footer line — <b>"19 signals searched locally · no network"</b> — costs one <code>&lt;span&gt;</code>
+      and is the only place in the product where the local-first architecture becomes something the user can
+      feel rather than read about. Keep it.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">06<span class="sep">/</span><span class="tasks">delta</span></p>
+    <h2>What changed</h2>
+    <ul class="ledger">
+      <li class="add"><span class="task">P3</span><span class="op">+</span><span class="body"><code>lib/keymap.ts</code> — the only place a binding is declared; <kbd>?</kbd> is generated from it</span></li>
+      <li class="add"><span class="task">P3</span><span class="op">+</span><span class="body">Focused-row model: <kbd>j</kbd><kbd>k</kbd>, ring plus 2px leading bar, bindings shown on the focused row's action</span></li>
+      <li class="add"><span class="task">P3</span><span class="op">+</span><span class="body">Shortcut hints in every menu item and tooltip, right-aligned mono</span></li>
+      <li class="add"><span class="task">P5</span><span class="op">+</span><span class="body">Schema: <code>starred</code>, <code>snoozed_until</code>, <code>triage_state</code> on <code>items</code> — reversible migration</span></li>
+      <li class="add"><span class="task">P5</span><span class="op">+</span><span class="body">Undo toast, 10s, <kbd>⌘Z</kbd>, restores exact prior state</span></li>
+      <li class="add"><span class="task">P5</span><span class="op">+</span><span class="body">The local-only sentence, in the menu where the action lives</span></li>
+      <li class="add"><span class="task">P5</span><span class="op">+</span><span class="body">Guard test at the HTTP boundary + CI grep for non-GET in the provider clients</span></li>
+      <li class="add"><span class="task">P6</span><span class="op">+</span><span class="body"><code>lib/query.ts</code> — <code>parseQuery</code> / <code>applyQuery</code>, both pure, nine prefixes, closed</span></li>
+      <li class="add"><span class="task">P6</span><span class="op">+</span><span class="body">Saved views, unlimited, reorderable, optional numeric shortcut</span></li>
+      <li class="add"><span class="task">P12</span><span class="op">+</span><span class="body">Command palette on shadcn's existing <code>command</code> component — no new dependency</span></li>
+      <li class="mod"><span class="task">P3</span><span class="op">~</span><span class="body">Row actions at rest go low-emphasis, full on hover <em>or</em> focus — parity, not hover-only</span></li>
+      <li class="mod"><span class="task">P6</span><span class="op">~</span><span class="body">Filter chips and query text become one bidirectional state</span></li>
+      <li class="cut"><span class="task">P12</span><span class="op">−</span><span class="body">The 390px header search input — replaced by the ⌘K affordance</span></li>
+      <li class="cut"><span class="task">P3</span><span class="op">−</span><span class="body">The always-on pin button — folded into ⋯, where it shows its binding</span></li>
+    </ul>
+
+    <div class="note">
+      <span class="tag">The classic bugs, pre-committed to tests</span>
+      Single letters must be inert in <code>input</code>, <code>textarea</code> and
+      <code>contenteditable</code> — explicitly tested, not assumed. No duplicate bindings in
+      <code>keymap.ts</code>, and every binding must have help text, or the test fails. Focus must return from
+      all four overlays: breakdown, palette, snooze menu, help.
+    </div>
+  </section>
+
+</main>
+
+<nav class="pager">
+  <span><span class="lbl">Previous</span><a href="phase-1-thesis.html">← Phase 1 · Make the thesis visible</a></span>
+  <span><span class="lbl">Next</span><a href="phase-3-shape-of-a-day.html">Phase 3 · The shape of a day →</a></span>
+</nav>
+
+</div>
+</body>
+</html>

--- a/docs/wireframes/phase-3-shape-of-a-day.html
+++ b/docs/wireframes/phase-3-shape-of-a-day.html
@@ -1,0 +1,429 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Phase 3 · The shape of a day — Ariadne wireframes</title>
+<link rel="stylesheet" href="wireframe.css">
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <p class="kicker"><a href="index.html">Ariadne wireframes</a> · phase 3 of 4</p>
+  <h1>The shape<br>of a day</h1>
+  <p class="standfirst">Seven items are started at once and Today is empty. This phase adds the moment that
+  asks you to choose, the arithmetic that tells you the truth about how much you chose, and a freshness
+  readout you can actually trust. It adds no calendar, no suggestion, and no clock position — ever.</p>
+  <p class="meta">Tasks <b>P7 · P9 · P8</b> · Effort <b>L · M · M</b> · Depends on <b>P1 · P2 · P5</b><br>
+  Highest INV-4 risk in the whole plan · the two failure modes are named at the bottom of this page</p>
+</header>
+
+<main class="thread">
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">01<span class="sep">/</span><span class="tasks">P8 · trust before features</span></p>
+    <h2>The header stops making a claim it can't keep</h2>
+    <p>"Last synced: just now" is a single global sentence over two independent providers. If the Azure DevOps
+    token expired an hour ago, the dashboard still says <em>just now</em> — on a manual-refresh product that is
+    the most damaging failure available, because completeness is the entire value.</p>
+
+    <figure class="frame">
+      <figcaption><span>Header · phase 3, healthy</span><span class="w">per-source freshness · ambient count · timer · Refresh demoted</span></figcaption>
+      <div class="stage">
+        <div class="ui" style="padding-bottom:0">
+          <div class="topbar">
+            <span class="logo"><span class="glyph">✳</span> Ariadne</span>
+            <span class="spacer"></span>
+            <span class="timer"><span style="color:#7ee2a0">●</span><span class="nm">WI-41493 member picker</span><span class="el">1:12:40</span><span class="iconbtn">⏸</span></span>
+            <span class="kbar">⌕ <kbd>⌘K</kbd></span>
+            <span class="iconbtn">▥</span><span class="iconbtn">⚙</span><span class="iconbtn">☀</span>
+          </div>
+          <div class="statusline">
+            <b>Sprint 4</b>
+            <span class="sprintbar" title="0 of 17 sprint items done, 8 of 21 days elapsed">
+              <i style="width:0"></i><span class="elapsed" style="left:38%"></span></span>
+            <span>0/17 sprint items<span class="dot"> · </span>13 days left</span>
+            <span class="dot">·</span>
+            <b style="color:#f5a524">9 waiting on you</b>
+            <span class="spacer"></span>
+            <span class="srcstat"><span class="st ok"></span>GitHub 2m</span>
+            <span class="srcstat"><span class="st ok"></span>Azure DevOps 2m</span>
+            <span class="btn ghost">⟳ Refresh <kbd>R</kbd></span>
+            <span class="iconbtn">＋</span>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <figure class="frame">
+      <figcaption><span>Header · phase 3, one provider failing</span><span class="w">degrade loudly, stay usable</span></figcaption>
+      <div class="stage">
+        <div class="ui">
+          <div class="topbar">
+            <span class="logo"><span class="glyph">✳</span> Ariadne</span>
+            <span class="spacer"></span>
+            <span class="kbar">⌕ <kbd>⌘K</kbd></span>
+            <span class="iconbtn">▥</span><span class="iconbtn">⚙</span><span class="iconbtn">☀</span>
+          </div>
+          <div class="statusline">
+            <b>Sprint 4</b>
+            <span class="sprintbar"><i style="width:0"></i><span class="elapsed" style="left:38%"></span></span>
+            <span>0/17 sprint items<span class="dot"> · </span>13 days left</span>
+            <span class="dot">·</span>
+            <b style="color:#f5a524">9 waiting on you</b>
+            <span class="spacer"></span>
+            <span class="srcstat"><span class="st ok"></span>GitHub 2m</span>
+            <span class="srcstat" style="color:#ff9a9d"><span class="st err"></span>Azure DevOps failed</span>
+            <span class="btn ghost">⟳ Refresh <kbd>R</kbd></span>
+          </div>
+          <div class="banner">
+            <span>⚠</span>
+            <span><b style="font-weight:600">Azure DevOps rejected the token.</b> The 14 work items below were
+              read 1h 14m ago and are marked stale. Update the Azure DevOps token in Settings, then refresh.</span>
+            <span class="btn outline">Open Settings <kbd>g</kbd> <kbd>s</kbd></span>
+          </div>
+          <div class="sec">
+            <div class="grouphead">Blocked <span class="c">· 2</span></div>
+            <div class="row stale">
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">[BE] Optimistic concurrency on document set updates</span>
+                <span class="ctx">WI-41502<span class="s">·</span>Sprint 4<span class="s">·</span><span style="color:#f5a824">stale · read 1h 14m ago</span></span></span>
+              <span class="badge blocked">Blocked</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <ol class="pins">
+      <li><span class="n">1</span><span><b>Two readouts, two truths.</b> No global "synced" sentence can be true
+        while a source is failing, so the global sentence is deleted rather than qualified.</span></li>
+      <li><span class="n">2</span><span><b>Rows from the failed source carry their own age.</b> Stale data is
+        never mistaken for current data; the dashboard is never blanked because one provider is down.</span></li>
+      <li><span class="n">3</span><span><b>The banner names the cause and the remedy</b> and does not apologise.
+        Auth, rate limit and network each get their own sentence, and each is tested.</span></li>
+      <li><span class="n">4</span><span><b>Refresh becomes a ghost button</b> beside the status it acts on. It is
+        maintenance, not the job.</span></li>
+      <li><span class="n">5</span><span><b>Sprint progress gains a bar with two marks</b> — done, and elapsed —
+        so "0/17 with 13 days left" reads as the signal it is. Text stays for screen readers, and the
+        <code>progressbar</code> role carries <code>aria-valuenow</code>.</span></li>
+      <li><span class="n">6</span><span><b>One ambient number: 9 waiting on you.</b> Its own denominator, its own
+        group, no relationship to 0/17.</span></li>
+    </ol>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">02<span class="sep">/</span><span class="tasks">P7 · the empty state becomes the door</span></p>
+    <h2>Today, before you've chosen</h2>
+    <p>Currently the most valuable card on the page spends itself on one sentence and a text link that reads
+    like it might rearrange your afternoon. Replace it with a real button and one fact.</p>
+
+    <div class="compare two">
+      <figure class="before">
+        <figcaption>Today</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="card">
+              <div class="sec-head" style="padding-bottom:6px">Today <span class="count">0</span>
+                <span class="right" style="color:#a1a1aa">Review my day</span></div>
+              <p style="margin:0;font-size:13px;color:#a1a1aa">Nothing chosen for today — pin something from below.</p>
+            </div>
+          </div>
+        </div>
+      </figure>
+      <figure class="after">
+        <figcaption>Phase 3</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="card" style="border-left:2px solid #cfa348">
+              <div class="sec-head" style="padding-bottom:6px">Today
+                <span class="right mono" style="font-size:11.5px">0 planned · 0h of 6h</span></div>
+              <p style="margin:0 0 12px;font-size:13px;color:#a1a1aa">Nothing chosen yet. 9 signals are waiting on you.</p>
+              <div style="display:flex;align-items:center;gap:12px">
+                <span class="btn primary lg">Plan the day <kbd style="border-color:rgba(255,255,255,.3);color:#fff">P</kbd></span>
+                <span class="after">or pin anything below with <kbd>t</kbd></span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </figure>
+    </div>
+    <p class="dek" style="margin-top:1rem">The gold rule down the left edge is the only place brand colour
+    enters the product. It marks Today, and Today only — which is also the thread this document is drawn on.</p>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">03<span class="sep">/</span><span class="tasks">P7 · four steps, no recommendation</span></p>
+    <h2>Plan the day</h2>
+    <p>Sunsama's ritual with the calendar surgically removed. Every step is a decision you make; nothing is
+    ordered, suggested, or timeboxed for you. Re-enterable at any hour without losing state.</p>
+
+    <figure class="frame">
+      <figcaption><span>Step 1 of 4 · Yesterday</span><span class="w">no judgement copy, no streak, no score</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="dialog" style="max-width:560px">
+            <div class="dhead"><h5>Plan the day</h5><span class="step">step 1 of 4 · yesterday</span>
+              <span class="spacer" style="flex:1"></span><span class="iconbtn">✕</span></div>
+            <div class="dbody">
+              <p style="margin:0 0 12px;font-size:13px;color:#a1a1aa">Three of yesterday's five picks are still open.</p>
+              <div class="mini"><span class="t">Prostream — QR stamp fails with rotated pages</span>
+                <span class="est">1h 20m logged</span>
+                <span class="btn outline">Keep</span><span class="btn ghost">Snooze</span><span class="btn ghost">Drop</span></div>
+              <div class="mini"><span class="t">[BE] Optimistic concurrency on document set updates</span>
+                <span class="est">—</span>
+                <span class="btn outline">Keep</span><span class="btn ghost">Snooze</span><span class="btn ghost">Drop</span></div>
+              <div class="mini"><span class="t">Create pipeline template for gateway smoke tests</span>
+                <span class="est">15m logged</span>
+                <span class="btn outline">Keep</span><span class="btn ghost">Snooze</span><span class="btn ghost">Drop</span></div>
+            </div>
+            <div class="dfoot"><span style="font-size:12px;color:#71717a">Keep all <kbd>⌘↵</kbd></span>
+              <span class="spacer"></span><span class="btn ghost">Skip</span><span class="btn primary">Next <kbd>↵</kbd></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <figure class="frame">
+      <figcaption><span>Step 2 of 4 · Choose</span><span class="w">the ranked list, unmodified · <kbd>t</kbd> adds</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="dialog" style="max-width:640px">
+            <div class="dhead"><h5>Plan the day</h5><span class="step">step 2 of 4 · choose</span>
+              <span class="spacer" style="flex:1"></span><span class="mono" style="font-size:11.5px;color:#a1a1aa">4 picked</span></div>
+            <div class="dbody" style="padding-top:8px">
+              <div class="grouphead" style="padding-top:6px">Waiting on you <span class="c">· 9</span></div>
+              <div class="row"><span class="score critical">60</span><span class="src">⑂</span>
+                <span class="titles"><span class="title">feat(#39596): option to disable notification digest for org members</span></span>
+                <span class="btn outline">Pinned ✓</span></div>
+              <div class="row"><span class="score high">55</span><span class="src">▤</span>
+                <span class="titles"><span class="title">Document sets: toast is incorrect after publishing a revision</span></span>
+                <span class="btn outline">Add <kbd>t</kbd></span></div>
+              <div class="row"><span class="score high">40</span><span class="src">▤</span>
+                <span class="titles"><span class="title">Prostream — QR stamp fails with rotated pages</span></span>
+                <span class="btn outline">Pinned ✓</span></div>
+              <div class="grouphead">Blocked <span class="c">· 2</span></div>
+              <div class="row"><span class="score high">40</span><span class="src">▤</span>
+                <span class="titles"><span class="title">[BE] Optimistic concurrency on document set updates</span></span>
+                <span class="badge blocked">Blocked</span><span class="btn outline">Pinned ✓</span></div>
+            </div>
+            <div class="dfoot"><span style="font-size:12px;color:#71717a">Ordered by score. Nothing is
+              recommended.</span><span class="spacer"></span><span class="btn ghost">Back</span><span class="btn primary">Next <kbd>↵</kbd></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <figure class="frame">
+      <figcaption><span>Step 3 of 4 · Estimate</span><span class="w">skippable — an unestimated plan is still a plan</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="dialog" style="max-width:560px">
+            <div class="dhead"><h5>Plan the day</h5><span class="step">step 3 of 4 · estimate</span></div>
+            <div class="dbody">
+              <div class="mini"><span class="grip">⠿</span><span class="t">feat(#39596): option to disable notification digest</span>
+                <span class="querybar" style="height:24px;width:74px;justify-content:center">3h 00m</span></div>
+              <div class="mini"><span class="grip">⠿</span><span class="t">Prostream — QR stamp fails with rotated pages</span>
+                <span class="querybar" style="height:24px;width:74px;justify-content:center">2h 30m</span></div>
+              <div class="mini"><span class="grip">⠿</span><span class="t">[BE] Optimistic concurrency on document set updates</span>
+                <span class="querybar" style="height:24px;width:74px;justify-content:center;color:#71717a">2h 00m</span></div>
+              <div class="mini"><span class="grip">⠿</span><span class="t">Create pipeline template for gateway smoke tests</span>
+                <span class="querybar" style="height:24px;width:74px;justify-content:center;color:#71717a">1h 00m</span></div>
+              <p style="margin:12px 0 0;font-size:12px;color:#71717a">Drag to reorder, or <kbd>⌥↑</kbd> <kbd>⌥↓</kbd>.
+                You finish review-type work about 40% slower than you estimate — that's from your own logs.</p>
+            </div>
+            <div class="dfoot"><span class="spacer"></span><span class="btn ghost">Skip estimates</span><span class="btn primary">Next <kbd>↵</kbd></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <figure class="frame">
+      <figcaption><span>Step 4 of 4 · Check</span><span class="w">the two most important words in the product</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="dialog" style="max-width:560px">
+            <div class="dhead"><h5>Plan the day</h5><span class="step">step 4 of 4 · check</span></div>
+            <div class="dbody">
+              <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:8px">
+                <span style="font-size:13px">Planned</span>
+                <span class="mono" style="font-size:15px;font-weight:600;color:#f5a524">8h 30m</span></div>
+              <div class="meter"><i class="over" style="width:100%"></i><span class="cap" style="left:70.6%"></span></div>
+              <div style="display:flex;justify-content:space-between;margin-top:6px">
+                <span class="mono" style="font-size:11px;color:#71717a">0</span>
+                <span class="mono" style="font-size:11px;color:#a1a1aa">capacity 6h 00m</span></div>
+              <p style="margin:16px 0 0;font-size:14px">That's 2h 30m more than your day. <b>Your call.</b></p>
+              <p style="margin:8px 0 0;font-size:12px;color:#71717a">Nothing has been removed or reordered.
+                Capacity is a number you set — <span style="color:#8179f0">change it</span>.</p>
+            </div>
+            <div class="dfoot"><span class="spacer"></span><span class="btn ghost">Back and adjust</span><span class="btn primary">Looks right <kbd>↵</kbd></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <div class="note decision">
+      <span class="tag">Copy discipline</span>
+      <b>"Your call."</b> is the entire product philosophy in two words: state the arithmetic, hand back the
+      decision. It must never become "consider dropping one" or "this looks like a lot". If a future diff
+      softens that line into advice, the diff is the bug.
+    </div>
+
+    <div class="note decision">
+      <span class="tag">Decision · default capacity</span>
+      §12 question 5 asks whether to prompt for capacity on first run. <b>No — pre-fill 6h and make it editable
+      right here, in the step where the number means something.</b> A first-run question about your daily
+      capacity is a question with no context behind it; the same question next to "8h 30m planned" answers itself.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">04<span class="sep">/</span><span class="tasks">P7 · P9 · after the ritual</span></p>
+    <h2>Today, once you've chosen</h2>
+    <p>A hand-ordered flat list. Per-item estimate, per-item logged time, plan total against capacity. No
+    time-of-day field exists — not in the schema, not in the UI, not ever.</p>
+
+    <figure class="frame">
+      <figcaption><span>Today · planned, one timer running</span><span class="w">⌥↑ ⌥↓ reorders · space starts the clock</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="card" style="border-left:2px solid #cfa348">
+            <div class="sec-head" style="padding-bottom:8px">Today <span class="count">4</span>
+              <span class="right mono" style="font-size:11.5px">1h 28m logged of 8h 30m planned<span style="color:#f5a524"> · 6h capacity</span></span></div>
+            <div class="row today-thread"><span class="grip" style="color:rgba(255,255,255,.25);font-size:11px">⠿</span>
+              <span class="score critical">60</span><span class="src">⑂</span>
+              <span class="titles"><span class="title">feat(#39596): option to disable notification digest for org members</span>
+                <span class="ctx">pro4all-services-identity<span class="s">·</span>#39596</span></span>
+              <span class="est mono" style="font-size:11.5px;color:#a1a1aa">3h 00m</span>
+              <span class="badge neutral">Draft</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+            <div class="row today-thread"><span class="grip" style="color:rgba(255,255,255,.25);font-size:11px">⠿</span>
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Prostream — users not found in the project member picker</span>
+                <span class="ctx">WI-41493<span class="s">·</span>Sprint 4</span></span>
+              <span class="est mono" style="font-size:11.5px;color:#7ee2a0">1h 12m / 2h 30m</span>
+              <span class="badge progress">In Progress</span>
+              <span class="actions"><span class="btn outline">⏸ Pause</span><span class="iconbtn">⋯</span></span></div>
+            <div class="row today-thread"><span class="grip" style="color:rgba(255,255,255,.25);font-size:11px">⠿</span>
+              <span class="score high">40</span><span class="src">▤</span>
+              <span class="titles"><span class="title">[BE] Optimistic concurrency on document set updates</span>
+                <span class="ctx">WI-41502<span class="s">·</span>Sprint 4</span></span>
+              <span class="est mono" style="font-size:11.5px;color:#a1a1aa">2h 00m</span>
+              <span class="badge blocked">Blocked</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+            <div class="row today-thread"><span class="grip" style="color:rgba(255,255,255,.25);font-size:11px">⠿</span>
+              <span class="score low">10</span><span class="src">✉</span>
+              <span class="titles"><span class="title">Create pipeline template for gateway smoke tests</span>
+                <span class="ctx">ad-hoc<span class="s">·</span>from standup</span></span>
+              <span class="est mono" style="font-size:11.5px;color:#a1a1aa">16m / 1h 00m</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <div class="note">
+      <span class="tag">Guardrail check</span>
+      Today and In&nbsp;progress stay disjoint — the member-picker item shows <code>In Progress</code> because that
+      is its <em>upstream</em> ADO state, and it sits in Today because you picked it. The local
+      <code>status</code> that drives the In&nbsp;progress section is unchanged and still exclusive.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">05<span class="sep">/</span><span class="tasks">P7 · P9 · closing</span></p>
+    <h2>Wrap up — mostly already built</h2>
+    <p><code>ShutdownDialog.tsx</code> already does the hard part: completed today, still open, total hours
+    logged, carry to tomorrow. What it lacks is the plan it was measured against, an estimate-vs-actual
+    line, and the free-text note. It also lacks a name that says what it does — it is currently reached from a
+    link called <em>"Review my day"</em>, sitting in the Today header where a planning control belongs.</p>
+
+    <figure class="frame">
+      <figcaption><span>Wrap up · <kbd>W</kbd></span><span class="w">extends ShutdownDialog · additions marked</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="dialog" style="max-width:560px">
+            <div class="dhead"><h5>Wrap up the day</h5><span class="step">thursday 14 august</span></div>
+            <div class="dbody">
+              <div class="grouphead" style="padding-top:0">Finished <span class="c">· 2</span></div>
+              <div class="mini"><span class="t">Prostream — QR stamp fails with rotated pages</span><span class="est">2h 40m / 2h 30m est</span></div>
+              <div class="mini"><span class="t">Create pipeline template for gateway smoke tests</span><span class="est">1h 05m / 1h 00m est</span></div>
+              <div class="grouphead">Still open <span class="c">· 2</span></div>
+              <div class="mini"><span class="t">feat(#39596): option to disable notification digest</span>
+                <span class="btn outline">Tomorrow</span><span class="btn ghost">Snooze</span><span class="btn ghost">Drop</span></div>
+              <div class="mini"><span class="t">[BE] Optimistic concurrency on document set updates</span>
+                <span class="btn outline">Tomorrow</span><span class="btn ghost">Snooze</span><span class="btn ghost">Drop</span></div>
+              <div style="height:1px;background:rgba(255,255,255,.1);margin:14px 0"></div>
+              <div style="display:flex;justify-content:space-between;font-size:13px">
+                <span>Logged today</span><span class="mono" style="font-weight:600">6h 20m</span></div>
+              <div style="display:flex;justify-content:space-between;font-size:13px;color:#a1a1aa;margin-top:4px">
+                <span>Planned this morning</span><span class="mono">8h 30m</span></div>
+              <p style="margin:12px 0 0;font-size:12.5px;color:#a1a1aa">You planned 8h 30m against a 6h day and
+                logged 6h 20m. Review-type work ran 40% over estimate again.</p>
+              <div class="querybar" style="height:auto;min-height:56px;align-items:flex-start;padding:9px 10px;margin-top:12px;font-family:var(--sans);color:#71717a;font-size:13px">
+                Anything worth remembering about today? (optional, stays local)</div>
+            </div>
+            <div class="dfoot"><span class="spacer"></span><span class="btn primary">Close the day <kbd>↵</kbd></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <div class="note">
+      <span class="tag">Framing, which is this task's real risk</span>
+      "Review-type work ran 40% over estimate again" is calibration — second person, about a <em>kind of work</em>,
+      derived from your own logs, computed locally. It becomes self-surveillance the moment it turns into a rate,
+      a streak, a grade, or a comparison. There are none of those anywhere in this phase, and the copy review is
+      part of the definition of done, not a step afterwards.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">06<span class="sep">/</span><span class="tasks">delta</span></p>
+    <h2>What changed</h2>
+    <ul class="ledger">
+      <li class="add"><span class="task">P8</span><span class="op">+</span><span class="body">Per-source freshness and state — <code>ok</code> / <code>stale</code> / <code>error</code> / <code>partial</code>, text plus icon, never colour alone</span></li>
+      <li class="add"><span class="task">P8</span><span class="op">+</span><span class="body">Stale marking on rows from a failed source, with the row's own read age</span></li>
+      <li class="add"><span class="task">P8</span><span class="op">+</span><span class="body">Failure banner naming cause and remedy — auth, rate limit, network each tested</span></li>
+      <li class="add"><span class="task">P8</span><span class="op">+</span><span class="body">Sprint progress bar, two marks (done + elapsed), <code>role="progressbar"</code> with a text equivalent</span></li>
+      <li class="add"><span class="task">P8</span><span class="op">+</span><span class="body">Ambient count: <em>9 waiting on you</em>, with its own denominator</span></li>
+      <li class="add"><span class="task">P7</span><span class="op">+</span><span class="body"><code>plans</code> (date, capacity_minutes, note) and <code>plan_items</code> (plan_date, item_id, sort_order, estimate_minutes). <em>No time-of-day column — schema test asserts it</em></span></li>
+      <li class="add"><span class="task">P7</span><span class="op">+</span><span class="body">Plan the day, four steps, <kbd>P</kbd>, re-enterable mid-day without data loss</span></li>
+      <li class="add"><span class="task">P7</span><span class="op">+</span><span class="body">Capacity check that states the arithmetic and takes no action</span></li>
+      <li class="add"><span class="task">P7</span><span class="op">+</span><span class="body">Today becomes hand-ordered — drag or <kbd>⌥↑</kbd><kbd>⌥↓</kbd> — with estimate and logged time per row</span></li>
+      <li class="add"><span class="task">P9</span><span class="op">+</span><span class="body">Persistent header timer, one at a time, switching prompts. Long-run nudge offers, never enforces</span></li>
+      <li class="add"><span class="task">P9</span><span class="op">+</span><span class="body">Estimate vs actual per item and by work type, computed locally, framed as calibration</span></li>
+      <li class="mod"><span class="task">P7</span><span class="op">~</span><span class="body"><code>ShutdownDialog</code> becomes <b>Wrap up the day</b> on <kbd>W</kbd> — gains the morning plan, the estimate comparison, and a local note</span></li>
+      <li class="mod"><span class="task">P8</span><span class="op">~</span><span class="body">Refresh drops from <code>primary</code> to <code>ghost</code>, beside the readout it acts on</span></li>
+      <li class="cut"><span class="task">P8</span><span class="op">−</span><span class="body">The global "Last synced: just now" sentence</span></li>
+      <li class="cut"><span class="task">P7</span><span class="op">−</span><span class="body">The "Review my day" text link in the Today header</span></li>
+    </ul>
+
+    <div class="note decision">
+      <span class="tag">The two diffs to reject on sight</span>
+      <b>(a) "Suggested for today."</b> However gentle, that is an algorithm deciding — INV-3 and INV-4 both.
+      <b>(b) A time-of-day field on a plan item.</b> That is the calendar arriving through the side door; the
+      first version is always framed as a convenience. Both start small. Neither gets in.
+      <em>Nothing in this phase decides when you do anything, and no order on screen is machine-chosen except
+      the score, which shows its arithmetic.</em>
+    </div>
+  </section>
+
+</main>
+
+<nav class="pager">
+  <span><span class="lbl">Previous</span><a href="phase-2-speed-and-control.html">← Phase 2 · Speed and control</a></span>
+  <span><span class="lbl">Next</span><a href="phase-4-finish.html">Phase 4 · Finish →</a></span>
+</nav>
+
+</div>
+</body>
+</html>

--- a/docs/wireframes/phase-4-finish.html
+++ b/docs/wireframes/phase-4-finish.html
@@ -1,0 +1,367 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Phase 4 · Finish — Ariadne wireframes</title>
+<link rel="stylesheet" href="wireframe.css">
+</head>
+<body>
+<div class="wrap">
+
+<header class="masthead">
+  <p class="kicker"><a href="index.html">Ariadne wireframes</a> · phase 4 of 4</p>
+  <h1>Finish</h1>
+  <p class="standfirst">Every control named for what it does, the formula given a home a user can read, empty
+  and broken states turned into directions, and the layout carried down to a phone. The formula surface is the
+  one artefact no competitor in this market can publish — it goes last because it can only be written once
+  everything else is true.</p>
+  <p class="meta">Tasks <b>P11 · P10 items 6–9</b> · Effort <b>S · M</b> · Depends on <b>P1 · P7 · P8</b></p>
+</header>
+
+<main class="thread">
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">01<span class="sep">/</span><span class="tasks">P11 · every name earns its place</span></p>
+    <h2>Names, applied</h2>
+    <p>A control says what happens when it's used, and keeps that name all the way through the flow: the button
+    that says <em>Complete</em> produces a toast that says <em>Completed</em>. Nothing on screen may imply that
+    Ariadne decided anything.</p>
+
+    <table class="tokens">
+      <thead><tr><th>Was</th><th>Is</th><th>Because</th></tr></thead>
+      <tbody>
+        <tr><td class="use" style="color:#8a8379">Review my day</td><td class="use" style="color:#e8e3da"><b>Plan the day</b> · and <b>Wrap up the day</b></td>
+            <td class="val">One ambiguous link was doing two jobs, and "review" hints at scheduling</td></tr>
+        <tr><td class="use" style="color:#8a8379">Everything else</td><td class="use" style="color:#e8e3da"><b>Lower priority</b></td>
+            <td class="val">Says what the bucket is, not what it isn't <em>(landed in Phase 1)</em></td></tr>
+        <tr><td class="use" style="color:#8a8379">Needs attention</td><td class="use" style="color:#e8e3da"><b>Signals</b> + four obligation groups</td>
+            <td class="val">"Needs attention" was true of the whole page <em>(landed in Phase 1)</em></td></tr>
+        <tr><td class="use" style="color:#8a8379">Nothing chosen for today — pin something from below.</td>
+            <td class="use" style="color:#e8e3da"><b>Nothing chosen yet. 9 signals are waiting on you.</b> + a real button</td>
+            <td class="val">An empty state is an invitation <em>(landed in Phase 3)</em></td></tr>
+        <tr><td class="use" style="color:#8a8379">Complete <em>(primary emphasis)</em></td><td class="use" style="color:#e8e3da"><b>Complete</b> <em>(outline)</em>, Pause into ⋯</td>
+            <td class="val">Don't bias toward closing work; completing is the hard action to undo</td></tr>
+        <tr><td class="use" style="color:#8a8379">Paused · 4</td><td class="use" style="color:#e8e3da"><b>Paused · 4</b> at ≥4.5:1, with <code>aria-expanded</code></td>
+            <td class="val">It was a sub-contrast label on a collapsible with no state exposed</td></tr>
+        <tr><td class="use" style="color:#8a8379">— <em>(new)</em></td><td class="use" style="color:#e8e3da"><b>Starred, snoozed and done are local. Ariadne never changes anything in GitHub or Azure DevOps.</b></td>
+            <td class="val">Turns the read-only invariant into visible reassurance <em>(landed in Phase 2)</em></td></tr>
+        <tr><td class="use" style="color:#8a8379">— <em>(new)</em></td><td class="use" style="color:#e8e3da"><b>Tokens are stored in plaintext in your local database — the same trust model as a <code>.env</code> file.</b></td>
+            <td class="val">The README already says this. Settings should too, next to the field</td></tr>
+      </tbody>
+    </table>
+
+    <div class="note">
+      <span class="tag">Rule for the whole product</span>
+      Active voice. A control's name survives into its confirmation. Errors state cause and remedy without
+      apologising. Empty states invite. <b>And never imply the tool decided anything</b> — which rules out
+      "recommended", "suggested", "smart", "optimised" and "for you" across every string in the app.
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">02<span class="sep">/</span><span class="tasks">P11 · the artefact nobody else can publish</span></p>
+    <h2>The whole formula, on one screen</h2>
+    <p>Reached from every breakdown popover. Generated from the same tables <code>lib/scoring.ts</code> scores
+    with, so it cannot lie. Lives in a modal, not a route.</p>
+
+    <figure class="frame">
+      <figcaption><span>How urgency is scored</span><span class="w">from any "Why 60?" popover · Settings · ⌘K</span></figcaption>
+      <div class="stage pad">
+        <div class="ui fluid" style="padding:0">
+          <div class="dialog" style="max-width:600px">
+            <div class="dhead"><h5>How urgency is scored</h5>
+              <span class="spacer" style="flex:1"></span>
+              <span class="step">generated from lib/scoring.ts</span><span class="iconbtn">✕</span></div>
+            <div class="dbody">
+              <p style="margin:0 0 14px;font-size:13px;color:#a1a1aa">This is the whole formula. There is no model,
+                no learned weight, and nothing hidden. Every number below is the number the code adds.</p>
+
+              <div class="grouphead" style="padding-top:0">Why the signal exists <span class="c">· exactly one applies</span></div>
+              <div class="mini"><span class="t">Ready to merge — approved and unmerged</span><span class="est">+45</span></div>
+              <div class="mini"><span class="t">Mentioned you</span><span class="est">+40</span></div>
+              <div class="mini"><span class="t">Review requested</span><span class="est">+40</span></div>
+              <div class="mini"><span class="t">Stale — your PR, no reviews</span><span class="est">+30</span></div>
+              <div class="mini"><span class="t">Assigned to you</span><span class="est">+10</span></div>
+              <div class="mini"><span class="t">Your PR</span><span class="est">+10</span></div>
+              <div class="mini"><span class="t">Ad-hoc — you filed it yourself</span><span class="est">+10</span></div>
+
+              <div class="grouphead">Then these stack on top <span class="c">· any number of them</span></div>
+              <div class="mini"><span class="t">Due, or overdue, within 2 days <span style="color:#71717a">— falls back to the sprint end date</span></span><span class="est">+25</span></div>
+              <div class="mini"><span class="t">Unresolved review conversations</span><span class="est">+20</span></div>
+              <div class="mini"><span class="t">No activity for more than 5 days</span><span class="est">+15</span></div>
+
+              <div style="height:1px;background:rgba(255,255,255,.1);margin:14px 0"></div>
+              <div class="mini"><span class="t"><b style="font-weight:600">Highest score possible</b></span><span class="est" style="color:#fafafa;font-weight:600">105</span></div>
+
+              <div class="grouphead">Bands, and what they colour</div>
+              <div class="mini"><span class="t"><span class="score critical">60</span> &nbsp;Critical</span><span class="est">60 – 105</span></div>
+              <div class="mini"><span class="t"><span class="score high">45</span> &nbsp;High</span><span class="est">40 – 59</span></div>
+              <div class="mini"><span class="t"><span class="score medium">30</span> &nbsp;Medium</span><span class="est">25 – 39</span></div>
+              <div class="mini"><span class="t"><span class="score low">10</span> &nbsp;Low — below the attention threshold</span><span class="est">0 – 24</span></div>
+
+              <div class="grouphead">The two rules that aren't points</div>
+              <p style="margin:0 0 8px;font-size:12.5px;color:#d4d4d8"><b style="font-weight:600">Anything you've
+                started sorts first</b>, whatever it scores. Work in progress outranks work you haven't touched.</p>
+              <p style="margin:0 0 8px;font-size:12.5px;color:#d4d4d8"><b style="font-weight:600">Equal scores break
+                by oldest activity first</b>, so the order never shuffles between refreshes.</p>
+              <p style="margin:0;font-size:12.5px;color:#d4d4d8"><b style="font-weight:600">Ad-hoc requests stay
+                visible below 25</b>, because they have no upstream activity to earn points from. Rows held by that
+                rule are marked <span class="badge local" style="height:17px">Kept visible</span>.</p>
+            </div>
+            <div class="dfoot"><span style="font-size:11.5px;color:#71717a">lib/scoring.ts · 96 lines · read it
+              end to end</span><span class="spacer"></span><span class="btn outline">Close <kbd>esc</kbd></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <div class="note decision">
+      <span class="tag">Decision · disclose the sort rules, not just the points</span>
+      The proposal's reference covers the point table. It has to cover more than that:
+      <code>sortByUrgency()</code> promotes <b>every in-progress item above every other item regardless of
+      score</b>. That rule is invisible, it overrides the number the user is being shown, and leaving it out of
+      the reference would make the page technically accurate and practically a lie. Same for the ad-hoc
+      threshold exemption. <b>If a rule changes what you see, it belongs on this screen.</b>
+    </div>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">03<span class="sep">/</span><span class="tasks">P11 · nothing, and broken</span></p>
+    <h2>The states nobody designs</h2>
+    <p>Three empty states and one first run. Each says what is absent, then offers the next action — no confetti,
+    no apology, no shrug.</p>
+
+    <div class="compare two">
+      <figure class="after">
+        <figcaption>Nothing waiting on you</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="sec-head" style="padding:0 0 8px">Signals <span class="count">6</span>
+              <span class="right">nothing needs you right now</span></div>
+            <div class="grouphead empty" style="padding-top:6px">Waiting on you <span class="c">· 0</span></div>
+            <div class="grouphead empty">Blocked <span class="c">· 0</span></div>
+            <div class="grouphead">Moving without you <span class="c">· 2</span></div>
+            <div class="row"><span class="score medium">30</span><span class="src">⑂</span>
+              <span class="titles"><span class="title">fix: reassign document owner on user deactivation</span>
+                <span class="ctx">pro4all-services-dms<span class="s">·</span>3d no reviews</span></span></div>
+            <div class="grouphead">Lower priority <span class="c">· 4</span><span class="more">Show 4 ⌄</span></div>
+            <p style="font-size:12.5px;color:#a1a1aa;margin:14px 0 0">Two of your PRs are in other people's
+              queues. Nothing here needs a decision from you.</p>
+          </div>
+        </div>
+      </figure>
+      <figure class="after">
+        <figcaption>First run · no tokens yet</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="card">
+              <div class="sec-head" style="padding-bottom:6px">Nothing synced yet</div>
+              <p style="margin:0 0 4px;font-size:13px;color:#a1a1aa">Ariadne reads GitHub and Azure DevOps with
+                read-only tokens you provide. It never writes to either.</p>
+              <p style="margin:0 0 12px;font-size:12px;color:#71717a">Tokens are stored in plaintext in your local
+                database — the same trust model as a <span class="mono">.env</span> file.</p>
+              <div style="display:flex;gap:8px;align-items:center">
+                <span class="btn primary lg">Add tokens in Settings</span>
+                <span class="btn outline lg">Add an ad-hoc request instead</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </figure>
+    </div>
+
+    <div class="compare two">
+      <figure class="after">
+        <figcaption>Query matched nothing</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <span class="querybar" style="max-width:100%">
+              <span style="color:#71717a">⌕</span>
+              <span><span class="tok">source:</span>github <span class="tok">group:</span>blocked</span><span class="caret"></span></span>
+            <p style="font-family:var(--sans);font-size:12.5px;color:#a1a1aa;margin:12px 0 0">
+              No signals match. There are <b style="color:#fafafa;font-weight:500">2 blocked signals</b>, both from
+              Azure DevOps. <span style="color:#8179f0">Drop source:github</span> ·
+              <span style="color:#8179f0">Clear the query</span></p>
+          </div>
+        </div>
+      </figure>
+      <figure class="after">
+        <figcaption>Rate limited</figcaption>
+        <div class="stage pad">
+          <div class="ui fluid" style="padding:0">
+            <div class="banner" style="margin:0">
+              <span>⚠</span>
+              <span><b style="font-weight:600">GitHub is rate limiting requests.</b> The 4 pull requests below were
+                read 22m ago. The limit resets at 14:48 — refreshing before then will fail again.</span>
+              <span class="btn outline">Dismiss</span></div>
+          </div>
+        </div>
+      </figure>
+    </div>
+    <p class="dek" style="margin-top:1rem">The rate-limit copy gives a clock time rather than a countdown, and
+    says what refreshing early will do. An error that only says "try again later" makes the user run the
+    experiment themselves.</p>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">04<span class="sep">/</span><span class="tasks">P10 items 6–9 · the responsive floor</span></p>
+    <h2>Down to 375px</h2>
+    <p>The full-width list from Phase 1 degrades on its own — which is the quiet dividend of deleting the
+    two-column layout. Below 900px the only real decisions are what leaves the row and where it goes.</p>
+
+    <figure class="frame">
+      <figcaption><span>1024px</span><span class="w">titles still uncut · context on one line</span></figcaption>
+      <div class="stage">
+        <div class="ui w1024">
+          <div class="statusline"><b>Sprint 4</b>
+            <span class="sprintbar"><i style="width:0"></i><span class="elapsed" style="left:38%"></span></span>
+            <span>0/17<span class="dot"> · </span>13d left</span><span class="dot">·</span>
+            <b style="color:#f5a524">9 waiting on you</b><span class="spacer"></span>
+            <span class="srcstat"><span class="st ok"></span>GitHub 2m</span>
+            <span class="srcstat"><span class="st ok"></span>ADO 2m</span>
+            <span class="btn ghost">⟳</span></div>
+          <div class="sec">
+            <div class="grouphead">Waiting on you <span class="c">· 9</span><span class="more">Show 4 more ⌄</span></div>
+            <div class="row"><span class="score critical">60</span><span class="src">⑂</span>
+              <span class="titles"><span class="title">feat(#39596): option to disable notification digest for org members</span>
+                <span class="ctx">pro4all-services-identity<span class="s">·</span>#39596<span class="s">·</span>2 open threads</span></span>
+              <span class="badge neutral">Draft</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+            <div class="row"><span class="score high">55</span><span class="src">▤</span>
+              <span class="titles"><span class="title">Document sets: toast is incorrect after publishing a revision</span>
+                <span class="ctx">WI-41487<span class="s">·</span>Sprint 4<span class="s">·</span>11d quiet</span></span>
+              <span class="badge neutral">Code Review</span>
+              <span class="actions onhover"><span class="btn outline">Start</span><span class="iconbtn">⋯</span></span></div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <figure class="frame">
+      <figcaption><span>375px</span><span class="w">single column · 44px touch targets · full title via title attr</span></figcaption>
+      <div class="stage" style="max-width:420px">
+        <div class="ui w375">
+          <div class="topbar" style="gap:10px">
+            <span class="logo" style="font-size:16px"><span class="glyph">✳</span> Ariadne</span>
+            <span class="spacer"></span><span class="iconbtn">⌕</span><span class="iconbtn">⚙</span><span class="iconbtn">☰</span>
+          </div>
+          <div class="statusline" style="display:block;line-height:1.9">
+            <div><b>Sprint 4</b><span class="dot"> · </span>0/17<span class="dot"> · </span>13d left</div>
+            <div style="display:flex;align-items:center;gap:10px">
+              <span class="sprintbar" style="width:110px"><i style="width:0"></i><span class="elapsed" style="left:38%"></span></span>
+              <b style="color:#f5a524">9 waiting on you</b></div>
+            <div style="display:flex;gap:12px;align-items:center;padding-top:2px">
+              <span class="srcstat"><span class="st ok"></span>GitHub 2m</span>
+              <span class="srcstat"><span class="st ok"></span>ADO 2m</span>
+              <span class="spacer" style="flex:1"></span>
+              <span class="btn ghost" style="height:32px">⟳ Refresh</span></div>
+          </div>
+          <div class="sec">
+            <div class="card" style="border-left:2px solid #cfa348;padding:10px 12px">
+              <div class="sec-head" style="padding-bottom:4px">Today <span class="count">0</span></div>
+              <p style="margin:0 0 10px;font-size:12.5px;color:#a1a1aa">Nothing chosen yet. 9 signals are waiting on you.</p>
+              <span class="btn primary" style="height:44px;width:100%;justify-content:center">Plan the day</span>
+            </div>
+          </div>
+          <div class="sec">
+            <div class="chips" style="overflow-x:auto;flex-wrap:nowrap">
+              <span class="chip on" style="height:32px;flex:none">All <span class="n">19</span></span>
+              <span class="chip" style="height:32px;flex:none">⑂ GitHub <span class="n">4</span></span>
+              <span class="chip" style="height:32px;flex:none">▤ ADO <span class="n">14</span></span>
+              <span class="chip" style="height:32px;flex:none">✉ Ad-hoc <span class="n">1</span></span>
+            </div>
+            <div class="grouphead">Waiting on you <span class="c">· 9</span></div>
+            <div class="row" style="align-items:flex-start;padding:8px 4px;min-height:0">
+              <span class="score critical" style="margin-top:1px">60</span>
+              <span class="titles">
+                <span class="title" title="feat(#39596): option to disable notification digest for org members">feat(#39596): option to disable notification digest for org members</span>
+                <span class="ctx" style="margin-top:3px">⑂ pro4all-services-identity<span class="s">·</span>#39596</span>
+                <span style="display:flex;align-items:center;gap:8px;margin-top:7px">
+                  <span class="badge neutral">Draft</span>
+                  <span class="spacer" style="flex:1"></span>
+                  <span class="btn outline" style="height:32px">Start</span>
+                  <span class="iconbtn" style="width:32px;height:32px">⋯</span></span>
+              </span>
+            </div>
+            <div class="row" style="align-items:flex-start;padding:8px 4px;min-height:0">
+              <span class="score high" style="margin-top:1px">55</span>
+              <span class="titles">
+                <span class="title" title="Document sets: toast is incorrect after publishing a revision">Document sets: toast is incorrect after publishing a revision</span>
+                <span class="ctx" style="margin-top:3px">▤ WI-41487<span class="s">·</span>11d quiet</span>
+                <span style="display:flex;align-items:center;gap:8px;margin-top:7px">
+                  <span class="badge neutral">Code Review</span>
+                  <span class="spacer" style="flex:1"></span>
+                  <span class="btn outline" style="height:32px">Start</span>
+                  <span class="iconbtn" style="width:32px;height:32px">⋯</span></span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </figure>
+
+    <ol class="pins">
+      <li><span class="n">1</span><span><b>The row wraps rather than sheds.</b> Score, title, source, context,
+        badge and both actions all survive — they restack. Nothing becomes unreachable by pointer, which is
+        Linear's documented failure mode and the reason keyboard parity is not enough.</span></li>
+      <li><span class="n">2</span><span><b>Titles wrap to two lines before they truncate</b>, and carry the full
+        string in <code>title</code> plus the accessible name when they do.</span></li>
+      <li><span class="n">3</span><span><b>Touch targets go to 44px</b> in comfortable density — the primary
+        action, the ⋯ menu, the filter chips, and the Plan the day button.</span></li>
+      <li><span class="n">4</span><span><b>The sync readout survives the narrowest layout.</b> It is the one
+        element that must never be the thing that gets dropped for space.</span></li>
+    </ol>
+  </section>
+
+  <!-- ============================================================ -->
+  <section class="phase node">
+    <p class="eyebrow">05<span class="sep">/</span><span class="tasks">P10 · the floor, itemised</span></p>
+    <h2>Done means these are true</h2>
+    <ul class="ledger">
+      <li class="mod"><span class="task">P10·1</span><span class="op">✓</span><span class="body">No colour-only information anywhere <em>— proved by the greyscale pass in Phase 0</em></span></li>
+      <li class="mod"><span class="task">P10·2</span><span class="op">✓</span><span class="body">Every text/background pair ≥4.5:1, ≥3:1 for large text and meaningful boundaries. <em>Fix the token, not the instance</em></span></li>
+      <li class="mod"><span class="task">P10·3</span><span class="op">✓</span><span class="body">Accessible name on every icon-only control — theme toggle, report, settings, ⋯, +, refresh</span></li>
+      <li class="mod"><span class="task">P10·4</span><span class="op">✓</span><span class="body">Truncated text exposes its full value on hover and to assistive tech</span></li>
+      <li class="mod"><span class="task">P10·5</span><span class="op">✓</span><span class="body">Visible focus on everything interactive, meeting non-text contrast</span></li>
+      <li class="mod"><span class="task">P10·6</span><span class="op">✓</span><span class="body">Single column below 900px · verified at 1440 / 1024 / 768 / 375 · no horizontal page scroll</span></li>
+      <li class="mod"><span class="task">P10·7</span><span class="op">✓</span><span class="body"><code>prefers-reduced-motion</code> honoured — row transitions, ritual step changes, toasts</span></li>
+      <li class="mod"><span class="task">P10·8</span><span class="op">✓</span><span class="body">Collapsibles expose <code>aria-expanded</code>; counts are part of the accessible name</span></li>
+      <li class="mod"><span class="task">P10·9</span><span class="op">✓</span><span class="body">Keyboard-only walkthrough completes every task. Pointer-only walkthrough completes every task. Both run, separately</span></li>
+      <li class="add"><span class="task">P11</span><span class="op">+</span><span class="body">Scoring reference modal, generated from <code>REASON_LABEL</code> / <code>REASON_SCORE</code> — includes the sort rules, not only the points</span></li>
+      <li class="add"><span class="task">P11</span><span class="op">+</span><span class="body">Empty states for: no signals, nothing waiting, query matched nothing, first run with no tokens</span></li>
+      <li class="add"><span class="task">P11</span><span class="op">+</span><span class="body">Error states for auth, rate limit and network — each names cause, age and remedy</span></li>
+      <li class="mod"><span class="task">P11</span><span class="op">~</span><span class="body">Complete drops to outline emphasis; Pause moves into ⋯</span></li>
+      <li class="mod"><span class="task">P11</span><span class="op">~</span><span class="body">The plaintext-token tradeoff appears in Settings, beside the field, in the README's own words</span></li>
+    </ul>
+
+    <div class="note decision">
+      <span class="tag">The gate that outranks the checkboxes</span>
+      Before merging any phase, one question: <b>does this change make the user's own decision easier, or does
+      it make a decision for them?</b> The second answer is a blocker regardless of how good the feature is —
+      and it is the only test in this document that cannot be automated.
+    </div>
+  </section>
+
+  <section class="phase node hollow">
+    <p class="eyebrow">Where this lands</p>
+    <h2>Ranked, and explained</h2>
+    <p>Five phases on, a user goes from coloured dots they can't decode to <span class="ui" style="width:auto;min-width:0;padding:0;background:none;display:inline"><span class="score critical">60</span></span>
+    and the arithmetic behind it. Every researched competitor either has no ranking to explain or has one it
+    won't explain. That position is still empty.</p>
+  </section>
+
+</main>
+
+<nav class="pager">
+  <span><span class="lbl">Previous</span><a href="phase-3-shape-of-a-day.html">← Phase 3 · The shape of a day</a></span>
+  <span><span class="lbl">Back to</span><a href="index.html">Baseline &amp; decisions</a></span>
+</nav>
+
+</div>
+</body>
+</html>

--- a/docs/wireframes/wireframe.css
+++ b/docs/wireframes/wireframe.css
@@ -1,0 +1,707 @@
+/* ==========================================================================
+   Ariadne — wireframe document chrome + product mockup system
+   --------------------------------------------------------------------------
+   Two visual registers, kept strictly apart:
+
+   1. DOCUMENT  — warm ink ground, classical serif, one gold thread.
+                  This is the reviewer's voice. Prefix: none / .doc-*
+   2. PRODUCT   — the app's real dark tokens, Inter-ish sans, mono for data.
+                  This is Ariadne itself. Everything inside .ui.
+
+   The gold thread is the only element allowed to cross between them: it is
+   the document's spine, and inside the product it marks Today — the one
+   place brand and meaning coincide (proposal 5.2).
+   ========================================================================== */
+
+/* ---------- document register ------------------------------------------- */
+
+:root {
+  --ink: #100e0b;          /* warm document ground */
+  --ink-raised: #191510;   /* panels, ledgers */
+  --bone: #e8e3da;         /* document body */
+  --stone: #8a8379;        /* document secondary */
+  --stone-dim: #5d574e;    /* rules, disabled */
+  --thread: #cfa348;       /* Ariadne's thread — brand gold */
+  --thread-dim: #6b5324;
+
+  --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+
+  --gutter: 3.5rem;        /* space the thread lives in */
+  --measure: 34rem;        /* prose measure */
+}
+
+* { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  background: var(--ink);
+  color: var(--bone);
+  font: 400 16px/1.65 var(--serif);
+  -webkit-font-smoothing: antialiased;
+  padding: 0 1.5rem 8rem;
+}
+
+a { color: var(--thread); text-decoration: none; border-bottom: 1px solid var(--thread-dim); }
+a:hover { border-bottom-color: var(--thread); }
+a:focus-visible, button:focus-visible { outline: 2px solid var(--thread); outline-offset: 3px; }
+
+.wrap { max-width: 78rem; margin: 0 auto; }
+
+/* --- masthead --- */
+
+.masthead {
+  padding: 5rem 0 2.5rem var(--gutter);
+  position: relative;
+}
+.masthead .kicker {
+  font: 500 11px/1 var(--mono);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--stone);
+  margin: 0 0 1.5rem;
+}
+.masthead h1 {
+  font: 400 clamp(2.4rem, 5.5vw, 4rem)/1.02 var(--serif);
+  margin: 0 0 1rem;
+  letter-spacing: -.01em;
+}
+.masthead h1 em { font-style: italic; color: var(--thread); }
+.masthead .standfirst {
+  font-size: 1.15rem;
+  color: var(--stone);
+  max-width: var(--measure);
+  margin: 0;
+}
+.masthead .meta {
+  margin-top: 2rem;
+  font: 400 12px/1.8 var(--mono);
+  color: var(--stone-dim);
+}
+.masthead .meta b { color: var(--stone); font-weight: 500; }
+
+/* --- the thread: a single continuous 1px gold line down the left ---------- */
+
+.thread {
+  position: relative;
+  padding-left: var(--gutter);
+}
+.thread::before {
+  content: "";
+  position: absolute;
+  left: 1.25rem;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: linear-gradient(to bottom, var(--thread-dim), var(--thread-dim) 96%, transparent);
+}
+/* a node marks each phase — filled when the phase exists, hollow when it's a
+   later step the reader hasn't reached */
+.node { position: relative; }
+.node::before {
+  content: "";
+  position: absolute;
+  left: calc(1.25rem - 3.5px - var(--gutter));
+  top: .55em;
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--thread);
+  box-shadow: 0 0 0 4px var(--ink);
+}
+.node.hollow::before { background: var(--ink); border: 1px solid var(--thread-dim); }
+
+/* --- phase blocks --- */
+
+.phase { padding: 4.5rem 0 0; }
+.phase > .eyebrow {
+  font: 500 11px/1 var(--mono);
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--thread);
+  margin: 0 0 .85rem;
+}
+.phase > .eyebrow .sep { color: var(--thread-dim); margin: 0 .5rem; }
+.phase > .eyebrow .tasks { color: var(--stone); }
+.phase h2 {
+  font: 400 clamp(1.75rem, 3.4vw, 2.5rem)/1.1 var(--serif);
+  margin: 0 0 1rem;
+  letter-spacing: -.01em;
+}
+.phase > p, .phase > .prose { max-width: var(--measure); color: var(--bone); }
+.phase > p { margin: 0 0 1.1rem; }
+.dek { color: var(--stone) !important; }
+
+h3.sub {
+  font: 400 1.3rem/1.2 var(--serif);
+  margin: 3rem 0 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255,255,255,.07);
+}
+h4.sub {
+  font: 500 11px/1 var(--mono);
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--stone);
+  margin: 2.25rem 0 .9rem;
+}
+
+/* --- change ledger: the deltas, keyed to proposal task ids --------------- */
+
+.ledger {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  border-top: 1px solid rgba(255,255,255,.07);
+  font-family: var(--sans);
+  font-size: 13.5px;
+  max-width: 52rem;
+}
+.ledger li {
+  display: grid;
+  grid-template-columns: 5.5rem 1.1rem 1fr;
+  gap: .75rem;
+  padding: .7rem 0;
+  border-bottom: 1px solid rgba(255,255,255,.05);
+  align-items: baseline;
+}
+.ledger .task {
+  font: 500 11px/1.4 var(--mono);
+  letter-spacing: .04em;
+  color: var(--thread);
+  text-transform: uppercase;
+}
+.ledger .op { font: 600 13px/1.4 var(--mono); }
+.ledger .add .op { color: #6ecf8e; }
+.ledger .cut .op { color: #e07a72; }
+.ledger .mod .op { color: var(--stone); }
+.ledger .body { color: var(--bone); }
+.ledger .body em { color: var(--stone); font-style: normal; }
+.ledger .body code { font: 400 12px/1.4 var(--mono); color: var(--stone); }
+
+/* --- reviewer notes / decisions ----------------------------------------- */
+
+.note {
+  border-left: 2px solid var(--thread-dim);
+  padding: .1rem 0 .1rem 1.1rem;
+  margin: 1.75rem 0;
+  max-width: var(--measure);
+  color: var(--stone);
+  font-size: 15px;
+}
+.note b { color: var(--bone); font-weight: 400; font-style: italic; }
+.note.decision { border-left-color: var(--thread); }
+.note .tag {
+  display: block;
+  font: 500 10px/1 var(--mono);
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--thread);
+  margin-bottom: .5rem;
+}
+
+/* --- the mockup frame --------------------------------------------------- */
+
+.frame { margin: 1.75rem 0 0; }
+.frame > figcaption {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .6rem 1rem;
+  align-items: baseline;
+  font: 500 11px/1.5 var(--mono);
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--stone);
+  margin-bottom: .6rem;
+}
+.frame > figcaption .w { color: var(--stone-dim); letter-spacing: .06em; }
+/* the frame outlines the viewport being drawn, so it shrink-wraps its mockup
+   rather than stretching to the document measure */
+.frame .stage {
+  background: #09090b;
+  border: 1px solid rgba(255,255,255,.09);
+  border-radius: 10px;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+.frame .stage.pad { width: auto; }
+.frame .stage.pad { padding: 1.25rem; }
+.frame.narrow .stage { max-width: 26rem; }
+
+/* callout pins that sit over a mockup, numbered to the notes beneath it */
+.pins { list-style: none; margin: .9rem 0 0; padding: 0; max-width: 52rem; }
+.pins li {
+  display: grid; grid-template-columns: 1.5rem 1fr; gap: .7rem;
+  font-family: var(--sans); font-size: 13.5px; color: var(--stone);
+  padding: .35rem 0;
+}
+.pins .n {
+  font: 600 10px/1.5rem var(--mono);
+  text-align: center;
+  color: var(--ink);
+  background: var(--thread);
+  border-radius: 50%;
+  width: 1.5rem; height: 1.5rem;
+}
+.pins b { color: var(--bone); font-weight: 500; }
+
+.pin {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 15px; height: 15px; flex: none;
+  border-radius: 50%;
+  background: var(--thread); color: #100e0b;
+  font: 600 9px/1 var(--mono);
+  vertical-align: middle;
+}
+
+/* --- side-by-side comparison ------------------------------------------- */
+
+.compare { display: grid; gap: 1.25rem; margin: 1.5rem 0 0; }
+@media (min-width: 62rem) { .compare.two { grid-template-columns: 1fr 1fr; } }
+.compare > figure { margin: 0; }
+.compare > figure > figcaption {
+  font: 500 11px/1.5 var(--mono); letter-spacing: .1em; text-transform: uppercase;
+  color: var(--stone); margin-bottom: .55rem;
+}
+.compare .before > figcaption { color: var(--stone-dim); }
+.compare .before > figcaption::before { content: "− "; }
+.compare .after > figcaption::before { content: "+ "; color: var(--thread); }
+
+/* --- token board -------------------------------------------------------- */
+
+.tokens { border-collapse: collapse; width: 100%; max-width: 52rem; margin: 1.25rem 0 0;
+          font-family: var(--sans); font-size: 13.5px; }
+.tokens th, .tokens td { text-align: left; padding: .65rem .8rem .65rem 0;
+                         border-bottom: 1px solid rgba(255,255,255,.06); vertical-align: middle; }
+.tokens th { font: 500 10px/1 var(--mono); letter-spacing: .14em; text-transform: uppercase;
+             color: var(--stone); padding-bottom: .8rem; }
+.tokens td.name { font: 400 12px/1.5 var(--mono); color: var(--bone); white-space: nowrap; }
+.tokens td.val  { font: 400 12px/1.5 var(--mono); color: var(--stone); white-space: nowrap; }
+.tokens td.use  { color: var(--stone); }
+.tokens .sw { display: inline-block; width: 2.5rem; height: 1rem; border-radius: 3px;
+              vertical-align: -3px; border: 1px solid rgba(255,255,255,.12); }
+
+/* --- footer nav --------------------------------------------------------- */
+
+.pager {
+  display: flex; flex-wrap: wrap; gap: 1.5rem; justify-content: space-between;
+  margin-top: 5rem; padding: 1.5rem 0 0 var(--gutter);
+  border-top: 1px solid rgba(255,255,255,.09);
+  font: 500 11px/1.6 var(--mono); letter-spacing: .1em; text-transform: uppercase;
+}
+.pager a { border: 0; }
+.pager .lbl { display: block; color: var(--stone-dim); letter-spacing: .16em; }
+
+/* ==========================================================================
+   PRODUCT REGISTER — everything below renders Ariadne itself.
+   Tokens mirror app/globals.css .dark, converted from HSL for portability.
+   ========================================================================== */
+
+.ui {
+  /* existing app tokens */
+  --bg: #09090b;
+  --card: #18181b;
+  --fg: #fafafa;
+  --muted-fg: #a1a1aa;
+  --border-c: rgba(255,255,255,.10);
+  --accent: #8179f0;          /* indigo — INTERACTIVE ONLY from P0 on */
+  --gold: #cfa348;            /* logo + Today marker ONLY */
+  --warning: #f9a825;
+  --destructive: #ff6b70;
+  --success: #2fbe5f;
+
+  /* P0 additions — urgency bands, derived from lib/scoring.ts (max 105) */
+  --u-critical: #e5484d;      /* >= 60 : filled */
+  --u-high: #f5a524;          /* 40-59 : filled, dark text */
+  --u-medium: #a1a1aa;        /* 25-39 : outline */
+  --u-low: #6b6b74;           /* < 25  : muted, no border */
+
+  /* P0 additions — status semantics */
+  --status-blocked: #f9a825;
+  --status-neutral: #a1a1aa;
+
+  --grid: 4px;
+  --row-h: 44px;              /* comfortable; compact = 36px */
+
+  width: 960px;
+  min-width: 960px;
+  background: var(--bg);
+  color: var(--fg);
+  font: 400 14px/1.45 var(--sans);
+  padding: 0 0 20px;
+}
+.ui.compact { --row-h: 36px; font-size: 13px; }
+.ui.w1024 { width: 1024px; min-width: 1024px; }
+.ui.w768  { width: 768px;  min-width: 768px; }
+.ui.w375  { width: 375px;  min-width: 375px; }
+.ui.fluid { width: 100%; min-width: 0; }
+.ui * { box-sizing: border-box; }
+.ui .mono { font-family: var(--mono); }
+
+/* --- top bar --- */
+
+.ui .topbar {
+  display: flex; align-items: center; gap: 16px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border-c);
+}
+.ui .logo {
+  display: flex; align-items: center; gap: 8px;
+  font: 400 18px/1 var(--serif); letter-spacing: .01em;
+}
+.ui .logo .glyph { color: var(--gold); font-size: 17px; }
+.ui .spacer { flex: 1; }
+.ui .search {
+  flex: 0 0 390px;
+  white-space: nowrap; overflow: hidden;
+  display: flex; align-items: center; gap: 8px;
+  height: 32px; padding: 0 10px;
+  background: var(--card); border: 1px solid var(--border-c); border-radius: 6px;
+  color: var(--muted-fg); font-size: 13px;
+}
+.ui .iconbtn {
+  width: 28px; height: 28px; display: grid; place-items: center;
+  color: var(--muted-fg); border-radius: 5px; font-size: 13px;
+}
+.ui .iconbtn.on { color: var(--fg); background: rgba(255,255,255,.06); }
+
+/* the compact ⌘K affordance that replaces the search field in P12 */
+.ui .kbar {
+  display: flex; align-items: center; gap: 7px;
+  height: 28px; padding: 0 8px 0 10px;
+  border: 1px solid var(--border-c); border-radius: 6px;
+  color: var(--muted-fg); font-size: 12.5px;
+}
+
+/* --- sprint / status line --- */
+
+.ui .statusline {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  padding: 14px 20px 12px;
+  font-size: 13px; color: var(--muted-fg);
+  border-bottom: 1px solid var(--border-c);
+}
+.ui .statusline b { color: var(--fg); font-weight: 600; }
+.ui .statusline .dot { color: rgba(255,255,255,.22); }
+
+.ui .sprintbar {
+  position: relative; height: 4px; width: 148px; flex: none;
+  background: rgba(255,255,255,.09); border-radius: 2px; overflow: visible;
+}
+.ui .sprintbar i { position: absolute; inset: 0 auto 0 0; background: var(--success); border-radius: 2px; }
+.ui .sprintbar .elapsed {
+  position: absolute; top: -3px; width: 2px; height: 10px;
+  background: var(--muted-fg); border-radius: 1px;
+}
+
+/* --- generic section shell --- */
+
+.ui .sec { margin: 16px 20px 0; }
+.ui .sec-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 0 8px;
+  font-size: 13.5px; font-weight: 600;
+}
+.ui .sec-head .count {
+  font: 500 11px/16px var(--mono);
+  min-width: 18px; padding: 0 5px; text-align: center;
+  background: rgba(255,255,255,.08); color: var(--muted-fg); border-radius: 9px;
+}
+.ui .sec-head .right { margin-left: auto; font-weight: 400; font-size: 12.5px; color: var(--muted-fg); }
+.ui .card {
+  background: var(--card); border: 1px solid var(--border-c); border-radius: 10px;
+  padding: 12px 14px;
+}
+
+/* --- group header inside the single ranked list (P2) --- */
+
+.ui .grouphead {
+  display: flex; align-items: center; gap: 8px;
+  padding: 18px 0 6px;
+  font: 500 10.5px/1 var(--mono); letter-spacing: .13em; text-transform: uppercase;
+  color: var(--muted-fg);
+}
+.ui .grouphead .c { color: rgba(255,255,255,.35); }
+.ui .grouphead .more { margin-left: auto; letter-spacing: .04em; color: var(--accent); text-transform: none;
+                        font-family: var(--sans); font-size: 12px; }
+.ui .grouphead.empty { color: var(--u-low); }
+
+/* --- THE ROW — one grammar everywhere ---------------------------------- */
+
+.ui .row {
+  display: flex; align-items: center; gap: 10px;
+  min-height: var(--row-h);
+  padding: 0 10px 0 8px;
+  border-bottom: 1px solid rgba(255,255,255,.05);
+  position: relative;
+}
+.ui .row:last-child { border-bottom: 0; }
+.ui .row.focused {
+  background: rgba(129,121,240,.07);
+  box-shadow: inset 0 0 0 1px rgba(129,121,240,.45);
+  border-radius: 6px;
+}
+.ui .row.focused::before {              /* shape, not colour alone */
+  content: ""; position: absolute; left: 0; top: 6px; bottom: 6px;
+  width: 2px; background: var(--accent); border-radius: 1px;
+}
+.ui .row.today-thread::after {          /* the thread enters the product */
+  content: ""; position: absolute; left: -14px; top: 0; bottom: 0;
+  width: 1px; background: var(--gold); opacity: .55;
+}
+.ui .row.stale { opacity: .72; }
+
+.ui .src { width: 14px; flex: none; color: var(--muted-fg); font-size: 12px; text-align: center; }
+
+.ui .titles { flex: 1; min-width: 0; }
+/* Row height is fixed per density mode, so the title is a single line that
+   ellipsises. At 960px that leaves ~78 characters — comfortably past the
+   60-character floor the proposal sets, and it never reflows the row. */
+.ui .title {
+  display: block;
+  font-size: 13.5px; line-height: 1.35; color: var(--fg);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.ui .title .trunc { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* the narrow layout is the one place a title is allowed two lines */
+.ui.w375 .title { white-space: normal; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+.ui .ctx {
+  font: 400 11.5px/1.4 var(--mono);
+  color: var(--muted-fg);
+  display: flex; gap: 6px; flex-wrap: wrap;
+}
+.ui .ctx .s { color: rgba(255,255,255,.2); }
+
+.ui .row .actions { display: flex; align-items: center; gap: 6px; flex: none; }
+.ui .row .actions.onhover { opacity: .28; }        /* mockup shows resting state */
+.ui .row.focused .actions.onhover { opacity: 1; }
+
+/* --- score chip (P1) --------------------------------------------------- */
+
+.ui .score {
+  flex: none;
+  min-width: 30px; height: 20px; padding: 0 5px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font: 600 12px/1 var(--mono); letter-spacing: .01em;
+  border-radius: 5px;
+  border: 1px solid transparent;
+}
+.ui .score.critical { background: var(--u-critical); color: #1a0405; }
+.ui .score.high     { background: var(--u-high);     color: #1f1401; }
+.ui .score.medium   { border-color: rgba(255,255,255,.28); color: #e4e4e7; }
+.ui .score.low      { color: var(--u-low); }
+
+/* the old, unlabelled urgency dot — kept only to show what P1 removes */
+.ui .olddot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+.ui .olddot.crit { background: var(--destructive); }
+.ui .olddot.high { background: var(--warning); }
+.ui .olddot.med  { background: var(--accent); }
+.ui .olddot.low  { background: #52525b; }
+
+/* --- badges ------------------------------------------------------------- */
+
+.ui .badge {
+  flex: none;
+  display: inline-flex; align-items: center; gap: 4px;
+  height: 19px; padding: 0 7px;
+  font-size: 11px; font-weight: 500; line-height: 1;
+  border-radius: 10px; border: 1px solid transparent; white-space: nowrap;
+}
+/* before P0/P4 — indigo does double duty, Blocked is the calmest thing here */
+.ui .badge.old-review   { background: var(--accent); color: #fff; }
+.ui .badge.old-progress { background: var(--accent); color: #fff; }
+.ui .badge.old-blocked  { border-color: var(--border-c); color: var(--muted-fg); }
+.ui .badge.old-neutral  { background: rgba(255,255,255,.09); color: #d4d4d8; }
+/* after P4 — one job per channel */
+.ui .badge.blocked  { background: var(--status-blocked); color: #1f1401; font-weight: 600; }
+.ui .badge.review   { border-color: rgba(255,255,255,.30); color: #e4e4e7; }
+.ui .badge.progress { background: rgba(255,255,255,.09); color: #d4d4d8; }
+.ui .badge.neutral  { border-color: rgba(255,255,255,.16); color: var(--status-neutral); }
+.ui .badge.local    { border-color: rgba(207,163,72,.4); color: var(--gold); }
+
+/* --- buttons ------------------------------------------------------------ */
+
+.ui .btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 26px; padding: 0 10px;
+  font-size: 12.5px; font-weight: 500;
+  border-radius: 6px; border: 1px solid transparent; white-space: nowrap;
+  color: var(--fg);
+}
+.ui .btn.primary { background: var(--accent); color: #fff; }
+.ui .btn.ghost   { color: var(--muted-fg); }
+.ui .btn.outline { border-color: var(--border-c); }
+.ui .btn.lg { height: 32px; padding: 0 14px; font-size: 13px; }
+.ui .btn kbd { font: 500 10.5px/1 var(--mono); opacity: .7; }
+
+.ui kbd {
+  display: inline-block; padding: 1px 4px; min-width: 16px; text-align: center;
+  font: 500 10.5px/1.5 var(--mono);
+  border: 1px solid var(--border-c); border-radius: 3px;
+  color: var(--muted-fg); background: rgba(255,255,255,.04);
+}
+
+/* --- filter / view chips ------------------------------------------------ */
+
+.ui .chips { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 2px 0 6px; }
+.ui .chip {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  height: 24px; padding: 0 9px;
+  font-size: 12px; border-radius: 12px;
+  border: 1px solid var(--border-c); color: var(--muted-fg);
+}
+.ui .chip .n { font: 500 10.5px/1 var(--mono); color: rgba(255,255,255,.35); }
+.ui .chip.on { border-color: var(--accent); background: rgba(129,121,240,.12); color: var(--fg); }
+.ui .chip.on .n { color: var(--fg); }
+.ui .chip.saved { border-style: dashed; }
+
+/* --- popovers / dialogs ------------------------------------------------- */
+
+.ui .pop {
+  background: var(--card); border: 1px solid rgba(255,255,255,.14);
+  border-radius: 10px; padding: 14px;
+  box-shadow: 0 12px 32px rgba(0,0,0,.55);
+  width: 320px;
+}
+.ui .pop h5 { margin: 0 0 10px; font-size: 13px; font-weight: 600; }
+.ui .pop .rule { height: 1px; background: var(--border-c); margin: 8px 0; }
+.ui .pop .line { display: flex; gap: 12px; align-items: baseline; font-size: 12.5px; padding: 3px 0; }
+.ui .pop .line span:first-child { flex: 1; color: #d4d4d8; }
+.ui .pop .line .pts { font: 500 12px/1 var(--mono); color: var(--fg); }
+.ui .pop .line.total span:first-child { color: var(--fg); font-weight: 600; }
+.ui .pop .line.total .pts { font-weight: 600; }
+.ui .pop .foot { margin-top: 10px; font-size: 11.5px; color: var(--muted-fg); }
+.ui .pop .foot a { color: var(--accent); border: 0; }
+
+.ui .dialog {
+  background: var(--card); border: 1px solid rgba(255,255,255,.14);
+  border-radius: 12px; box-shadow: 0 24px 64px rgba(0,0,0,.6);
+}
+.ui .dialog .dhead {
+  display: flex; align-items: baseline; gap: 10px;
+  padding: 14px 16px; border-bottom: 1px solid var(--border-c);
+}
+.ui .dialog .dhead h5 { margin: 0; font-size: 14px; font-weight: 600; }
+.ui .dialog .dhead .step { font: 500 11px/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; color: var(--muted-fg); }
+.ui .dialog .dbody { padding: 14px 16px; }
+.ui .dialog .dfoot {
+  display: flex; align-items: center; gap: 8px;
+  padding: 12px 16px; border-top: 1px solid var(--border-c);
+}
+.ui .dialog .dfoot .spacer { flex: 1; }
+
+/* --- keyboard help grid ------------------------------------------------- */
+
+.ui .keys { display: grid; grid-template-columns: 1fr 1fr; gap: 0 32px; }
+.ui .keys h6 {
+  grid-column: 1 / -1;
+  margin: 12px 0 6px;
+  font: 500 10.5px/1 var(--mono); letter-spacing: .13em; text-transform: uppercase;
+  color: var(--muted-fg);
+}
+.ui .keys h6:first-child { margin-top: 0; }
+.ui .keys .k { display: flex; align-items: baseline; gap: 8px; padding: 3.5px 0; font-size: 12.5px; }
+.ui .keys .k .kk { flex: none; display: flex; gap: 3px; min-width: 62px; }
+.ui .keys .k .lbl { color: #d4d4d8; }
+
+/* --- capacity meter ----------------------------------------------------- */
+
+.ui .meter { position: relative; height: 8px; background: rgba(255,255,255,.08); border-radius: 4px; }
+.ui .meter i { position: absolute; inset: 0 auto 0 0; background: var(--accent); border-radius: 4px; }
+.ui .meter i.over { background: var(--warning); }
+.ui .meter .cap {
+  position: absolute; top: -4px; width: 2px; height: 16px;
+  background: var(--fg); border-radius: 1px;
+}
+
+/* --- per-source sync readout ------------------------------------------- */
+
+.ui .srcstat { display: flex; align-items: center; gap: 6px; font: 400 11.5px/1 var(--mono); color: var(--muted-fg); }
+.ui .srcstat .st { width: 6px; height: 6px; border-radius: 50%; flex: none; }
+.ui .srcstat .st.ok { background: var(--success); }
+.ui .srcstat .st.stale { background: var(--warning); }
+.ui .srcstat .st.err { background: var(--destructive); }
+
+/* --- inline banner ------------------------------------------------------ */
+
+.ui .banner {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 10px 12px; margin: 12px 20px 0;
+  border: 1px solid rgba(249,168,37,.35); background: rgba(249,168,37,.07);
+  border-radius: 8px; font-size: 12.5px; color: #e8dcc0;
+}
+.ui .banner .btn { margin-left: auto; flex: none; }
+
+/* --- empty state -------------------------------------------------------- */
+
+.ui .empty { padding: 4px 0 8px; }
+.ui .empty p { margin: 0 0 12px; font-size: 13px; color: var(--muted-fg); }
+.ui .empty .after { font-size: 12px; color: var(--muted-fg); margin-left: 10px; }
+
+/* --- toast -------------------------------------------------------------- */
+
+.ui .toast {
+  display: inline-flex; align-items: center; gap: 12px;
+  padding: 9px 12px;
+  background: #232326; border: 1px solid rgba(255,255,255,.14); border-radius: 8px;
+  font-size: 12.5px; box-shadow: 0 10px 28px rgba(0,0,0,.5);
+}
+.ui .toast .btn { height: 22px; }
+
+/* --- timer -------------------------------------------------------------- */
+
+.ui .timer {
+  display: inline-flex; align-items: center; gap: 8px;
+  height: 28px; padding: 0 8px 0 10px;
+  border: 1px solid rgba(47,190,95,.35); background: rgba(47,190,95,.08);
+  border-radius: 6px; font-size: 12px;
+}
+.ui .timer .el { font: 600 12px/1 var(--mono); color: #7ee2a0; }
+.ui .timer .nm { color: var(--muted-fg); max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* --- query bar ---------------------------------------------------------- */
+
+.ui .querybar {
+  display: flex; align-items: center; gap: 8px;
+  height: 32px; padding: 0 10px;
+  background: var(--card); border: 1px solid var(--border-c); border-radius: 6px;
+  font: 400 12.5px/1 var(--mono); color: var(--fg);
+}
+.ui .querybar .tok { color: var(--accent); }
+.ui .querybar .neg { color: var(--destructive); }
+.ui .querybar .caret { width: 1px; height: 14px; background: var(--fg); }
+.ui .querybar.invalid { border-color: rgba(255,107,112,.5); }
+
+/* --- mini list used inside dialogs -------------------------------------- */
+
+.ui .mini { display: flex; align-items: center; gap: 10px; padding: 7px 0; border-bottom: 1px solid rgba(255,255,255,.05); font-size: 13px; }
+.ui .mini:last-child { border-bottom: 0; }
+.ui .mini .t { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ui .mini .est { font: 500 11.5px/1 var(--mono); color: var(--muted-fg); flex: none; }
+.ui .mini .grip { color: rgba(255,255,255,.25); flex: none; font-size: 11px; }
+
+/* --- responsive product mockups ---------------------------------------- */
+
+.ui.w375 .topbar { flex-wrap: wrap; }
+.ui.w375 .sec, .ui.w375 .banner { margin-left: 12px; margin-right: 12px; }
+.ui.w375 .statusline, .ui.w375 .topbar { padding-left: 12px; padding-right: 12px; }
+
+/* --- print ------------------------------------------------------------- */
+
+@media print {
+  body { background: #fff; color: #111; }
+  .thread::before, .node::before { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition: none !important; }
+}
+
+@media (max-width: 40rem) {
+  :root { --gutter: 2rem; }
+  body { padding: 0 1rem 5rem; }
+}


### PR DESCRIPTION
Wireframes for the UI/UX pass in #15, split into five independently shippable phases.

Six self-contained HTML pages plus a shared stylesheet, with a markdown README since GitHub will not render the HTML in the browser. Open `docs/wireframes/index.html` to walk them.

### What's here

| Page | Covers |
|---|---|
| `index.html` | Current dashboard redrawn, the three structural gaps, the phase ladder, all nine open questions answered |
| `phase-0-foundation.html` | Tokens, urgency bands, badge pass preview, density, greyscale proof |
| `phase-1-thesis.html` | Score chip, breakdown popover, one ranked list grouped by actionability |
| `phase-2-speed-and-control.html` | Focused row, shortcut sheet, local triage, query grammar, command palette |
| `phase-3-shape-of-a-day.html` | Per-source freshness, sprint progress, planning ritual, Today planned, wrap up |
| `phase-4-finish.html` | Microcopy, scoring reference, empty and error states, 1024 and 375 layouts |

### Findings that came from the code, not the screenshot

- `TIER_DOT_CLASS.medium` is `bg-primary`, so indigo currently carries urgency, status and interactivity at once.
- `adoStatusVariant()` has no branch for `Blocked`, so it falls through to `outline`. Phase 0 contains a real bug fix.
- `ShutdownDialog.tsx` already builds most of P7's wrap-up ritual. It needs the plan it was measured against and a name that says what it does, not a rewrite.
- `sortByUrgency()` promotes every in-progress item above everything else regardless of score. That rule overrides the number the user is shown, so phase 4 discloses it in the scoring reference.

Score bands needed no deriving either: `getPriorityTier()` already cuts at 60 / 40 / 25 and the real maximum is 105, so the chip inherits the tier that already sorts the list.

Docs only, no runtime changes.

Closes #15