### PR TITLE
Phase 0: design token foundation (P0)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -42,6 +42,19 @@
     --sidebar-border: 240 5.9% 90%;
     --sidebar-ring: 240 5.5% 64.3%;
     --brand-gold: 41.4 53.8% 54.1%;
+
+    /* Urgency bands mirror getPriorityTier()'s cuts at 60/40/25 (lib/scoring.ts).
+       critical and high share hue with --destructive/--warning; medium and low
+       are neutral grays so only the top two bands compete for attention. */
+    --urgency-critical: 358 75% 46%;
+    --urgency-high: 38 92% 50%;
+    --urgency-medium: 240 5% 45%;
+    --urgency-low: 240 4.2% 46.3%;
+
+    /* Status is neutral outline by default; a fill is reserved for states
+       that demand action (blocked). See lib/status-pill.ts. */
+    --status-blocked: 38 92% 50%;
+    --status-neutral: 240 5% 45%;
   }
   .dark {
     --background: 240 10% 3.9%;
@@ -79,7 +92,15 @@
     --sidebar-accent: 240 3.7% 15.9%;
     --sidebar-accent-foreground: 0 0% 98%;
     --sidebar-border: 0 0% 100% / 10%;
-    --sidebar-ring: 240 4.2% 46.3%
+    --sidebar-ring: 240 4.2% 46.3%;
+
+    --urgency-critical: 358 75% 59%;
+    --urgency-high: 38 92% 55%;
+    --urgency-medium: 240 5% 65%;
+    --urgency-low: 240 5.5% 64.3%;
+
+    --status-blocked: 38 92% 55%;
+    --status-neutral: 240 5% 65%;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,11 @@ import { Inter, Marcellus } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import { SearchProvider } from '@/components/SearchProvider';
+import { DensityProvider } from '@/components/DensityProvider';
 import TopBar from '@/components/TopBar';
+import { db } from '@/lib/db-instance';
+import { getSetting } from '@/lib/settings-repo';
+import { SETTINGS_KEYS, DEFAULT_DENSITY, type Density } from '@/lib/config';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
@@ -14,17 +18,26 @@ export const metadata: Metadata = {
   description: 'Personal attention-triage dashboard',
 };
 
+// Every route below opts into force-dynamic rendering (db reads at request
+// time), which already makes this layout dynamic too — declared explicitly
+// so the density setting it reads here never gets baked in at build time.
+export const dynamic = 'force-dynamic';
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const density: Density = getSetting(db, SETTINGS_KEYS.density) === 'compact' ? 'compact' : DEFAULT_DENSITY;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
         className={`${inter.variable} ${marcellus.variable} bg-background font-sans text-foreground antialiased`}
       >
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-          <SearchProvider>
-            <TopBar />
-            {children}
-          </SearchProvider>
+          <DensityProvider density={density}>
+            <SearchProvider>
+              <TopBar />
+              {children}
+            </SearchProvider>
+          </DensityProvider>
           <Toaster />
         </ThemeProvider>
       </body>

--- a/components/DensityProvider.tsx
+++ b/components/DensityProvider.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+import type { Density } from '@/lib/config';
+
+const DensityContext = createContext<Density | undefined>(undefined);
+
+export function DensityProvider({ density, children }: { density: Density; children: ReactNode }) {
+  return <DensityContext.Provider value={density}>{children}</DensityContext.Provider>;
+}
+
+export function useDensity(): Density {
+  const ctx = useContext(DensityContext);
+  if (!ctx) throw new Error('useDensity must be used within a DensityProvider');
+  return ctx;
+}

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -46,11 +46,19 @@ import { matchesQuery } from '@/lib/search';
 import type { Item, Status } from '@/lib/types';
 import type { LinkedRef } from '@/lib/links-repo';
 import { useSearch } from '@/components/SearchProvider';
+import { useDensity } from '@/components/DensityProvider';
+
+// Row height is fixed per mode so content can never reflow it — comfortable
+// is 44px (11 * 4px grid), compact is 36px (9 * 4px grid).
+const ROW_HEIGHT_CLASS = { comfortable: 'h-11', compact: 'h-9' } as const;
 
 type ReasonVariant = 'default' | 'secondary' | 'destructive' | 'outline' | 'warning';
 
+// Indigo ('default') never appears on a badge — that channel is
+// interactive-only. approved_unmerged's urgency is already carried by the
+// priority dot, so its reason pill is neutral outline like the others.
 const REASON_VARIANT: Record<Item['reason'], ReasonVariant> = {
-  approved_unmerged: 'default',
+  approved_unmerged: 'outline',
   mention: 'warning',
   review_requested: 'secondary',
   stale_own_pr: 'destructive',
@@ -101,11 +109,15 @@ const TIER_LABEL: Record<PriorityTier, string> = {
   critical: 'Critical',
 };
 
+// Urgency bands per docs/wireframes/phase-0-foundation.html: only the top two
+// bands are filled, medium is an outline, low has no border at all — so
+// visual weight falls off in the same direction the score does. Indigo never
+// appears here; that channel is interactive-only.
 const TIER_DOT_CLASS: Record<PriorityTier, string> = {
-  low: 'bg-muted-foreground/40',
-  medium: 'bg-primary',
-  high: 'bg-warning',
-  critical: 'bg-destructive',
+  low: 'bg-urgency-low/40',
+  medium: 'border-2 border-urgency-medium bg-transparent',
+  high: 'bg-urgency-high',
+  critical: 'bg-urgency-critical',
 };
 
 interface Props {
@@ -284,6 +296,7 @@ export default function ItemRow({
   const Icon = SOURCE_ICON[item.source];
   const tier = getPriorityTier(item.score);
   const { query } = useSearch();
+  const density = useDensity();
   const isMatch = matchesQuery(item.title, query);
   const [open, setOpen] = useState(false);
   const [hours, setHours] = useState('');
@@ -538,7 +551,8 @@ export default function ItemRow({
     return (
       <div
         className={cn(
-          'flex items-center justify-between gap-3 border-b py-3 last:border-0',
+          'flex items-center justify-between gap-3 overflow-hidden border-b last:border-0',
+          ROW_HEIGHT_CLASS[density],
           'motion-safe:transition-opacity motion-safe:duration-200 motion-safe:ease-out',
           isMatch ? 'opacity-55' : 'opacity-30'
         )}
@@ -566,7 +580,8 @@ export default function ItemRow({
   return (
     <div
       className={cn(
-        'flex items-center justify-between gap-3 border-b py-3 last:border-0',
+        'flex items-center justify-between gap-3 overflow-hidden border-b last:border-0',
+        ROW_HEIGHT_CLASS[density],
         'motion-safe:transition-opacity motion-safe:duration-200 motion-safe:ease-out',
         !isMatch && 'opacity-40'
       )}
@@ -593,7 +608,9 @@ export default function ItemRow({
               </Badge>
             )}
           </div>
-          {item.repo && <span className="block truncate text-xs text-muted-foreground">{item.repo}</span>}
+          {item.repo && density === 'comfortable' && (
+            <span className="block truncate text-xs text-muted-foreground">{item.repo}</span>
+          )}
         </div>
         <HoverCard openDelay={150}>
           <HoverCardTrigger asChild>
@@ -608,7 +625,7 @@ export default function ItemRow({
               {item.scoreBreakdown?.map((entry, i) => (
                 <div key={i} className="flex items-center justify-between gap-3">
                   <span className="text-muted-foreground">{entry.label}</span>
-                  <span className="font-medium tabular-nums">+{entry.points}</span>
+                  <span className="font-mono font-medium tabular-nums">+{entry.points}</span>
                 </div>
               ))}
             </div>

--- a/components/ItemSection.tsx
+++ b/components/ItemSection.tsx
@@ -43,7 +43,9 @@ export default function ItemSection({
       <AccordionTrigger>
         <span className="flex items-center gap-2">
           {title}
-          <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{items.length}</span>
+          <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs tabular-nums text-muted-foreground">
+            {items.length}
+          </span>
         </span>
       </AccordionTrigger>
       <AccordionContent>
@@ -68,7 +70,9 @@ export default function ItemSection({
             ))}
             {parkedItems && parkedItems.length > 0 && (
               <>
-                <p className="pb-1 pt-3 text-xs font-medium text-muted-foreground">Paused · {parkedItems.length}</p>
+                <p className="pb-1 pt-3 text-xs font-medium text-muted-foreground">
+                  Paused · <span className="font-mono tabular-nums">{parkedItems.length}</span>
+                </p>
                 {parkedItems.map((item) => (
                   <ItemRow
                     key={item.id}

--- a/components/NeedsAttentionBoard.tsx
+++ b/components/NeedsAttentionBoard.tsx
@@ -25,7 +25,9 @@ export default function NeedsAttentionBoard({ items, onStart, onComplete, onOpen
     <div>
       <h2 className="mb-3 flex items-center gap-2 text-base font-semibold">
         Needs attention
-        <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{items.length}</span>
+        <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs tabular-nums text-muted-foreground">
+          {items.length}
+        </span>
       </h2>
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         {SOURCE_GROUPS.map((group) => {
@@ -36,7 +38,7 @@ export default function NeedsAttentionBoard({ items, onStart, onComplete, onOpen
               <CardHeader className="flex flex-row items-center gap-2 space-y-0 p-4">
                 <Icon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                 <CardTitle className="text-sm">{group.label}</CardTitle>
-                <span className="ml-auto rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                <span className="ml-auto rounded-full bg-muted px-2 py-0.5 font-mono text-xs tabular-nums text-muted-foreground">
                   {groupItems.length}
                 </span>
               </CardHeader>

--- a/components/SettingsForm.tsx
+++ b/components/SettingsForm.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { SETTINGS_KEYS, DEFAULT_STALE_DAYS } from '@/lib/config';
+import { SETTINGS_KEYS, DEFAULT_STALE_DAYS, DEFAULT_DENSITY } from '@/lib/config';
 
 // react-hook-form treats dots in a field `name` as a nested-path separator
 // (e.g. "ado.org" is stored as { ado: { org } }), so SETTINGS_KEYS' dotted
@@ -25,6 +25,7 @@ const settingsSchema = z.object({
   staleDays: z.string().optional(),
   localReposBaseDir: z.string().optional(),
   repoPathOverrides: z.string().optional(),
+  density: z.enum(['comfortable', 'compact']).optional(),
 });
 
 type SettingsValues = z.infer<typeof settingsSchema>;
@@ -46,6 +47,7 @@ export default function SettingsForm({ initialSettings }: Props) {
       staleDays: initialSettings[SETTINGS_KEYS.staleDays] ?? String(DEFAULT_STALE_DAYS),
       localReposBaseDir: initialSettings[SETTINGS_KEYS.localReposBaseDir] ?? '',
       repoPathOverrides: initialSettings[SETTINGS_KEYS.repoPathOverrides] ?? '',
+      density: (initialSettings[SETTINGS_KEYS.density] as 'comfortable' | 'compact' | undefined) ?? DEFAULT_DENSITY,
     },
   });
 
@@ -61,6 +63,7 @@ export default function SettingsForm({ initialSettings }: Props) {
         [SETTINGS_KEYS.staleDays]: values.staleDays ?? String(DEFAULT_STALE_DAYS),
         [SETTINGS_KEYS.localReposBaseDir]: values.localReposBaseDir ?? '',
         [SETTINGS_KEYS.repoPathOverrides]: values.repoPathOverrides ?? '',
+        [SETTINGS_KEYS.density]: values.density ?? DEFAULT_DENSITY,
       }),
     });
     setSaved(true);
@@ -170,6 +173,25 @@ export default function SettingsForm({ initialSettings }: Props) {
                   <FormLabel>Repo path overrides (optional)</FormLabel>
                   <FormControl>
                     <Textarea placeholder="repo-name=/absolute/path (one per line)" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="density"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Row density</FormLabel>
+                  <FormControl>
+                    <select
+                      className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      {...field}
+                    >
+                      <option value="comfortable">Comfortable — 44px rows (default)</option>
+                      <option value="compact">Compact — 36px rows</option>
+                    </select>
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/components/ShutdownDialog.tsx
+++ b/components/ShutdownDialog.tsx
@@ -50,7 +50,10 @@ export default function ShutdownDialog({ open, onOpenChange, onCarried }: Props)
         {summary && (
           <div className="space-y-4">
             <p className="text-sm font-medium">
-              {doneCount} of {total} planned item{total === 1 ? '' : 's'} done
+              <span className="font-mono tabular-nums">
+                {doneCount} of {total}
+              </span>{' '}
+              planned item{total === 1 ? '' : 's'} done
             </p>
             <div>
               <h3 className="mb-1.5 text-sm font-semibold text-muted-foreground">Done</h3>
@@ -61,7 +64,7 @@ export default function ShutdownDialog({ open, onOpenChange, onCarried }: Props)
                   {summary.doneToday.map((item) => (
                     <li key={item.id} className="flex items-center justify-between gap-2 text-sm">
                       <span className="min-w-0 truncate">{item.title}</span>
-                      <span className="shrink-0 tabular-nums text-muted-foreground">
+                      <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
                         {item.hoursLoggedToday.toFixed(2)}h
                       </span>
                     </li>
@@ -90,7 +93,10 @@ export default function ShutdownDialog({ open, onOpenChange, onCarried }: Props)
         )}
         <DialogFooter className="sm:justify-between">
           <span className="text-sm text-muted-foreground">
-            Total hours logged today: {summary ? summary.hoursLoggedToday.toFixed(2) : '0.00'}h
+            Total hours logged today:{' '}
+            <span className="font-mono tabular-nums">
+              {summary ? summary.hoursLoggedToday.toFixed(2) : '0.00'}h
+            </span>
           </span>
           <Button type="button" onClick={() => onOpenChange(false)}>
             Close

--- a/components/SprintProgressHeader.tsx
+++ b/components/SprintProgressHeader.tsx
@@ -29,8 +29,18 @@ export default function SprintProgressHeader({ sprint, onRefresh, syncing, error
         <p className="min-w-0 truncate text-sm text-muted-foreground">
           <span className="font-medium text-foreground">{sprint.name ?? 'No active sprint'}</span>
           {' · '}
-          {sprint.completedCount}/{sprint.totalCount} done
-          {daysRemaining !== null ? ` · ${daysRemaining} days left` : ''}
+          <span className="font-mono tabular-nums">
+            {sprint.completedCount}/{sprint.totalCount}
+          </span>{' '}
+          done
+          {daysRemaining !== null ? (
+            <>
+              {' · '}
+              <span className="font-mono tabular-nums">{daysRemaining}</span> days left
+            </>
+          ) : (
+            ''
+          )}
           {' · '}
           {lastSyncedLabel}
         </p>

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -30,7 +30,9 @@ export default function TodaySection({
         <div className="mb-3 flex items-center justify-between gap-2">
           <h2 className="flex items-center gap-2 text-base font-semibold">
             Today
-            <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{items.length}</span>
+            <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs tabular-nums text-muted-foreground">
+              {items.length}
+            </span>
           </h2>
           <Button type="button" variant="ghost" size="sm" onClick={onReviewDay}>
             Review my day

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -10,9 +10,16 @@ export const SETTINGS_KEYS = {
   sprintEnd: 'sprint.end',
   localReposBaseDir: 'warp.localReposBaseDir',
   repoPathOverrides: 'warp.repoPathOverrides',
+  density: 'ui.density',
 } as const;
 
 export const DEFAULT_STALE_DAYS = 3;
 export const NEEDS_ATTENTION_THRESHOLD = 25;
+
+export type Density = 'comfortable' | 'compact';
+
+// Compact wins on a screenshot and loses on a Tuesday afternoon — a tool
+// opened dozens of times a day shouldn't ship at its tightest setting.
+export const DEFAULT_DENSITY: Density = 'comfortable';
 
 export const SPRINT_DONE_ADO_STATES = new Set(['done', 'ready for validation', 'ready for test']);

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -90,6 +90,9 @@ export type PriorityTier = 'low' | 'medium' | 'high' | 'critical';
 
 // Boundaries line up with NEEDS_ATTENTION_THRESHOLD (25) in lib/config.ts —
 // 'low' never appears in the Needs Attention UI, only medium/high/critical do.
+// Max achievable score is 105: approved_unmerged (45) + due-date urgency (25)
+// + unresolved conversations (20) + stale (15). The --urgency-* CSS tokens
+// (app/globals.css) are keyed to these same cuts.
 export function getPriorityTier(score: number): PriorityTier {
   if (score >= 60) return 'critical';
   if (score >= 40) return 'high';

--- a/lib/status-pill.test.ts
+++ b/lib/status-pill.test.ts
@@ -15,22 +15,23 @@ describe('getStatusPill', () => {
   });
 
   it.each([
-    ['draft', 'Draft', 'secondary'],
-    ['ready_for_review', 'Ready for review', 'default'],
+    ['draft', 'Draft', 'outline'],
+    ['ready_for_review', 'Ready for review', 'outline'],
     ['changes_requested', 'Changes requested', 'warning'],
-    ['approved', 'Approved', 'success'],
+    ['approved', 'Approved', 'outline'],
     ['merged', 'Merged', 'outline'],
   ] as const)('maps github_pr prStatus %s to label %s and variant %s', (prStatus, label, variant) => {
     expect(getStatusPill({ source: 'github_pr', prStatus, adoStatus: null })).toEqual({ label, variant });
   });
 
   it.each([
-    ['New', 'secondary'],
-    ['Active', 'default'],
-    ['Committed', 'default'],
+    ['New', 'outline'],
+    ['Active', 'secondary'],
+    ['Committed', 'secondary'],
     ['Resolved', 'success'],
     ['Closed', 'success'],
     ['Removed', 'destructive'],
+    ['Blocked', 'warning'],
   ] as const)('buckets ado_workitem state %s into variant %s', (adoStatus, variant) => {
     expect(getStatusPill({ source: 'ado_workitem', prStatus: null, adoStatus })).toEqual({ label: adoStatus, variant });
   });
@@ -38,7 +39,18 @@ describe('getStatusPill', () => {
   it('is case-insensitive when bucketing ado state', () => {
     expect(getStatusPill({ source: 'ado_workitem', prStatus: null, adoStatus: 'ACTIVE' })).toEqual({
       label: 'ACTIVE',
-      variant: 'default',
+      variant: 'secondary',
+    });
+  });
+
+  it('treats blocked as more urgent than an unrecognized neutral state', () => {
+    expect(getStatusPill({ source: 'ado_workitem', prStatus: null, adoStatus: 'Blocked' })).toEqual({
+      label: 'Blocked',
+      variant: 'warning',
+    });
+    expect(getStatusPill({ source: 'ado_workitem', prStatus: null, adoStatus: 'To Do' })).toEqual({
+      label: 'To Do',
+      variant: 'outline',
     });
   });
 

--- a/lib/status-pill.ts
+++ b/lib/status-pill.ts
@@ -7,20 +7,23 @@ export interface StatusPill {
   variant: BadgeVariant;
 }
 
+// Status is neutral outline by default; a filled variant is reserved for
+// states that demand action. Indigo ('default') never appears here — that
+// channel is interactive-only (see docs/wireframes/phase-0-foundation.html).
 const PR_STATUS_PILL: Record<PrStatus, StatusPill> = {
-  draft: { label: 'Draft', variant: 'secondary' },
-  ready_for_review: { label: 'Ready for review', variant: 'default' },
+  draft: { label: 'Draft', variant: 'outline' },
+  ready_for_review: { label: 'Ready for review', variant: 'outline' },
   changes_requested: { label: 'Changes requested', variant: 'warning' },
-  approved: { label: 'Approved', variant: 'success' },
+  approved: { label: 'Approved', variant: 'outline' },
   merged: { label: 'Merged', variant: 'outline' },
 };
 
 function adoStatusVariant(state: string): BadgeVariant {
   const s = state.toLowerCase();
-  if (/new|propos|to do|backlog/.test(s)) return 'secondary';
-  if (/active|committ|doing|progress|approved/.test(s)) return 'default';
+  if (/block/.test(s)) return 'warning';
   if (/resolv|done|closed|complet/.test(s)) return 'success';
   if (/remov/.test(s)) return 'destructive';
+  if (/active|committ|doing|progress/.test(s)) return 'secondary';
   return 'outline';
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -54,6 +54,16 @@ const config: Config = {
   				DEFAULT: 'hsl(var(--success))',
   				foreground: 'hsl(var(--success-foreground))'
   			},
+  			urgency: {
+  				critical: 'hsl(var(--urgency-critical))',
+  				high: 'hsl(var(--urgency-high))',
+  				medium: 'hsl(var(--urgency-medium))',
+  				low: 'hsl(var(--urgency-low))'
+  			},
+  			status: {
+  				blocked: 'hsl(var(--status-blocked))',
+  				neutral: 'hsl(var(--status-neutral))'
+  			},
   			border: 'hsl(var(--border))',
   			input: 'hsl(var(--input))',
   			ring: 'hsl(var(--ring))',


### PR DESCRIPTION
## Summary
One job per colour channel, replacing three overlapping systems:

- Indigo is interactive-only now — removed from `PR_STATUS_PILL`, `adoStatusVariant()`, and the priority dot
- `adoStatusVariant()` gains the missing `/block/` branch (was falling through to `outline`, the calmest treatment)
- New `--urgency-critical/high/medium/low` and `--status-blocked/neutral` tokens, derived from the existing `getPriorityTier()` cuts (60/40/25, 105 max — documented in `lib/scoring.ts`), exposed via `tailwind.config.ts`
- Density toggle (44px comfortable / 36px compact) added to Settings, persisted through the `settings` table, read server-side in the root layout
- Monospace face applied to scores, counts, and hours

Layout, counts, sections, and row grammar are untouched — this only changes the palette underneath them, per the wireframe in `docs/wireframes/phase-0-foundation.html`.

## Test plan
- [x] `npm test` — 216/216 passing (updated `lib/status-pill.test.ts` for the new variant mapping + added a Blocked coverage case)
- [x] `npm run build` — typechecks and builds clean
- [x] Screenshotted the live dashboard at both densities against real local data — confirmed Blocked now reads as the most urgent badge, Ready for review/Approved/Draft/To Do read as neutral outline, no indigo appears on any badge or priority dot, and compact density visibly shrinks row height
- [x] Grepped `components/` and `app/` for hard-coded hex — none found

Closes #20