### PR TITLE
Phase 2: speed and control (keyboard nav, local triage, query language, ⌘K)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npx tsc --noEmit
+      - name: Guard against non-GET calls in the read-only provider clients
+        run: |
+          # Both files are read-only in effect. Each has exactly one
+          # legitimate exception -- a read-only query submitted via POST,
+          # which HTTP requires for a request body (GitHub GraphQL, Azure
+          # DevOps WIQL). Anything else matching a non-GET method string
+          # fails the build.
+          for file in lib/github-client.ts lib/ado-client.ts; do
+            matches=$(grep -nE "method:\s*['\"](POST|PUT|PATCH|DELETE)['\"]" "$file" | grep -v "READ-ONLY-QUERY" || true)
+            if [ -n "$matches" ]; then
+              echo "::error file=$file::Non-GET method string found outside an explicitly marked read-only query:"
+              echo "$matches"
+              exit 1
+            fi
+          done

--- a/app/api/items/[id]/done/route.test.ts
+++ b/app/api/items/[id]/done/route.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem } from '@/lib/items-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM items;');
+});
+
+describe('POST /api/items/:id/done', () => {
+  it('marks an item locally done and reverses it', async () => {
+    const item = createAdhocItem(testDb, { title: 'Done me' });
+    const res = await POST(
+      new Request('http://localhost/api/items/1/done', { method: 'POST', body: JSON.stringify({ done: true }) }),
+      { params: { id: String(item.id) } }
+    );
+    expect((await res.json()).triageState).toBe('done');
+
+    const undone = await POST(
+      new Request('http://localhost/api/items/1/done', { method: 'POST', body: JSON.stringify({ done: false }) }),
+      { params: { id: String(item.id) } }
+    );
+    expect((await undone.json()).triageState).toBe('none');
+  });
+});

--- a/app/api/items/[id]/done/route.ts
+++ b/app/api/items/[id]/done/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { setTriageState, getItemById } from '@/lib/items-repo';
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  const { done } = await request.json();
+  setTriageState(db, id, done ? 'done' : 'none');
+  return NextResponse.json(getItemById(db, id));
+}

--- a/app/api/items/[id]/snooze/route.test.ts
+++ b/app/api/items/[id]/snooze/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem } from '@/lib/items-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST, DELETE } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM items;');
+});
+
+describe('POST /api/items/:id/snooze', () => {
+  it('snoozes an item until tomorrow', async () => {
+    const item = createAdhocItem(testDb, { title: 'Snooze me' });
+    const res = await POST(
+      new Request('http://localhost/api/items/1/snooze', { method: 'POST', body: JSON.stringify({ option: 'tomorrow' }) }),
+      { params: { id: String(item.id) } }
+    );
+    const body = await res.json();
+    expect(body.snoozedUntil).not.toBeNull();
+  });
+});
+
+describe('DELETE /api/items/:id/snooze', () => {
+  it('undoes a snooze', async () => {
+    const item = createAdhocItem(testDb, { title: 'Unsnooze me' });
+    await POST(
+      new Request('http://localhost/api/items/1/snooze', { method: 'POST', body: JSON.stringify({ option: 'tomorrow' }) }),
+      { params: { id: String(item.id) } }
+    );
+    const res = await DELETE(new Request('http://localhost/api/items/1/snooze', { method: 'DELETE' }), {
+      params: { id: String(item.id) },
+    });
+    const body = await res.json();
+    expect(body.snoozedUntil).toBeNull();
+  });
+});

--- a/app/api/items/[id]/snooze/route.ts
+++ b/app/api/items/[id]/snooze/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { setSnoozedUntil, getItemById } from '@/lib/items-repo';
+import { computeSnoozeUntil, type SnoozeOption } from '@/lib/snooze';
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  const { option } = (await request.json()) as { option: SnoozeOption };
+  setSnoozedUntil(db, id, computeSnoozeUntil(option, new Date()));
+  return NextResponse.json(getItemById(db, id));
+}
+
+export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  setSnoozedUntil(db, id, null);
+  return NextResponse.json(getItemById(db, id));
+}

--- a/app/api/items/[id]/star/route.test.ts
+++ b/app/api/items/[id]/star/route.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem } from '@/lib/items-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM items;');
+});
+
+describe('POST /api/items/:id/star', () => {
+  it('stars an item', async () => {
+    const item = createAdhocItem(testDb, { title: 'Star me' });
+    const res = await POST(
+      new Request('http://localhost/api/items/1/star', { method: 'POST', body: JSON.stringify({ starred: true }) }),
+      { params: { id: String(item.id) } }
+    );
+    const body = await res.json();
+    expect(body.starred).toBe(true);
+  });
+
+  it('unstars an item', async () => {
+    const item = createAdhocItem(testDb, { title: 'Unstar me' });
+    await POST(
+      new Request('http://localhost/api/items/1/star', { method: 'POST', body: JSON.stringify({ starred: true }) }),
+      { params: { id: String(item.id) } }
+    );
+    const res = await POST(
+      new Request('http://localhost/api/items/1/star', { method: 'POST', body: JSON.stringify({ starred: false }) }),
+      { params: { id: String(item.id) } }
+    );
+    const body = await res.json();
+    expect(body.starred).toBe(false);
+  });
+});

--- a/app/api/items/[id]/star/route.ts
+++ b/app/api/items/[id]/star/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { setStarred, getItemById } from '@/lib/items-repo';
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  const { starred } = await request.json();
+  setStarred(db, id, Boolean(starred));
+  return NextResponse.json(getItemById(db, id));
+}

--- a/app/api/saved-views/route.test.ts
+++ b/app/api/saved-views/route.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { GET, POST, DELETE, PUT } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec("DELETE FROM settings WHERE key = 'ui.savedViews';");
+});
+
+describe('/api/saved-views', () => {
+  it('starts empty, adds a view, lists it, deletes it', async () => {
+    expect(await (await GET()).json()).toEqual([]);
+
+    const afterAdd = await (
+      await POST(
+        new Request('http://localhost/api/saved-views', {
+          method: 'POST',
+          body: JSON.stringify({ label: 'Starred', query: 'is:starred', shortcut: '1' }),
+        })
+      )
+    ).json();
+    expect(afterAdd).toHaveLength(1);
+
+    const id = afterAdd[0].id;
+    const afterDelete = await (
+      await DELETE(new Request(`http://localhost/api/saved-views?id=${id}`, { method: 'DELETE' }))
+    ).json();
+    expect(afterDelete).toEqual([]);
+  });
+
+  it('reorders views', async () => {
+    const first = await (
+      await POST(
+        new Request('http://localhost/api/saved-views', {
+          method: 'POST',
+          body: JSON.stringify({ label: 'A', query: 'is:starred', shortcut: '1' }),
+        })
+      )
+    ).json();
+    const second = await (
+      await POST(
+        new Request('http://localhost/api/saved-views', {
+          method: 'POST',
+          body: JSON.stringify({ label: 'B', query: 'is:snoozed', shortcut: '2' }),
+        })
+      )
+    ).json();
+    const idA = first[0].id;
+    const idB = second[1].id;
+
+    const reordered = await (
+      await PUT(
+        new Request('http://localhost/api/saved-views', {
+          method: 'PUT',
+          body: JSON.stringify({ orderedIds: [idB, idA] }),
+        })
+      )
+    ).json();
+    expect(reordered.map((v: { id: string }) => v.id)).toEqual([idB, idA]);
+  });
+});

--- a/app/api/saved-views/route.ts
+++ b/app/api/saved-views/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { getSavedViews, addSavedView, removeSavedView, reorderSavedViews } from '@/lib/saved-views';
+
+export async function GET() {
+  return NextResponse.json(getSavedViews(db));
+}
+
+export async function POST(request: Request) {
+  const { label, query, shortcut } = await request.json();
+  return NextResponse.json(addSavedView(db, { label, query, shortcut: shortcut ?? null }));
+}
+
+export async function DELETE(request: Request) {
+  const id = new URL(request.url).searchParams.get('id') ?? '';
+  return NextResponse.json(removeSavedView(db, id));
+}
+
+export async function PUT(request: Request) {
+  const { orderedIds } = await request.json();
+  return NextResponse.json(reorderSavedViews(db, orderedIds));
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Marcellus } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import { SearchProvider } from '@/components/SearchProvider';
+import { CommandPaletteProvider } from '@/components/CommandPaletteProvider';
 import { DensityProvider } from '@/components/DensityProvider';
 import TopBar from '@/components/TopBar';
 import { db } from '@/lib/db-instance';
@@ -34,8 +35,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
           <DensityProvider density={density}>
             <SearchProvider>
-              <TopBar />
-              {children}
+              <CommandPaletteProvider>
+                <TopBar />
+                {children}
+              </CommandPaletteProvider>
             </SearchProvider>
           </DensityProvider>
           <Toaster />

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@/components/ui/command';
+import { parseQuery } from '@/lib/query';
+import type { ScoredItem } from '@/lib/dashboard';
+import type { SavedView } from '@/lib/saved-views';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  items: ScoredItem[];
+  savedViews: SavedView[];
+  search: string;
+  onSearchChange: (value: string) => void;
+  onSelectItem: (item: ScoredItem) => void;
+  onSelectQuery: (query: string) => void;
+  onGoToDashboard: () => void;
+  onGoToSettings: () => void;
+  onWrapUp: () => void;
+}
+
+const QUERY_PREFIXES = ['source:', 'group:', 'state:', 'score:', 'repo:', 'sprint:', 'is:', 'stale:', 'reason:'];
+
+export default function CommandPalette({
+  open,
+  onOpenChange,
+  items,
+  savedViews,
+  search,
+  onSearchChange,
+  onSelectItem,
+  onSelectQuery,
+  onGoToDashboard,
+  onGoToSettings,
+  onWrapUp,
+}: Props) {
+  const isQueryToken = QUERY_PREFIXES.some((p) => search.startsWith(p));
+  const matchingItems =
+    search && !isQueryToken ? items.filter((i) => i.title.toLowerCase().includes(search.toLowerCase())).slice(0, 8) : [];
+  const matchingViews = search
+    ? savedViews.filter((v) => v.label.toLowerCase().includes(search.toLowerCase()))
+    : savedViews;
+
+  function select(action: () => void) {
+    action();
+    onOpenChange(false);
+    onSearchChange('');
+  }
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput
+        placeholder="Search signals, jump to a view, or type a filter…"
+        value={search}
+        onValueChange={onSearchChange}
+      />
+      <CommandList>
+        <CommandEmpty>No results.</CommandEmpty>
+        {matchingItems.length > 0 && (
+          <CommandGroup heading="Signals">
+            {matchingItems.map((item) => (
+              <CommandItem key={item.id} value={`item-${item.id}`} onSelect={() => select(() => onSelectItem(item))}>
+                {item.title}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+        {isQueryToken && parseQuery(search).errors.length === 0 && (
+          <CommandGroup heading="Filter">
+            <CommandItem value={search} onSelect={() => select(() => onSelectQuery(search))}>
+              Apply <span className="font-mono">{search}</span>
+            </CommandItem>
+          </CommandGroup>
+        )}
+        {matchingViews.length > 0 && (
+          <CommandGroup heading="Saved views">
+            {matchingViews.map((view) => (
+              <CommandItem key={view.id} value={`view-${view.id}`} onSelect={() => select(() => onSelectQuery(view.query))}>
+                {view.label}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+        <CommandGroup heading="Go to">
+          <CommandItem value="go-dashboard" onSelect={() => select(onGoToDashboard)}>
+            Dashboard
+          </CommandItem>
+          <CommandItem value="go-settings" onSelect={() => select(onGoToSettings)}>
+            Settings
+          </CommandItem>
+        </CommandGroup>
+        <CommandGroup heading="Rituals">
+          <CommandItem value="wrap-up" onSelect={() => select(onWrapUp)}>
+            Wrap up the day
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+      <p className="border-t px-3 py-2 text-xs text-muted-foreground">
+        {items.length} signals searched locally, no network
+      </p>
+    </CommandDialog>
+  );
+}

--- a/components/CommandPaletteProvider.tsx
+++ b/components/CommandPaletteProvider.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+interface CommandPaletteContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | undefined>(undefined);
+
+// Lives at the layout level (mounted once, alongside SearchProvider) so
+// TopBar's ⌘K button -- rendered above every page, not just the dashboard --
+// can open the palette without Dashboard needing to hand it a prop.
+export function CommandPaletteProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return <CommandPaletteContext.Provider value={{ open, setOpen }}>{children}</CommandPaletteContext.Provider>;
+}
+
+export function useCommandPalette(): CommandPaletteContextValue {
+  const ctx = useContext(CommandPaletteContext);
+  if (!ctx) throw new Error('useCommandPalette must be used within a CommandPaletteProvider');
+  return ctx;
+}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { toast } from '@/components/ui/sonner';
 import { Accordion } from '@/components/ui/accordion';
 import { Card, CardContent } from '@/components/ui/card';
@@ -12,6 +13,8 @@ import SignalsBoard from './SignalsBoard';
 import QuickAddForm from './QuickAddForm';
 import TodaySection from './TodaySection';
 import ShutdownDialog from './ShutdownDialog';
+import GlobalKeymapProvider from './GlobalKeymapProvider';
+import KeymapHelpDialog from './KeymapHelpDialog';
 import {
   fetchDashboardData,
   triggerSync,
@@ -52,13 +55,17 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   const [reviewDayOpen, setReviewDayOpen] = useState(false);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [inProgressAccordion, setInProgressAccordion] = useState<string[]>(['in-progress']);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
 
   const autoSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
   const prevQueryRef = useRef('');
   const preSearchAccordionRef = useRef<{ inProgress: string[] } | null>(null);
+  const lastUndoRef = useRef<(() => void) | null>(null);
 
   const { query } = useSearch();
+  const router = useRouter();
 
   function scheduleAutoSync() {
     if (!isMountedRef.current) return;
@@ -150,15 +157,16 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   async function handleSnooze(id: number, option: SnoozeOption) {
     await snoozeItem(id, option);
     await refresh();
+    const undo = async () => {
+      await unsnoozeItem(id);
+      await refresh();
+    };
+    lastUndoRef.current = () => {
+      undo();
+    };
     toast(`Snoozed — ${SNOOZE_LABEL[option]}`, {
       duration: 10_000,
-      action: {
-        label: 'Undo',
-        onClick: async () => {
-          await unsnoozeItem(id);
-          await refresh();
-        },
-      },
+      action: { label: 'Undo', onClick: undo },
     });
   }
 
@@ -171,15 +179,16 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
     await setItemDone(id, done);
     await refresh();
     if (done) {
+      const undo = async () => {
+        await setItemDone(id, false);
+        await refresh();
+      };
+      lastUndoRef.current = () => {
+        undo();
+      };
       toast('Marked done locally.', {
         duration: 10_000,
-        action: {
-          label: 'Undo',
-          onClick: async () => {
-            await setItemDone(id, false);
-            await refresh();
-          },
-        },
+        action: { label: 'Undo', onClick: undo },
       });
     }
   }
@@ -239,6 +248,16 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
     [...data.today, ...data.signals, ...data.inProgress, ...data.parked].some((i) => matchesQuery(i.title, trimmedQuery));
 
   return (
+    <GlobalKeymapProvider
+      onOpenPalette={() => setPaletteOpen(true)}
+      onFocusQueryBar={() => document.getElementById('query-bar-input')?.focus()}
+      onUndo={() => lastUndoRef.current?.()}
+      onRefresh={handleRefresh}
+      onWrapUp={() => setReviewDayOpen(true)}
+      onOpenHelp={() => setHelpOpen(true)}
+      onGoToDashboard={() => router.push('/')}
+      onGoToSettings={() => router.push('/settings')}
+    >
     <main className="mx-auto max-w-6xl space-y-6 p-6">
       <SprintProgressHeader
         sprint={data.sprint}
@@ -291,6 +310,8 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
         currentSprintIteration={data.sprint.name}
       />
       <ShutdownDialog open={reviewDayOpen} onOpenChange={setReviewDayOpen} onCarried={refresh} />
+      <KeymapHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
     </main>
+    </GlobalKeymapProvider>
   );
 }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -26,7 +26,12 @@ import {
   openInClaude,
   pinToday,
   unpinToday,
+  starItem,
+  snoozeItem,
+  unsnoozeItem,
+  setItemDone,
 } from '@/lib/api-client';
+import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
 import type { ScoredItem } from '@/lib/dashboard';
 import type { SprintProgress } from '@/lib/sprint';
 
@@ -137,6 +142,48 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
     });
   }
 
+  async function handleStar(id: number, starred: boolean) {
+    await starItem(id, starred);
+    await refresh();
+  }
+
+  async function handleSnooze(id: number, option: SnoozeOption) {
+    await snoozeItem(id, option);
+    await refresh();
+    toast(`Snoozed — ${SNOOZE_LABEL[option]}`, {
+      duration: 10_000,
+      action: {
+        label: 'Undo',
+        onClick: async () => {
+          await unsnoozeItem(id);
+          await refresh();
+        },
+      },
+    });
+  }
+
+  async function handleUnsnooze(id: number) {
+    await unsnoozeItem(id);
+    await refresh();
+  }
+
+  async function handleDone(id: number, done: boolean) {
+    await setItemDone(id, done);
+    await refresh();
+    if (done) {
+      toast('Marked done locally.', {
+        duration: 10_000,
+        action: {
+          label: 'Undo',
+          onClick: async () => {
+            await setItemDone(id, false);
+            await refresh();
+          },
+        },
+      });
+    }
+  }
+
   async function handleQuickAdd(input: { title: string; category?: string; dueDate?: string }) {
     await createAdhocItemRequest(input);
     await refresh();
@@ -237,6 +284,11 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
         onOpenClaude={handleOpenClaude}
         onDelete={handleDelete}
         onPinToday={handlePinToday}
+        onStar={handleStar}
+        onSnooze={handleSnooze}
+        onUnsnooze={handleUnsnooze}
+        onDone={handleDone}
+        currentSprintIteration={data.sprint.name}
       />
       <ShutdownDialog open={reviewDayOpen} onOpenChange={setReviewDayOpen} onCarried={refresh} />
     </main>

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -6,6 +6,7 @@ import { toast } from '@/components/ui/sonner';
 import { Accordion } from '@/components/ui/accordion';
 import { Card, CardContent } from '@/components/ui/card';
 import { useSearch } from './SearchProvider';
+import { useCommandPalette } from './CommandPaletteProvider';
 import { matchesQuery } from '@/lib/search';
 import SprintProgressHeader from './SprintProgressHeader';
 import ItemSection from './ItemSection';
@@ -15,6 +16,7 @@ import TodaySection from './TodaySection';
 import ShutdownDialog from './ShutdownDialog';
 import GlobalKeymapProvider from './GlobalKeymapProvider';
 import KeymapHelpDialog from './KeymapHelpDialog';
+import CommandPalette from './CommandPalette';
 import {
   fetchDashboardData,
   triggerSync,
@@ -33,10 +35,12 @@ import {
   snoozeItem,
   unsnoozeItem,
   setItemDone,
+  fetchSavedViews,
 } from '@/lib/api-client';
 import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
 import type { ScoredItem } from '@/lib/dashboard';
 import type { SprintProgress } from '@/lib/sprint';
+import type { SavedView } from '@/lib/saved-views';
 
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -56,7 +60,8 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [inProgressAccordion, setInProgressAccordion] = useState<string[]>(['in-progress']);
   const [helpOpen, setHelpOpen] = useState(false);
-  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [signalsQuery, setSignalsQuery] = useState('');
+  const [savedViews, setSavedViews] = useState<SavedView[]>([]);
 
   const autoSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
@@ -64,8 +69,13 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   const preSearchAccordionRef = useRef<{ inProgress: string[] } | null>(null);
   const lastUndoRef = useRef<(() => void) | null>(null);
 
-  const { query } = useSearch();
+  const { query, setQuery } = useSearch();
+  const { open: paletteOpen, setOpen: setPaletteOpen } = useCommandPalette();
   const router = useRouter();
+
+  useEffect(() => {
+    fetchSavedViews().then(setSavedViews);
+  }, []);
 
   function scheduleAutoSync() {
     if (!isMountedRef.current) return;
@@ -308,9 +318,28 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
         onUnsnooze={handleUnsnooze}
         onDone={handleDone}
         currentSprintIteration={data.sprint.name}
+        queryText={signalsQuery}
+        onQueryTextChange={setSignalsQuery}
+        savedViews={savedViews}
+        onSavedViewsChange={setSavedViews}
       />
       <ShutdownDialog open={reviewDayOpen} onOpenChange={setReviewDayOpen} onCarried={refresh} />
       <KeymapHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
+      <CommandPalette
+        open={paletteOpen}
+        onOpenChange={setPaletteOpen}
+        items={data.signals}
+        savedViews={savedViews}
+        search={query}
+        onSearchChange={setQuery}
+        onSelectItem={(item) => {
+          if (item.url) window.open(item.url, '_blank', 'noopener,noreferrer');
+        }}
+        onSelectQuery={setSignalsQuery}
+        onGoToDashboard={() => router.push('/')}
+        onGoToSettings={() => router.push('/settings')}
+        onWrapUp={() => setReviewDayOpen(true)}
+      />
     </main>
     </GlobalKeymapProvider>
   );

--- a/components/GlobalKeymapProvider.tsx
+++ b/components/GlobalKeymapProvider.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect } from 'react';
+import { isTypingTarget } from '@/lib/keymap';
+
+interface Props {
+  children: React.ReactNode;
+  onOpenPalette: () => void;
+  onFocusQueryBar: () => void;
+  onUndo: () => void;
+  onRefresh: () => void;
+  onWrapUp: () => void;
+  onOpenHelp: () => void;
+  onGoToDashboard: () => void;
+  onGoToSettings: () => void;
+}
+
+export default function GlobalKeymapProvider({
+  children,
+  onOpenPalette,
+  onFocusQueryBar,
+  onUndo,
+  onRefresh,
+  onWrapUp,
+  onOpenHelp,
+  onGoToDashboard,
+  onGoToSettings,
+}: Props) {
+  useEffect(() => {
+    let pendingG = false;
+    let pendingGTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      const meta = e.metaKey || e.ctrlKey;
+
+      if (meta && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        onOpenPalette();
+        return;
+      }
+      if (meta && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        onUndo();
+        return;
+      }
+
+      if (isTypingTarget(e.target)) return;
+
+      if (pendingG) {
+        pendingG = false;
+        if (pendingGTimeout) clearTimeout(pendingGTimeout);
+        if (e.key.toLowerCase() === 'd') onGoToDashboard();
+        if (e.key.toLowerCase() === 's') onGoToSettings();
+        return;
+      }
+
+      switch (e.key.toLowerCase()) {
+        case '/':
+          e.preventDefault();
+          onFocusQueryBar();
+          return;
+        case '?':
+          onOpenHelp();
+          return;
+        case 'r':
+          onRefresh();
+          return;
+        case 'w':
+          onWrapUp();
+          return;
+        case 'g':
+          pendingG = true;
+          pendingGTimeout = setTimeout(() => {
+            pendingG = false;
+          }, 800);
+          return;
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (pendingGTimeout) clearTimeout(pendingGTimeout);
+    };
+  }, [onOpenPalette, onFocusQueryBar, onUndo, onRefresh, onWrapUp, onOpenHelp, onGoToDashboard, onGoToSettings]);
+
+  return <>{children}</>;
+}

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -12,6 +12,9 @@ import {
   Pause,
   MoreHorizontal,
   Pin,
+  Star,
+  Clock,
+  Check,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -44,6 +47,7 @@ import type { LinkedRef } from '@/lib/links-repo';
 import { useSearch } from '@/components/SearchProvider';
 import { useDensity } from '@/components/DensityProvider';
 import ScoreChip from './ScoreChip';
+import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
 
 // Row height is fixed per mode so content can never reflow it — comfortable
 // is 44px (11 * 4px grid), compact is 36px (9 * 4px grid).
@@ -116,6 +120,10 @@ interface Props {
   onUnpark?: (id: number) => void;
   onPinToday?: (id: number) => void;
   onUnpinToday?: (id: number) => void;
+  onStar?: (id: number, starred: boolean) => void;
+  onSnooze?: (id: number, option: SnoozeOption) => void;
+  onUnsnooze?: (id: number) => void;
+  onDone?: (id: number, done: boolean) => void;
 }
 
 function actionableLinks(links: LinkedRef[] | undefined, targetStatus: Status): LinkedRef[] {
@@ -182,6 +190,11 @@ function OverflowMenu({
   onDelete,
   onPinToday,
   onUnpinToday,
+  onStar,
+  onOpenSnooze,
+  onUnsnooze,
+  onDone,
+  snoozed,
 }: {
   item: Item;
   onRequeue?: (id: number) => void;
@@ -190,6 +203,11 @@ function OverflowMenu({
   onDelete?: () => void;
   onPinToday?: (id: number) => void;
   onUnpinToday?: (id: number) => void;
+  onStar?: (id: number, starred: boolean) => void;
+  onOpenSnooze?: () => void;
+  onUnsnooze?: (id: number) => void;
+  onDone?: (id: number, done: boolean) => void;
+  snoozed: boolean;
 }) {
   return (
     <DropdownMenu>
@@ -199,6 +217,34 @@ function OverflowMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {onStar && (
+          <DropdownMenuItem onSelect={() => onStar(item.id, !item.starred)}>
+            <Star aria-hidden="true" className={item.starred ? 'fill-current' : undefined} />
+            <span className="flex-1">{item.starred ? 'Unstar' : 'Star'}</span>
+            <kbd className="font-mono text-xs text-muted-foreground">s</kbd>
+          </DropdownMenuItem>
+        )}
+        {snoozed && onUnsnooze ? (
+          <DropdownMenuItem onSelect={() => onUnsnooze(item.id)}>
+            <Clock aria-hidden="true" />
+            <span className="flex-1">Unsnooze</span>
+          </DropdownMenuItem>
+        ) : (
+          onOpenSnooze && (
+            <DropdownMenuItem onSelect={onOpenSnooze}>
+              <Clock aria-hidden="true" />
+              <span className="flex-1">Snooze…</span>
+              <kbd className="font-mono text-xs text-muted-foreground">e</kbd>
+            </DropdownMenuItem>
+          )
+        )}
+        {onDone && (
+          <DropdownMenuItem onSelect={() => onDone(item.id, item.triageState !== 'done')}>
+            <Check aria-hidden="true" />
+            <span className="flex-1">{item.triageState === 'done' ? 'Mark not done' : 'Mark done'}</span>
+            <kbd className="font-mono text-xs text-muted-foreground">d</kbd>
+          </DropdownMenuItem>
+        )}
         {item.status === 'inbox' && onUnpinToday && (
           <DropdownMenuItem onSelect={() => onUnpinToday(item.id)}>
             <Pin aria-hidden="true" className="fill-current" /> Unpin from today
@@ -226,6 +272,11 @@ function OverflowMenu({
           <DropdownMenuItem onSelect={onDelete} className="text-destructive focus:text-destructive">
             <Trash2 aria-hidden="true" /> Delete
           </DropdownMenuItem>
+        )}
+        {(onStar || onOpenSnooze || onDone) && (
+          <div className="border-t px-2 py-1.5 text-xs text-muted-foreground">
+            Starred, snoozed and done are local. Ariadne never changes anything in GitHub or Azure DevOps.
+          </div>
         )}
       </DropdownMenuContent>
     </DropdownMenu>
@@ -262,12 +313,18 @@ export default function ItemRow({
   onUnpark,
   onPinToday,
   onUnpinToday,
+  onStar,
+  onSnooze,
+  onUnsnooze,
+  onDone,
 }: Props) {
   const Icon = SOURCE_ICON[item.source];
   const { query } = useSearch();
   const density = useDensity();
   const isMatch = matchesQuery(item.title, query);
   const [open, setOpen] = useState(false);
+  const [chipOpen, setChipOpen] = useState(false);
+  const [snoozeDialogOpen, setSnoozeDialogOpen] = useState(false);
   const [hours, setHours] = useState('');
   const [note, setNote] = useState('');
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -341,6 +398,35 @@ export default function ItemRow({
     if (!selectedRepoPath) return;
     onOpenClaude(item.id, selectedRepoPath);
     setClaudeDialogOpen(false);
+  }
+
+  // Row-scoped shortcuts (see lib/keymap.ts). Naturally inert while typing
+  // elsewhere: this handler only fires when the row div itself is the
+  // keydown target, and focus never lands here while an input has it.
+  function handleRowKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.target !== e.currentTarget) return;
+    switch (e.key.toLowerCase()) {
+      case 'enter':
+      case 'o':
+        if (item.url) window.open(item.url, '_blank', 'noopener,noreferrer');
+        return;
+      case 'x':
+        setChipOpen(true);
+        return;
+      case 's':
+        onStar?.(item.id, !item.starred);
+        return;
+      case 'e':
+        setSnoozeDialogOpen(true);
+        return;
+      case 'd':
+        onDone?.(item.id, item.triageState !== 'done');
+        return;
+      case 't':
+        if (item.todayDate) onUnpinToday?.(item.id);
+        else onPinToday?.(item.id);
+        return;
+    }
   }
 
   const completeDialog = (
@@ -485,6 +571,35 @@ export default function ItemRow({
     </Dialog>
   );
 
+  const snoozeDialog = (
+    <Dialog open={snoozeDialogOpen} onOpenChange={setSnoozeDialogOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Snooze</DialogTitle>
+          <DialogDescription>
+            Starred, snoozed and done are local. Ariadne never changes anything in GitHub or Azure DevOps.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-2 py-2">
+          {(Object.keys(SNOOZE_LABEL) as SnoozeOption[]).map((option) => (
+            <Button
+              key={option}
+              type="button"
+              variant="outline"
+              className="justify-start"
+              onClick={() => {
+                onSnooze?.(item.id, option);
+                setSnoozeDialogOpen(false);
+              }}
+            >
+              {SNOOZE_LABEL[option]}
+            </Button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+
   const completeCascadeDialog = (
     <Dialog
       open={completeCascadeOpen}
@@ -549,8 +664,12 @@ export default function ItemRow({
 
   return (
     <div
+      tabIndex={0}
+      data-row-id={item.id}
+      onKeyDown={handleRowKeyDown}
       className={cn(
-        'flex items-center justify-between gap-3 overflow-hidden border-b last:border-0',
+        'group relative flex items-center justify-between gap-3 overflow-hidden border-b last:border-0',
+        'border-l-2 border-l-transparent focus:border-l-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
         ROW_HEIGHT_CLASS[density],
         'motion-safe:transition-opacity motion-safe:duration-200 motion-safe:ease-out',
         !isMatch && 'opacity-40'
@@ -562,6 +681,8 @@ export default function ItemRow({
           scoreBreakdown={item.scoreBreakdown ?? []}
           notFired={item.notFired ?? []}
           keptVisible={keptVisible}
+          open={chipOpen}
+          onOpenChange={setChipOpen}
         >
           <HoverExtras item={item} keptVisible={keptVisible} />
         </ScoreChip>
@@ -589,14 +710,16 @@ export default function ItemRow({
               </Badge>
             )}
           </div>
-          {item.repo && density === 'comfortable' && (
-            <span className="block truncate text-xs text-muted-foreground" title={item.repo}>
+          {(item.repo || item.wokeEarly) && density === 'comfortable' && (
+            <span className="block truncate text-xs text-muted-foreground" title={item.repo ?? undefined}>
               {item.repo}
+              {item.repo && item.wokeEarly && ' · '}
+              {item.wokeEarly && 'woke early'}
             </span>
           )}
         </div>
       </div>
-      <div className="flex shrink-0 items-center gap-1">
+      <div className="flex shrink-0 items-center gap-1 opacity-60 motion-safe:transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
         {item.status === 'inbox' && onStart && (
           <Button type="button" variant="outline" size="sm" onClick={handleStartClick}>
             Start
@@ -615,6 +738,11 @@ export default function ItemRow({
           onDelete={canDelete ? () => setDeleteOpen(true) : undefined}
           onPinToday={onPinToday}
           onUnpinToday={onUnpinToday}
+          onStar={onStar}
+          onOpenSnooze={onSnooze ? () => setSnoozeDialogOpen(true) : undefined}
+          onUnsnooze={onUnsnooze}
+          onDone={onDone}
+          snoozed={Boolean(item.snoozedUntil)}
         />
       </div>
       {completeDialog}
@@ -622,6 +750,7 @@ export default function ItemRow({
       {claudeDialog}
       {startCascadeDialog}
       {completeCascadeDialog}
+      {snoozeDialog}
     </div>
   );
 }

--- a/components/KeymapHelpDialog.tsx
+++ b/components/KeymapHelpDialog.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { KEYMAP } from '@/lib/keymap';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function KeymapHelpDialog({ open, onOpenChange }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-1 text-sm">
+          {KEYMAP.map((binding) => (
+            <div key={binding.keys} className="flex items-center justify-between gap-3">
+              <span>{binding.description}</span>
+              <kbd className="font-mono text-xs text-muted-foreground">{binding.keys}</kbd>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/QueryBar.tsx
+++ b/components/QueryBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId, useState } from 'react';
+import { useId } from 'react';
 import { Search, Star, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -36,22 +36,16 @@ export default function QueryBar({
   onSelectSavedView,
   onDeleteSavedView,
 }: Props) {
-  const [draft, setDraft] = useState(value);
   const errorId = useId();
   const activeSourceToken = SOURCE_TOKENS.find((t) => t.token && value.includes(t.token))?.source ?? 'all';
 
-  function commit(next: string) {
-    setDraft(next);
-    onChange(next);
-  }
-
   function toggleSourceToken(token: string | null) {
-    const withoutSourceTokens = draft
+    const withoutSourceTokens = value
       .split(/\s+/)
       .filter((w) => !w.startsWith('source:'))
       .join(' ')
       .trim();
-    commit(token ? [withoutSourceTokens, token].filter(Boolean).join(' ') : withoutSourceTokens);
+    onChange(token ? [withoutSourceTokens, token].filter(Boolean).join(' ') : withoutSourceTokens);
   }
 
   return (
@@ -60,8 +54,8 @@ export default function QueryBar({
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           id="query-bar-input"
-          value={draft}
-          onChange={(e) => commit(e.target.value)}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
           placeholder="source:ado score:>25 -is:snoozed"
           aria-label="Filter signals"
           aria-invalid={errors.length > 0}
@@ -72,7 +66,7 @@ export default function QueryBar({
       {errors.length > 0 && (
         <p id={errorId} role="status" aria-live="polite" className="text-sm text-destructive">
           {errors[0]} — showing the last valid result.{' '}
-          <button type="button" className="underline" onClick={() => commit('')}>
+          <button type="button" className="underline" onClick={() => onChange('')}>
             Clear the query
           </button>
         </p>
@@ -123,8 +117,8 @@ export default function QueryBar({
             </span>
           </Button>
         ))}
-        {draft.trim() && parseQuery(draft).errors.length === 0 && (
-          <Button type="button" variant="ghost" size="sm" onClick={() => onSaveCurrentView(draft.trim())}>
+        {value.trim() && parseQuery(value).errors.length === 0 && (
+          <Button type="button" variant="ghost" size="sm" onClick={() => onSaveCurrentView(value.trim())}>
             Save this view
           </Button>
         )}

--- a/components/QueryBar.tsx
+++ b/components/QueryBar.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useId, useState } from 'react';
+import { Search, Star, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { parseQuery } from '@/lib/query';
+import type { SavedView } from '@/lib/saved-views';
+import type { Source } from '@/lib/types';
+
+const SOURCE_TOKENS: { source: Source | 'all'; label: string; token: string | null }[] = [
+  { source: 'all', label: 'All', token: null },
+  { source: 'github_pr', label: 'GitHub', token: 'source:github' },
+  { source: 'ado_workitem', label: 'Azure DevOps', token: 'source:ado' },
+  { source: 'adhoc', label: 'Ad-hoc', token: 'source:adhoc' },
+];
+
+interface Props {
+  value: string;
+  onChange: (raw: string) => void;
+  errors: string[];
+  savedViews: SavedView[];
+  sourceCounts: Record<Source | 'all', number>;
+  onSaveCurrentView: (label: string) => void;
+  onSelectSavedView: (query: string) => void;
+  onDeleteSavedView: (id: string) => void;
+}
+
+export default function QueryBar({
+  value,
+  onChange,
+  errors,
+  savedViews,
+  sourceCounts,
+  onSaveCurrentView,
+  onSelectSavedView,
+  onDeleteSavedView,
+}: Props) {
+  const [draft, setDraft] = useState(value);
+  const errorId = useId();
+  const activeSourceToken = SOURCE_TOKENS.find((t) => t.token && value.includes(t.token))?.source ?? 'all';
+
+  function commit(next: string) {
+    setDraft(next);
+    onChange(next);
+  }
+
+  function toggleSourceToken(token: string | null) {
+    const withoutSourceTokens = draft
+      .split(/\s+/)
+      .filter((w) => !w.startsWith('source:'))
+      .join(' ')
+      .trim();
+    commit(token ? [withoutSourceTokens, token].filter(Boolean).join(' ') : withoutSourceTokens);
+  }
+
+  return (
+    <div className="mb-4 space-y-2">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          id="query-bar-input"
+          value={draft}
+          onChange={(e) => commit(e.target.value)}
+          placeholder="source:ado score:>25 -is:snoozed"
+          aria-label="Filter signals"
+          aria-invalid={errors.length > 0}
+          aria-describedby={errors.length > 0 ? errorId : undefined}
+          className="pl-9 font-mono text-sm"
+        />
+      </div>
+      {errors.length > 0 && (
+        <p id={errorId} role="status" aria-live="polite" className="text-sm text-destructive">
+          {errors[0]} — showing the last valid result.{' '}
+          <button type="button" className="underline" onClick={() => commit('')}>
+            Clear the query
+          </button>
+        </p>
+      )}
+      <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by source and saved view">
+        {SOURCE_TOKENS.map(({ source, label, token }) => (
+          <Button
+            key={source}
+            type="button"
+            variant={activeSourceToken === source ? 'secondary' : 'outline'}
+            size="sm"
+            aria-pressed={activeSourceToken === source}
+            onClick={() => toggleSourceToken(token)}
+          >
+            {label} <span className="font-mono tabular-nums">{sourceCounts[source]}</span>
+          </Button>
+        ))}
+        {savedViews.length > 0 && <div className="mx-1 h-4 w-px bg-border" aria-hidden="true" />}
+        {savedViews.map((view) => (
+          <Button
+            key={view.id}
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onSelectSavedView(view.query)}
+            title={view.query}
+          >
+            <Star className="h-3 w-3" aria-hidden="true" />
+            {view.label}
+            {view.shortcut && <kbd className="ml-1 font-mono text-[10px] text-muted-foreground">{view.shortcut}</kbd>}
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label={`Delete saved view ${view.label}`}
+              className="ml-1 rounded hover:bg-muted"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteSavedView(view.id);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.stopPropagation();
+                  onDeleteSavedView(view.id);
+                }
+              }}
+            >
+              <X className="h-3 w-3" aria-hidden="true" />
+            </span>
+          </Button>
+        ))}
+        {draft.trim() && parseQuery(draft).errors.length === 0 && (
+          <Button type="button" variant="ghost" size="sm" onClick={() => onSaveCurrentView(draft.trim())}>
+            Save this view
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/ScoreChip.tsx
+++ b/components/ScoreChip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId, useState } from 'react';
+import { useId } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { getPriorityTier, MAX_SCORE, type PriorityTier, type ScoreBreakdownEntry } from '@/lib/scoring';
@@ -29,16 +29,17 @@ interface Props {
   scoreBreakdown: ScoreBreakdownEntry[];
   notFired: string[];
   keptVisible: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   children?: React.ReactNode;
 }
 
-export default function ScoreChip({ score, scoreBreakdown, notFired, keptVisible, children }: Props) {
-  const [open, setOpen] = useState(false);
+export default function ScoreChip({ score, scoreBreakdown, notFired, keptVisible, open, onOpenChange, children }: Props) {
   const tier = getPriorityTier(score);
   const titleId = useId();
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -51,7 +52,7 @@ export default function ScoreChip({ score, scoreBreakdown, notFired, keptVisible
           onKeyDown={(e) => {
             if (e.key.toLowerCase() === 'x') {
               e.preventDefault();
-              setOpen(true);
+              onOpenChange(true);
             }
           }}
         >

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -10,7 +10,7 @@ import { groupOf, isKeptVisible, GROUP_ORDER, GROUP_LABEL, type ObligationGroup 
 import { parseQuery, applyQuery } from '@/lib/query';
 import { isSnoozed, type SnoozeOption } from '@/lib/snooze';
 import { isTypingTarget } from '@/lib/keymap';
-import { fetchSavedViews, createSavedView, deleteSavedView } from '@/lib/api-client';
+import { createSavedView, deleteSavedView } from '@/lib/api-client';
 import type { SavedView } from '@/lib/saved-views';
 import type { Source } from '@/lib/types';
 import type { ScoredItem } from '@/lib/dashboard';
@@ -69,6 +69,10 @@ interface Props {
   onUnsnooze?: (id: number) => void;
   onDone?: (id: number, done: boolean) => void;
   currentSprintIteration: string | null;
+  queryText: string;
+  onQueryTextChange: (raw: string) => void;
+  savedViews: SavedView[];
+  onSavedViewsChange: (views: SavedView[]) => void;
 }
 
 export default function SignalsBoard({
@@ -83,6 +87,10 @@ export default function SignalsBoard({
   onUnsnooze,
   onDone,
   currentSprintIteration,
+  queryText,
+  onQueryTextChange,
+  savedViews,
+  onSavedViewsChange,
 }: Props) {
   const [expanded, setExpanded] = useState<Record<ObligationGroup, boolean>>({
     waiting_on_you: false,
@@ -90,13 +98,7 @@ export default function SignalsBoard({
     moving_without_you: false,
     lower_priority: false,
   });
-  const [queryText, setQueryText] = useState('');
   const [lastValidParsed, setLastValidParsed] = useState(parseQuery(''));
-  const [savedViews, setSavedViews] = useState<SavedView[]>([]);
-
-  useEffect(() => {
-    fetchSavedViews().then(setSavedViews);
-  }, []);
 
   const parsed = parseQuery(queryText);
   const activeParsed = parsed.errors.length === 0 ? parsed : lastValidParsed;
@@ -129,11 +131,11 @@ export default function SignalsBoard({
 
   async function handleSaveCurrentView(label: string) {
     const updated = await createSavedView({ label, query: queryText, shortcut: null });
-    setSavedViews(updated);
+    onSavedViewsChange(updated);
   }
 
   async function handleDeleteSavedView(id: string) {
-    setSavedViews(await deleteSavedView(id));
+    onSavedViewsChange(await deleteSavedView(id));
   }
 
   const grouped = useMemo(() => {
@@ -176,12 +178,12 @@ export default function SignalsBoard({
       </div>
       <QueryBar
         value={queryText}
-        onChange={setQueryText}
+        onChange={onQueryTextChange}
         errors={parsed.errors}
         savedViews={savedViews}
         sourceCounts={sourceCounts}
         onSaveCurrentView={handleSaveCurrentView}
-        onSelectSavedView={setQueryText}
+        onSelectSavedView={onQueryTextChange}
         onDeleteSavedView={handleDeleteSavedView}
       />
       {withoutHiddenTriage.length === 0 && (

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -9,6 +9,7 @@ import QueryBar from './QueryBar';
 import { groupOf, isKeptVisible, GROUP_ORDER, GROUP_LABEL, type ObligationGroup } from '@/lib/grouping';
 import { parseQuery, applyQuery } from '@/lib/query';
 import { isSnoozed, type SnoozeOption } from '@/lib/snooze';
+import { isTypingTarget } from '@/lib/keymap';
 import { fetchSavedViews, createSavedView, deleteSavedView } from '@/lib/api-client';
 import type { SavedView } from '@/lib/saved-views';
 import type { Source } from '@/lib/types';
@@ -150,7 +151,18 @@ export default function SignalsBoard({
   }, [filtered]);
 
   return (
-    <div aria-labelledby="signals-heading">
+    <div
+      aria-labelledby="signals-heading"
+      onKeyDown={(e) => {
+        if (isTypingTarget(document.activeElement)) return;
+        if (e.key !== 'j' && e.key !== 'k') return;
+        e.preventDefault();
+        const rows = Array.from(e.currentTarget.querySelectorAll<HTMLElement>('[data-row-id]'));
+        const currentIndex = rows.findIndex((el) => el === document.activeElement);
+        const nextIndex = e.key === 'j' ? Math.min(rows.length - 1, currentIndex + 1) : Math.max(0, currentIndex - 1);
+        rows[nextIndex === -1 ? 0 : nextIndex]?.focus();
+      }}
+    >
       <div className="mb-3 flex items-center justify-between gap-2">
         <h2 id="signals-heading" className="flex items-center gap-2 text-base font-semibold">
           Signals

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -1,24 +1,20 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { HelpCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import ItemRow, { SOURCE_ICON } from './ItemRow';
+import ItemRow from './ItemRow';
+import QueryBar from './QueryBar';
 import { groupOf, isKeptVisible, GROUP_ORDER, GROUP_LABEL, type ObligationGroup } from '@/lib/grouping';
+import { parseQuery, applyQuery } from '@/lib/query';
+import { isSnoozed, type SnoozeOption } from '@/lib/snooze';
+import { fetchSavedViews, createSavedView, deleteSavedView } from '@/lib/api-client';
+import type { SavedView } from '@/lib/saved-views';
 import type { Source } from '@/lib/types';
 import type { ScoredItem } from '@/lib/dashboard';
 
 const VISIBLE_PER_GROUP = 5;
-
-type SourceFilter = Source | 'all';
-
-const SOURCE_FILTERS: { source: SourceFilter; label: string; Icon?: typeof SOURCE_ICON.github_pr }[] = [
-  { source: 'all', label: 'All' },
-  { source: 'github_pr', label: 'GitHub', Icon: SOURCE_ICON.github_pr },
-  { source: 'ado_workitem', label: 'Azure DevOps', Icon: SOURCE_ICON.ado_workitem },
-  { source: 'adhoc', label: 'Ad-hoc', Icon: SOURCE_ICON.adhoc },
-];
 
 const STATUS_KEY: { label: string; description: string }[] = [
   { label: 'Blocked', description: 'Needs a nudge, not work.' },
@@ -67,30 +63,77 @@ interface Props {
   onOpenClaude: (id: number, workingDir?: string) => void;
   onDelete: (id: number) => void;
   onPinToday?: (id: number) => void;
+  onStar?: (id: number, starred: boolean) => void;
+  onSnooze?: (id: number, option: SnoozeOption) => void;
+  onUnsnooze?: (id: number) => void;
+  onDone?: (id: number, done: boolean) => void;
+  currentSprintIteration: string | null;
 }
 
-export default function SignalsBoard({ items, onStart, onComplete, onOpenClaude, onDelete, onPinToday }: Props) {
-  const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all');
+export default function SignalsBoard({
+  items,
+  onStart,
+  onComplete,
+  onOpenClaude,
+  onDelete,
+  onPinToday,
+  onStar,
+  onSnooze,
+  onUnsnooze,
+  onDone,
+  currentSprintIteration,
+}: Props) {
   const [expanded, setExpanded] = useState<Record<ObligationGroup, boolean>>({
     waiting_on_you: false,
     blocked: false,
     moving_without_you: false,
     lower_priority: false,
   });
+  const [queryText, setQueryText] = useState('');
+  const [lastValidParsed, setLastValidParsed] = useState(parseQuery(''));
+  const [savedViews, setSavedViews] = useState<SavedView[]>([]);
+
+  useEffect(() => {
+    fetchSavedViews().then(setSavedViews);
+  }, []);
+
+  const parsed = parseQuery(queryText);
+  const activeParsed = parsed.errors.length === 0 ? parsed : lastValidParsed;
+
+  useEffect(() => {
+    if (parsed.errors.length === 0) setLastValidParsed(parsed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryText]);
+
+  const context = { now: new Date(), currentSprintIteration };
+  const withoutHiddenTriage = items.filter(
+    (item) =>
+      (activeParsed.filters.some((f) => f.prefix === 'is' && f.values.includes('snoozed')) ||
+        !isSnoozed(item.snoozedUntil, context.now)) &&
+      (activeParsed.filters.some((f) => f.prefix === 'is' && f.values.includes('done')) || item.triageState !== 'done')
+  );
+  const filtered = applyQuery(withoutHiddenTriage, activeParsed, context);
 
   const needsYouCount = useMemo(
-    () => items.filter((item) => groupOf(item) === 'blocked' || groupOf(item) === 'waiting_on_you').length,
-    [items]
+    () => withoutHiddenTriage.filter((item) => groupOf(item) === 'blocked' || groupOf(item) === 'waiting_on_you').length,
+    [withoutHiddenTriage]
   );
 
-  const sourceCounts: Record<SourceFilter, number> = {
-    all: items.length,
-    github_pr: items.filter((i) => i.source === 'github_pr').length,
-    ado_workitem: items.filter((i) => i.source === 'ado_workitem').length,
-    adhoc: items.filter((i) => i.source === 'adhoc').length,
+  const sourceCounts: Record<Source | 'all', number> = {
+    all: withoutHiddenTriage.length,
+    github_pr: withoutHiddenTriage.filter((i) => i.source === 'github_pr').length,
+    ado_workitem: withoutHiddenTriage.filter((i) => i.source === 'ado_workitem').length,
+    adhoc: withoutHiddenTriage.filter((i) => i.source === 'adhoc').length,
   };
 
-  const filtered = sourceFilter === 'all' ? items : items.filter((item) => item.source === sourceFilter);
+  async function handleSaveCurrentView(label: string) {
+    const updated = await createSavedView({ label, query: queryText, shortcut: null });
+    setSavedViews(updated);
+  }
+
+  async function handleDeleteSavedView(id: string) {
+    setSavedViews(await deleteSavedView(id));
+  }
 
   const grouped = useMemo(() => {
     const buckets: Record<ObligationGroup, ScoredItem[]> = {
@@ -100,6 +143,9 @@ export default function SignalsBoard({ items, onStart, onComplete, onOpenClaude,
       lower_priority: [],
     };
     for (const item of filtered) buckets[groupOf(item)].push(item);
+    for (const key of Object.keys(buckets) as ObligationGroup[]) {
+      buckets[key].sort((a, b) => Number(b.starred) - Number(a.starred));
+    }
     return buckets;
   }, [filtered]);
 
@@ -109,29 +155,26 @@ export default function SignalsBoard({ items, onStart, onComplete, onOpenClaude,
         <h2 id="signals-heading" className="flex items-center gap-2 text-base font-semibold">
           Signals
           <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs tabular-nums text-muted-foreground">
-            {items.length}
+            {withoutHiddenTriage.length}
           </span>
         </h2>
         <p className="text-sm text-muted-foreground">
           <span className="font-mono tabular-nums">{needsYouCount}</span> need something from you
         </p>
       </div>
-      <div className="mb-4 flex flex-wrap gap-1.5" role="group" aria-label="Filter by source">
-        {SOURCE_FILTERS.map(({ source, label, Icon }) => (
-          <Button
-            key={source}
-            type="button"
-            variant={sourceFilter === source ? 'secondary' : 'outline'}
-            size="sm"
-            aria-pressed={sourceFilter === source}
-            onClick={() => setSourceFilter(source)}
-          >
-            {Icon && <Icon className="h-3.5 w-3.5" aria-hidden="true" />}
-            {label} <span className="font-mono tabular-nums">{sourceCounts[source]}</span>
-          </Button>
-        ))}
-      </div>
-      {items.length === 0 && <p className="text-sm text-muted-foreground">Nothing needs your attention right now.</p>}
+      <QueryBar
+        value={queryText}
+        onChange={setQueryText}
+        errors={parsed.errors}
+        savedViews={savedViews}
+        sourceCounts={sourceCounts}
+        onSaveCurrentView={handleSaveCurrentView}
+        onSelectSavedView={setQueryText}
+        onDeleteSavedView={handleDeleteSavedView}
+      />
+      {withoutHiddenTriage.length === 0 && (
+        <p className="text-sm text-muted-foreground">Nothing needs your attention right now.</p>
+      )}
       {GROUP_ORDER.map((group) => {
         const groupItems = grouped[group];
         if (groupItems.length === 0) return null;
@@ -160,6 +203,10 @@ export default function SignalsBoard({ items, onStart, onComplete, onOpenClaude,
                   onOpenClaude={onOpenClaude}
                   onDelete={onDelete}
                   onPinToday={onPinToday}
+                  onStar={onStar}
+                  onSnooze={onSnooze}
+                  onUnsnooze={onUnsnooze}
+                  onDone={onDone}
                 />
               ))}
             </div>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -4,12 +4,11 @@ import Link from 'next/link';
 import { BarChart3, Search, Settings } from 'lucide-react';
 import { AriadneMark } from '@/components/icons/ariadne-mark';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { ThemeToggle } from '@/components/theme-toggle';
-import { useSearch } from '@/components/SearchProvider';
+import { useCommandPalette } from '@/components/CommandPaletteProvider';
 
 export default function TopBar() {
-  const { query, setQuery } = useSearch();
+  const { setOpen } = useCommandPalette();
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
@@ -22,17 +21,15 @@ export default function TopBar() {
           <span className="font-display text-xl leading-none tracking-wide text-foreground">Ariadne</span>
         </Link>
 
-        <div className="relative justify-self-stretch">
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="search"
-            placeholder="Search work items, PRs, people…"
-            aria-label="Search"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className="pl-9 focus-visible:ring-[hsl(var(--brand-gold))]"
-          />
-        </div>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex items-center gap-2 justify-self-stretch rounded-md border border-input px-3 py-1.5 text-sm text-muted-foreground hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--brand-gold))] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
+          <Search className="h-4 w-4" aria-hidden="true" />
+          Search or jump to
+          <kbd className="ml-auto font-mono text-xs">⌘K</kbd>
+        </button>
 
         <div className="flex items-center justify-end gap-1">
           <Button type="button" variant="ghost" size="icon" asChild aria-label="Report">

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { cn } from "@/lib/utils"
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+Command.displayName = CommandPrimitive.displayName
+
+interface CommandDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: React.ReactNode
+}
+
+function CommandDialog({ open, onOpenChange, children }: CommandDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  </div>
+))
+CommandInput.displayName = CommandPrimitive.Input.displayName
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List ref={ref} className={cn("max-h-[400px] overflow-y-auto overflow-x-hidden", className)} {...props} />
+))
+CommandList.displayName = CommandPrimitive.List.displayName
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />)
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+CommandGroup.displayName = CommandPrimitive.Group.displayName
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  />
+))
+CommandItem.displayName = CommandPrimitive.Item.displayName
+
+export { Command, CommandDialog, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem }

--- a/lib/ado-client.test.ts
+++ b/lib/ado-client.test.ts
@@ -175,3 +175,47 @@ describe('fetchAdoData', () => {
     expect(result.items[0].adoStatus).toBe('Ready for Test');
   });
 });
+
+describe('read-only guard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('never issues a non-GET request, except the read-only WIQL query endpoint', async () => {
+    const calls: { url: string; method: string }[] = [];
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method ?? 'GET' });
+      if (url.includes('teamsettings/iterations')) {
+        return jsonResponse({ value: [{ name: 'Sprint 42', attributes: { startDate: '2026-06-29', finishDate: '2026-07-12' } }] });
+      }
+      if (url.includes('/wiql')) return jsonResponse({ workItems: [{ id: 101 }] });
+      if (url.includes('/workitems?ids=101')) {
+        return jsonResponse({
+          value: [
+            {
+              id: 101,
+              fields: {
+                'System.Title': 'Fix login bug',
+                'Microsoft.VSTS.Scheduling.DueDate': null,
+                'System.IterationPath': 'Project\\Sprint 42',
+                'System.ChangedDate': '2026-07-01T00:00:00Z',
+              },
+              _links: { html: { href: 'https://dev.azure.com/org/project/_workitems/edit/101' } },
+            },
+          ],
+        });
+      }
+      if (url.includes('/comments')) return jsonResponse({ comments: [] });
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    await fetchAdoData({ pat: 'x', org: 'org', project: 'project' });
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const isReadOnlyWiqlQuery = call.method === 'POST' && call.url.includes('wiql');
+      expect(call.method === 'GET' || isReadOnlyWiqlQuery).toBe(true);
+    }
+  });
+});

--- a/lib/ado-client.ts
+++ b/lib/ado-client.ts
@@ -53,7 +53,7 @@ async function fetchAssignedWorkItemIds(config: AdoConfig): Promise<number[]> {
   const result = await adoFetch(
     config,
     `https://dev.azure.com/${config.org}/${config.project}/${team}/_apis/wit/wiql?api-version=7.1`,
-    { method: 'POST', body: JSON.stringify(wiql) }
+    { method: 'POST', body: JSON.stringify(wiql) } // READ-ONLY-QUERY: Azure DevOps requires POST to submit a WIQL query body; this never mutates
   );
   return (result.workItems ?? []).map((wi: any) => wi.id);
 }

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -2,6 +2,7 @@ import type { TimeReport } from '@/lib/report';
 import type { LocalRepo } from '@/lib/warp';
 import { localDateString, addDays } from '@/lib/date';
 import type { Item } from '@/lib/types';
+import type { SnoozeOption } from '@/lib/snooze';
 
 export async function fetchDashboardData() {
   const [itemsRes, sprintRes] = await Promise.all([fetch('/api/items'), fetch('/api/sprint')]);
@@ -57,6 +58,22 @@ export async function unpinToday(id: number) {
 export async function carryToTomorrow(id: number) {
   const tomorrow = addDays(localDateString(new Date()), 1);
   return pinToday(id, tomorrow);
+}
+
+export async function starItem(id: number, starred: boolean) {
+  await fetch(`/api/items/${id}/star`, { method: 'POST', body: JSON.stringify({ starred }) });
+}
+
+export async function snoozeItem(id: number, option: SnoozeOption) {
+  await fetch(`/api/items/${id}/snooze`, { method: 'POST', body: JSON.stringify({ option }) });
+}
+
+export async function unsnoozeItem(id: number) {
+  await fetch(`/api/items/${id}/snooze`, { method: 'DELETE' });
+}
+
+export async function setItemDone(id: number, done: boolean) {
+  await fetch(`/api/items/${id}/done`, { method: 'POST', body: JSON.stringify({ done }) });
 }
 
 export async function fetchTodaySummary(): Promise<TodaySummaryResponse> {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -76,6 +76,26 @@ export async function setItemDone(id: number, done: boolean) {
   await fetch(`/api/items/${id}/done`, { method: 'POST', body: JSON.stringify({ done }) });
 }
 
+export async function fetchSavedViews() {
+  const res = await fetch('/api/saved-views');
+  return res.json();
+}
+
+export async function createSavedView(input: { label: string; query: string; shortcut: string | null }) {
+  const res = await fetch('/api/saved-views', { method: 'POST', body: JSON.stringify(input) });
+  return res.json();
+}
+
+export async function deleteSavedView(id: string) {
+  const res = await fetch(`/api/saved-views?id=${encodeURIComponent(id)}`, { method: 'DELETE' });
+  return res.json();
+}
+
+export async function reorderSavedViewsRequest(orderedIds: string[]) {
+  const res = await fetch('/api/saved-views', { method: 'PUT', body: JSON.stringify({ orderedIds }) });
+  return res.json();
+}
+
 export async function fetchTodaySummary(): Promise<TodaySummaryResponse> {
   const res = await fetch('/api/today/summary');
   return res.json();

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -11,6 +11,7 @@ export const SETTINGS_KEYS = {
   localReposBaseDir: 'warp.localReposBaseDir',
   repoPathOverrides: 'warp.repoPathOverrides',
   density: 'ui.density',
+  savedViews: 'ui.savedViews',
 } as const;
 
 export const DEFAULT_STALE_DAYS = 3;

--- a/lib/db.test.ts
+++ b/lib/db.test.ts
@@ -127,6 +127,57 @@ describe('openDb', () => {
   });
 });
 
+describe('items.starred / snoozed_until / triage_state / woke_early migration', () => {
+  it('adds all four columns to a fresh database', () => {
+    const db = openDb(':memory:');
+    const columns = (db.prepare('PRAGMA table_info(items)').all() as { name: string }[]).map((c) => c.name);
+    expect(columns).toContain('starred');
+    expect(columns).toContain('snoozed_until');
+    expect(columns).toContain('triage_state');
+    expect(columns).toContain('woke_early');
+    db.close();
+  });
+
+  it('adds all four columns to a pre-existing database that lacks them, without erroring on reopen', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ariadne-db-test-'));
+    const dbPath = join(dir, 'legacy.db');
+    try {
+      const legacy = new Database(dbPath);
+      legacy.exec(`
+        CREATE TABLE items (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          source TEXT NOT NULL,
+          external_id TEXT,
+          title TEXT NOT NULL,
+          url TEXT,
+          reason TEXT NOT NULL,
+          category TEXT,
+          due_date TEXT,
+          sprint_iteration TEXT,
+          raw_updated_at TEXT,
+          status TEXT NOT NULL DEFAULT 'inbox',
+          created_at TEXT NOT NULL,
+          completed_at TEXT,
+          UNIQUE(source, external_id)
+        );
+      `);
+      legacy.close();
+
+      const reopened = openDb(dbPath);
+      const columns = (reopened.prepare('PRAGMA table_info(items)').all() as { name: string }[]).map((c) => c.name);
+      expect(columns).toContain('starred');
+      expect(columns).toContain('snoozed_until');
+      expect(columns).toContain('triage_state');
+      expect(columns).toContain('woke_early');
+      reopened.close();
+
+      expect(() => openDb(dbPath).close()).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('addColumnTolerant', () => {
   it('adds the column when missing', () => {
     const db = new Database(':memory:');

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -141,6 +141,10 @@ export function openDb(path: string): Database.Database {
       addColumnIfMissing(db, 'items', 'has_unresolved_conversations', 'INTEGER');
       addColumnIfMissing(db, 'items', 'parked', 'INTEGER');
       addColumnIfMissing(db, 'items', 'today_date', 'TEXT');
+      addColumnIfMissing(db, 'items', 'starred', 'INTEGER');
+      addColumnIfMissing(db, 'items', 'snoozed_until', 'TEXT');
+      addColumnIfMissing(db, 'items', 'triage_state', 'TEXT');
+      addColumnIfMissing(db, 'items', 'woke_early', 'INTEGER');
       migrateTimeLogsToHours(db);
 
       return db;

--- a/lib/github-client.test.ts
+++ b/lib/github-client.test.ts
@@ -502,6 +502,48 @@ describe('fetchGithubItems linked ADO ids', () => {
   });
 });
 
+describe('read-only guard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('never issues a non-GET request, except the read-only GraphQL review-threads query', async () => {
+    const calls: { url: string; method: string }[] = [];
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method ?? 'GET' });
+      if (url.endsWith('/user')) return jsonResponse({ login: 'chris' });
+      if (url.includes('author%3Achris')) {
+        return jsonResponse({
+          items: [
+            {
+              number: 42,
+              title: 'Add feature',
+              html_url: 'https://github.com/acme/widgets/pull/42',
+              repository_url: 'https://api.github.com/repos/acme/widgets',
+              updated_at: '2026-07-01T00:00:00Z',
+            },
+          ],
+        });
+      }
+      if (url.includes('/pulls/42/reviews')) return jsonResponse([{ user: { login: 'reviewer1' }, state: 'APPROVED' }]);
+      if (url.endsWith('/pulls/42')) return jsonResponse({ draft: false });
+      if (url.includes('review-requested%3Achris')) return jsonResponse({ items: [] });
+      if (url.includes('mentions%3Achris')) return jsonResponse({ items: [] });
+      if (url.endsWith('/graphql')) return NO_THREADS_RESPONSE;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    await fetchGithubItems({ pat: 'x', staleDays: 3 });
+
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      const isReadOnlyGraphqlQuery = call.method === 'POST' && call.url.endsWith('/graphql');
+      expect(call.method === 'GET' || isReadOnlyGraphqlQuery).toBe(true);
+    }
+  });
+});
+
 describe('fetchMergedExternalIds', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());

--- a/lib/github-client.ts
+++ b/lib/github-client.ts
@@ -22,7 +22,7 @@ async function githubFetch(pat: string, path: string): Promise<any> {
 
 async function githubGraphql(pat: string, query: string, variables: Record<string, unknown>): Promise<any> {
   const res = await fetch(`${GITHUB_API}/graphql`, {
-    method: 'POST',
+    method: 'POST', // READ-ONLY-QUERY: GraphQL requires POST for a query body; this never mutates
     headers: {
       Authorization: `token ${pat}`,
       'Content-Type': 'application/json',

--- a/lib/items-repo.test.ts
+++ b/lib/items-repo.test.ts
@@ -9,6 +9,9 @@ import {
   setStatus,
   setParked,
   setTodayDate,
+  setStarred,
+  setSnoozedUntil,
+  setTriageState,
   deleteItem,
   getOpenGithubPrCandidates,
   setPrStatus,
@@ -418,6 +421,43 @@ describe('setTodayDate', () => {
     setTodayDate(db, item.id, '2026-08-13');
     setTodayDate(db, item.id, null);
     expect(getItemById(db, item.id)?.todayDate).toBeNull();
+  });
+});
+
+describe('setStarred', () => {
+  it('toggles the starred flag', () => {
+    const item = createAdhocItem(db, { title: 'Star me' });
+    setStarred(db, item.id, true);
+    expect(getItemById(db, item.id)?.starred).toBe(true);
+    setStarred(db, item.id, false);
+    expect(getItemById(db, item.id)?.starred).toBe(false);
+  });
+});
+
+describe('setSnoozedUntil', () => {
+  it('sets and clears the snooze timestamp', () => {
+    const item = createAdhocItem(db, { title: 'Snooze me' });
+    setSnoozedUntil(db, item.id, '2026-09-01T09:00:00.000Z');
+    expect(getItemById(db, item.id)?.snoozedUntil).toBe('2026-09-01T09:00:00.000Z');
+    setSnoozedUntil(db, item.id, null);
+    expect(getItemById(db, item.id)?.snoozedUntil).toBeNull();
+  });
+
+  it('clears any woke_early marker when a new snooze is set', () => {
+    const item = createAdhocItem(db, { title: 'Woke early item' });
+    db.prepare('UPDATE items SET woke_early = 1 WHERE id = ?').run(item.id);
+    setSnoozedUntil(db, item.id, '2026-09-01T09:00:00.000Z');
+    expect(getItemById(db, item.id)?.wokeEarly).toBe(false);
+  });
+});
+
+describe('setTriageState', () => {
+  it('marks an item done locally and back to none', () => {
+    const item = createAdhocItem(db, { title: 'Done me' });
+    setTriageState(db, item.id, 'done');
+    expect(getItemById(db, item.id)?.triageState).toBe('done');
+    setTriageState(db, item.id, 'none');
+    expect(getItemById(db, item.id)?.triageState).toBe('none');
   });
 });
 

--- a/lib/items-repo.test.ts
+++ b/lib/items-repo.test.ts
@@ -266,6 +266,72 @@ describe('upsertSyncedItem', () => {
   });
 });
 
+describe('upsertSyncedItem wake-early', () => {
+  it('clears an active snooze and marks woke_early when raw_updated_at changes upstream', () => {
+    const input = {
+      source: 'github_pr' as const,
+      externalId: '9@a/b',
+      title: 'Snoozed PR',
+      url: null,
+      reason: 'review_requested' as const,
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: '2026-08-01T00:00:00.000Z',
+      repo: null,
+    };
+    const item = upsertSyncedItem(db, input);
+    setSnoozedUntil(db, item.id, '2026-09-01T00:00:00.000Z');
+
+    upsertSyncedItem(db, { ...input, rawUpdatedAt: '2026-08-10T00:00:00.000Z' });
+
+    const updated = getItemById(db, item.id);
+    expect(updated?.snoozedUntil).toBeNull();
+    expect(updated?.wokeEarly).toBe(true);
+  });
+
+  it('leaves an active snooze untouched when raw_updated_at does not change', () => {
+    const input = {
+      source: 'github_pr' as const,
+      externalId: '10@a/b',
+      title: 'Quiet snoozed PR',
+      url: null,
+      reason: 'review_requested' as const,
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: '2026-08-01T00:00:00.000Z',
+      repo: null,
+    };
+    const item = upsertSyncedItem(db, input);
+    setSnoozedUntil(db, item.id, '2026-09-01T00:00:00.000Z');
+
+    upsertSyncedItem(db, input);
+
+    const updated = getItemById(db, item.id);
+    expect(updated?.snoozedUntil).toBe('2026-09-01T00:00:00.000Z');
+    expect(updated?.wokeEarly).toBe(false);
+  });
+
+  it('does nothing when the item was not snoozed', () => {
+    const input = {
+      source: 'github_pr' as const,
+      externalId: '11@a/b',
+      title: 'Never snoozed',
+      url: null,
+      reason: 'review_requested' as const,
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: '2026-08-01T00:00:00.000Z',
+      repo: null,
+    };
+    const item = upsertSyncedItem(db, input);
+    upsertSyncedItem(db, { ...input, rawUpdatedAt: '2026-08-10T00:00:00.000Z' });
+
+    const updated = getItemById(db, item.id);
+    expect(updated?.snoozedUntil).toBeNull();
+    expect(updated?.wokeEarly).toBe(false);
+  });
+});
+
 describe('createAdhocItem', () => {
   it('creates an ad-hoc item with manual reason', () => {
     const item = createAdhocItem(db, { title: 'Reply to Sarah re: deploy window' });

--- a/lib/items-repo.ts
+++ b/lib/items-repo.ts
@@ -37,6 +37,10 @@ function replaceItemLinks(db: Database.Database, prItemId: number, adoExternalId
 
 export function upsertSyncedItem(db: Database.Database, input: NewSyncedItemInput): Item {
   const now = new Date().toISOString();
+  const before = db
+    .prepare('SELECT raw_updated_at, snoozed_until FROM items WHERE source = ? AND external_id = ?')
+    .get(input.source, input.externalId) as { raw_updated_at: string | null; snoozed_until: string | null } | undefined;
+
   db.prepare(
     `INSERT INTO items (source, external_id, title, url, reason, due_date, sprint_iteration, raw_updated_at, ado_status, pr_status, repo, has_unresolved_conversations, status, created_at)
      VALUES (@source, @externalId, @title, @url, @reason, @dueDate, @sprintIteration, @rawUpdatedAt, @adoStatus, @prStatus, @repo, @hasUnresolvedConversations, 'inbox', @now)
@@ -63,11 +67,21 @@ export function upsertSyncedItem(db: Database.Database, input: NewSyncedItemInpu
   const row = db.prepare('SELECT * FROM items WHERE source = ? AND external_id = ?').get(input.source, input.externalId);
   const item = rowToItem(row);
 
+  // A snooze is a promise the item will stay quiet -- new upstream activity
+  // breaks that promise, so it wakes the item early rather than silently
+  // keeping it hidden. The row is marked woke_early instead of just clearing
+  // the snooze, so the surprise is labelled instead of silent.
+  const wasSnoozed = before?.snoozed_until != null;
+  const activityChanged = before !== undefined && before.raw_updated_at !== input.rawUpdatedAt;
+  if (wasSnoozed && activityChanged) {
+    db.prepare('UPDATE items SET snoozed_until = NULL, woke_early = 1 WHERE id = ?').run(item.id);
+  }
+
   if (input.source === 'github_pr' && input.linkedAdoExternalIds) {
     replaceItemLinks(db, item.id, input.linkedAdoExternalIds);
   }
 
-  return item;
+  return wasSnoozed && activityChanged ? { ...item, snoozedUntil: null, wokeEarly: true } : item;
 }
 
 export function createAdhocItem(db: Database.Database, input: NewAdhocItemInput): Item {

--- a/lib/items-repo.ts
+++ b/lib/items-repo.ts
@@ -22,6 +22,10 @@ function rowToItem(row: any): Item {
     hasUnresolvedConversations: !!row.has_unresolved_conversations,
     parked: !!row.parked,
     todayDate: row.today_date,
+    starred: !!row.starred,
+    snoozedUntil: row.snoozed_until,
+    triageState: (row.triage_state ?? 'none') as Item['triageState'],
+    wokeEarly: !!row.woke_early,
   };
 }
 
@@ -107,6 +111,21 @@ export function setParked(db: Database.Database, id: number, parked: boolean): v
 
 export function setTodayDate(db: Database.Database, id: number, date: string | null): void {
   db.prepare('UPDATE items SET today_date = ? WHERE id = ?').run(date, id);
+}
+
+export function setStarred(db: Database.Database, id: number, starred: boolean): void {
+  db.prepare('UPDATE items SET starred = ? WHERE id = ?').run(starred ? 1 : 0, id);
+}
+
+// Setting a new snooze always clears any previous "woke early" marker -- a
+// fresh snooze is the user re-acknowledging the item, so the old surprise
+// no longer needs flagging.
+export function setSnoozedUntil(db: Database.Database, id: number, until: string | null): void {
+  db.prepare('UPDATE items SET snoozed_until = ?, woke_early = 0 WHERE id = ?').run(until, id);
+}
+
+export function setTriageState(db: Database.Database, id: number, state: Item['triageState']): void {
+  db.prepare('UPDATE items SET triage_state = ? WHERE id = ?').run(state, id);
 }
 
 export function getOpenGithubPrCandidates(db: Database.Database): { id: number; externalId: string }[] {

--- a/lib/keymap.test.ts
+++ b/lib/keymap.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { KEYMAP, isTypingTarget } from './keymap';
+
+describe('KEYMAP', () => {
+  it('has no duplicate key bindings', () => {
+    const seen = new Set<string>();
+    for (const binding of KEYMAP) {
+      expect(seen.has(binding.keys)).toBe(false);
+      seen.add(binding.keys);
+    }
+  });
+
+  it('gives every binding non-empty help text', () => {
+    for (const binding of KEYMAP) {
+      expect(binding.description.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('declares every binding with a row or global scope', () => {
+    for (const binding of KEYMAP) {
+      expect(['row', 'global']).toContain(binding.scope);
+    }
+  });
+});
+
+describe('isTypingTarget', () => {
+  it('is true for an input element', () => {
+    expect(isTypingTarget({ tagName: 'INPUT', isContentEditable: false })).toBe(true);
+  });
+
+  it('is true for a textarea element', () => {
+    expect(isTypingTarget({ tagName: 'TEXTAREA', isContentEditable: false })).toBe(true);
+  });
+
+  it('is true for a contenteditable element', () => {
+    expect(isTypingTarget({ tagName: 'DIV', isContentEditable: true })).toBe(true);
+  });
+
+  it('is false for a plain element', () => {
+    expect(isTypingTarget({ tagName: 'DIV', isContentEditable: false })).toBe(false);
+  });
+
+  it('is false for null or undefined', () => {
+    expect(isTypingTarget(null)).toBe(false);
+    expect(isTypingTarget(undefined)).toBe(false);
+  });
+});

--- a/lib/keymap.ts
+++ b/lib/keymap.ts
@@ -1,0 +1,52 @@
+export interface KeyBinding {
+  keys: string;
+  description: string;
+  scope: 'row' | 'global';
+}
+
+// The single place a binding may be declared -- the `?` cheat sheet
+// (KeymapHelpDialog) and the command palette's shortcut hints both render
+// straight from this array, so neither can drift from what's actually wired
+// up. Row-scoped bindings fire from each row's own onKeyDown (naturally
+// inert while typing, since focus never reaches a row while an input has
+// it); global bindings go through the document-level listener in
+// GlobalKeymapProvider, which checks isTypingTarget before acting on any of
+// them.
+//
+// Deliberately NOT included yet: `space` (start/stop timer) and `P` (plan
+// the day) -- both trigger Phase 3 features that don't exist in this
+// codebase yet. Declaring a binding for a nonexistent action would ship a
+// dead shortcut; they're added here once Phase 3 builds what they call.
+export const KEYMAP: KeyBinding[] = [
+  { keys: 'j', description: 'Move focus to the next signal', scope: 'row' },
+  { keys: 'k', description: 'Move focus to the previous signal', scope: 'row' },
+  { keys: '↵ / o', description: 'Open upstream in a new tab', scope: 'row' },
+  { keys: 'x', description: 'Show the score breakdown', scope: 'row' },
+  { keys: 's', description: 'Star (local only)', scope: 'row' },
+  { keys: 'e', description: 'Snooze (local only)', scope: 'row' },
+  { keys: 'd', description: 'Mark done (local only)', scope: 'row' },
+  { keys: 't', description: 'Pin to Today', scope: 'row' },
+  { keys: '/', description: 'Focus the query bar', scope: 'global' },
+  { keys: '⌘K / Ctrl+K', description: 'Search or jump to', scope: 'global' },
+  { keys: '⌘Z', description: 'Undo the last triage action', scope: 'global' },
+  { keys: 'g d', description: 'Go to the dashboard', scope: 'global' },
+  { keys: 'g s', description: 'Go to Settings', scope: 'global' },
+  { keys: 'R', description: 'Refresh', scope: 'global' },
+  { keys: 'W', description: 'Wrap up the day', scope: 'global' },
+  { keys: '?', description: 'Show this cheat sheet', scope: 'global' },
+  { keys: 'Esc', description: 'Dismiss the open overlay', scope: 'global' },
+];
+
+interface TypingTargetLike {
+  tagName?: string;
+  isContentEditable?: boolean;
+}
+
+// Accepts `unknown` (not `EventTarget | null`) so it stays a pure function
+// testable with a plain object, no DOM/jsdom required.
+export function isTypingTarget(target: unknown): boolean {
+  if (!target || typeof target !== 'object') return false;
+  const el = target as TypingTargetLike;
+  if (el.isContentEditable) return true;
+  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA';
+}

--- a/lib/query.test.ts
+++ b/lib/query.test.ts
@@ -147,6 +147,14 @@ describe('applyQuery', () => {
     expect(applyQuery(items, parseQuery('sprint:current'), context).map((i) => i.id)).toEqual([1]);
   });
 
+  it('matches sprint:current against a full ADO iteration path ending in the current sprint name', () => {
+    const items = [
+      item({ id: 1, sprintIteration: 'Project\\Sprint 42' }),
+      item({ id: 2, sprintIteration: 'Project\\Sprint 41' }),
+    ];
+    expect(applyQuery(items, parseQuery('sprint:current'), context).map((i) => i.id)).toEqual([1]);
+  });
+
   it('returns items unchanged for an empty query', () => {
     const items = [item({ id: 1 }), item({ id: 2 })];
     expect(applyQuery(items, parseQuery(''), context).map((i) => i.id)).toEqual([1, 2]);

--- a/lib/query.test.ts
+++ b/lib/query.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { parseQuery, applyQuery, stateOf } from './query';
+import type { ScoredItem } from './dashboard';
+
+const NOW = new Date('2026-08-14T12:00:00.000Z');
+
+function item(overrides: Partial<ScoredItem> = {}): ScoredItem {
+  return {
+    id: 1,
+    source: 'github_pr',
+    externalId: null,
+    title: 'Fix the flaky test',
+    url: null,
+    reason: 'review_requested',
+    category: null,
+    dueDate: null,
+    sprintIteration: null,
+    rawUpdatedAt: '2026-08-14T00:00:00.000Z',
+    status: 'inbox',
+    createdAt: '2026-08-14T00:00:00.000Z',
+    completedAt: null,
+    adoStatus: null,
+    prStatus: null,
+    repo: 'widgets',
+    hasUnresolvedConversations: false,
+    parked: false,
+    todayDate: null,
+    starred: false,
+    snoozedUntil: null,
+    triageState: 'none',
+    wokeEarly: false,
+    score: 40,
+    scoreBreakdown: [],
+    notFired: [],
+    links: [],
+    ...overrides,
+  };
+}
+
+const context = { now: NOW, currentSprintIteration: 'Sprint 42' };
+
+describe('parseQuery', () => {
+  it('parses a source filter with comma-OR values', () => {
+    const parsed = parseQuery('source:github,adhoc');
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.filters).toEqual([{ prefix: 'source', values: ['github', 'adhoc'], negate: false }]);
+  });
+
+  it('parses negation', () => {
+    const parsed = parseQuery('-is:snoozed');
+    expect(parsed.filters).toEqual([{ prefix: 'is', values: ['snoozed'], negate: true }]);
+  });
+
+  it('collects bare words separately from prefixed filters', () => {
+    const parsed = parseQuery('source:github rotated pages');
+    expect(parsed.bareWords).toEqual(['rotated', 'pages']);
+    expect(parsed.filters).toEqual([{ prefix: 'source', values: ['github'], negate: false }]);
+  });
+
+  it('reports an error and keeps everything else for an unknown prefix', () => {
+    const parsed = parseQuery('bogus:value source:github');
+    expect(parsed.errors.length).toBe(1);
+    expect(parsed.filters).toEqual([{ prefix: 'source', values: ['github'], negate: false }]);
+  });
+
+  it('reports an error for a malformed score comparator', () => {
+    const parsed = parseQuery('score:>>25');
+    expect(parsed.errors.length).toBe(1);
+  });
+
+  it('parses a score range', () => {
+    const parsed = parseQuery('score:40..105');
+    expect(parsed.filters).toEqual([{ prefix: 'score', values: ['40..105'], negate: false }]);
+  });
+
+  it('reports an error for an unknown reason key', () => {
+    const parsed = parseQuery('reason:not_a_real_reason');
+    expect(parsed.errors.length).toBe(1);
+  });
+
+  it('parses every documented prefix without error', () => {
+    const queries = [
+      'source:github',
+      'group:waiting',
+      'state:review',
+      'score:>50',
+      'score:<30',
+      'repo:widgets',
+      'sprint:current',
+      'sprint:42',
+      'is:starred',
+      'stale:>5d',
+      'reason:approved_unmerged',
+    ];
+    for (const q of queries) {
+      expect(parseQuery(q).errors).toEqual([]);
+    }
+  });
+});
+
+describe('applyQuery', () => {
+  it('filters by source', () => {
+    const items = [item({ id: 1, source: 'github_pr' }), item({ id: 2, source: 'ado_workitem' })];
+    const result = applyQuery(items, parseQuery('source:github'), context);
+    expect(result.map((i) => i.id)).toEqual([1]);
+  });
+
+  it('filters by score comparator', () => {
+    const items = [item({ id: 1, score: 60 }), item({ id: 2, score: 10 })];
+    expect(applyQuery(items, parseQuery('score:>50'), context).map((i) => i.id)).toEqual([1]);
+    expect(applyQuery(items, parseQuery('score:<30'), context).map((i) => i.id)).toEqual([2]);
+  });
+
+  it('filters by score range', () => {
+    const items = [item({ id: 1, score: 45 }), item({ id: 2, score: 10 })];
+    expect(applyQuery(items, parseQuery('score:40..105'), context).map((i) => i.id)).toEqual([1]);
+  });
+
+  it('negates a filter', () => {
+    const items = [item({ id: 1, snoozedUntil: '2027-01-01T00:00:00.000Z' }), item({ id: 2, snoozedUntil: null })];
+    expect(applyQuery(items, parseQuery('-is:snoozed'), context).map((i) => i.id)).toEqual([2]);
+  });
+
+  it('applies bare-word title matching alongside a prefix filter', () => {
+    const items = [item({ id: 1, title: 'Fix the flaky test' }), item({ id: 2, title: 'Add a new endpoint' })];
+    expect(applyQuery(items, parseQuery('source:github flaky'), context).map((i) => i.id)).toEqual([1]);
+  });
+
+  it('matches is:stale using the default staleness window', () => {
+    const items = [
+      item({ id: 1, rawUpdatedAt: '2026-08-01T00:00:00.000Z' }),
+      item({ id: 2, rawUpdatedAt: '2026-08-14T00:00:00.000Z' }),
+    ];
+    expect(applyQuery(items, parseQuery('is:stale'), context).map((i) => i.id)).toEqual([1]);
+  });
+
+  it('matches stale:>Nd', () => {
+    const items = [
+      item({ id: 1, rawUpdatedAt: '2026-08-01T00:00:00.000Z' }),
+      item({ id: 2, rawUpdatedAt: '2026-08-13T00:00:00.000Z' }),
+    ];
+    expect(applyQuery(items, parseQuery('stale:>5d'), context).map((i) => i.id)).toEqual([1]);
+  });
+
+  it('matches sprint:current against the supplied current iteration', () => {
+    const items = [item({ id: 1, sprintIteration: 'Sprint 42' }), item({ id: 2, sprintIteration: 'Sprint 41' })];
+    expect(applyQuery(items, parseQuery('sprint:current'), context).map((i) => i.id)).toEqual([1]);
+  });
+
+  it('returns items unchanged for an empty query', () => {
+    const items = [item({ id: 1 }), item({ id: 2 })];
+    expect(applyQuery(items, parseQuery(''), context).map((i) => i.id)).toEqual([1, 2]);
+  });
+});
+
+describe('stateOf', () => {
+  it('maps a draft PR to draft', () => {
+    expect(stateOf({ source: 'github_pr', adoStatus: null, prStatus: 'draft' })).toBe('draft');
+  });
+
+  it('maps a ready-for-review PR to review', () => {
+    expect(stateOf({ source: 'github_pr', adoStatus: null, prStatus: 'ready_for_review' })).toBe('review');
+  });
+
+  it('maps a blocked ADO state to blocked', () => {
+    expect(stateOf({ source: 'ado_workitem', adoStatus: 'Blocked', prStatus: null })).toBe('blocked');
+  });
+
+  it('maps an active ADO state to progress', () => {
+    expect(stateOf({ source: 'ado_workitem', adoStatus: 'Active', prStatus: null })).toBe('progress');
+  });
+
+  it('maps a To Do ADO state to todo', () => {
+    expect(stateOf({ source: 'ado_workitem', adoStatus: 'To Do', prStatus: null })).toBe('todo');
+  });
+
+  it('returns null when there is nothing to map', () => {
+    expect(stateOf({ source: 'adhoc', adoStatus: null, prStatus: null })).toBeNull();
+  });
+});

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1,0 +1,202 @@
+import { REASON_LABEL } from './scoring';
+import { DEFAULT_STALE_DAYS } from './config';
+import { isSnoozed } from './snooze';
+import { groupOf, type ObligationGroup } from './grouping';
+import type { Item, Reason, Source } from './types';
+import type { ScoredItem } from './dashboard';
+
+export type QueryState = 'blocked' | 'review' | 'progress' | 'draft' | 'todo';
+
+const PREFIXES = ['source', 'group', 'state', 'score', 'repo', 'sprint', 'is', 'stale', 'reason'] as const;
+type Prefix = (typeof PREFIXES)[number];
+
+export interface ParsedFilter {
+  prefix: Prefix;
+  values: string[];
+  negate: boolean;
+}
+
+export interface ParsedQuery {
+  filters: ParsedFilter[];
+  bareWords: string[];
+  errors: string[];
+}
+
+const SOURCE_VALUES = new Set(['github', 'ado', 'adhoc']);
+const GROUP_VALUES = new Set(['waiting', 'blocked', 'moving', 'lower']);
+const STATE_VALUES = new Set(['blocked', 'review', 'todo', 'progress', 'draft']);
+const IS_VALUES = new Set(['starred', 'snoozed', 'done', 'stale']);
+const REASON_KEYS = new Set(Object.keys(REASON_LABEL));
+
+function isValidScoreExpr(expr: string | undefined): boolean {
+  if (!expr) return false;
+  if (/^[<>]\d+$/.test(expr)) return true;
+  if (/^\d+\.\.\d+$/.test(expr)) return true;
+  return false;
+}
+
+function validateValues(prefix: Prefix, values: string[]): string | null {
+  switch (prefix) {
+    case 'source':
+      return values.every((v) => SOURCE_VALUES.has(v)) ? null : `source: expects github, ado, or adhoc`;
+    case 'group':
+      return values.every((v) => GROUP_VALUES.has(v)) ? null : `group: expects waiting, blocked, moving, or lower`;
+    case 'state':
+      return values.every((v) => STATE_VALUES.has(v)) ? null : `state: expects blocked, review, todo, progress, or draft`;
+    case 'is':
+      return values.every((v) => IS_VALUES.has(v)) ? null : `is: expects starred, snoozed, done, or stale`;
+    case 'reason':
+      return values.every((v) => REASON_KEYS.has(v)) ? null : `reason: unknown reason key`;
+    case 'score':
+      return isValidScoreExpr(values[0]) ? null : `score: expected >n, <n, or n..n`;
+    case 'stale':
+      return /^>\d+d$/.test(values[0]) ? null : `stale: expected >Nd`;
+    case 'repo':
+    case 'sprint':
+      return values.length > 0 ? null : `${prefix}: expects a value`;
+  }
+}
+
+// Pure and total: never throws on malformed input. Anything that doesn't
+// parse is reported in `errors` and simply excluded from `filters`/
+// `bareWords` -- callers decide whether to apply a partially-valid query or
+// keep showing the last fully-valid one (SignalsBoard does the latter).
+export function parseQuery(raw: string): ParsedQuery {
+  const filters: ParsedFilter[] = [];
+  const bareWords: string[] = [];
+  const errors: string[] = [];
+
+  const tokens = raw.trim().split(/\s+/).filter(Boolean);
+  for (const token of tokens) {
+    const negate = token.startsWith('-');
+    const body = negate ? token.slice(1) : token;
+    const colonIndex = body.indexOf(':');
+
+    if (colonIndex === -1) {
+      if (negate) {
+        errors.push(`"${token}": negation only applies to a prefix filter`);
+      } else {
+        bareWords.push(body);
+      }
+      continue;
+    }
+
+    const prefix = body.slice(0, colonIndex);
+    const valuePart = body.slice(colonIndex + 1);
+    if (!(PREFIXES as readonly string[]).includes(prefix)) {
+      errors.push(`"${prefix}:" is not a recognized filter`);
+      continue;
+    }
+
+    const typedPrefix = prefix as Prefix;
+    const values = ['score', 'stale'].includes(typedPrefix) ? [valuePart] : valuePart.split(',').filter(Boolean);
+    const error = validateValues(typedPrefix, values);
+    if (error) {
+      errors.push(`"${token}": ${error}`);
+      continue;
+    }
+
+    filters.push({ prefix: typedPrefix, values, negate });
+  }
+
+  return { filters, bareWords, errors };
+}
+
+export interface QueryContext {
+  now: Date;
+  currentSprintIteration: string | null;
+}
+
+function matchesScore(expr: string, score: number): boolean {
+  if (expr.startsWith('>')) return score > Number(expr.slice(1));
+  if (expr.startsWith('<')) return score < Number(expr.slice(1));
+  const [lo, hi] = expr.split('..').map(Number);
+  return score >= lo && score <= hi;
+}
+
+function ageDays(rawUpdatedAt: string | null, now: Date): number | null {
+  if (!rawUpdatedAt) return null;
+  return (now.getTime() - new Date(rawUpdatedAt).getTime()) / 86_400_000;
+}
+
+const GROUP_KEY: Record<string, ObligationGroup> = {
+  waiting: 'waiting_on_you',
+  blocked: 'blocked',
+  moving: 'moving_without_you',
+  lower: 'lower_priority',
+};
+
+const SOURCE_KEY: Record<string, Source> = { github: 'github_pr', ado: 'ado_workitem', adhoc: 'adhoc' };
+
+function matchesFilter(item: ScoredItem, filter: ParsedFilter, context: QueryContext): boolean {
+  const { prefix, values } = filter;
+  switch (prefix) {
+    case 'source':
+      return values.some((v) => item.source === SOURCE_KEY[v]);
+    case 'group':
+      return values.some((v) => groupOf(item) === GROUP_KEY[v]);
+    case 'state':
+      return values.some((v) => stateOf(item) === v);
+    case 'score':
+      return matchesScore(values[0], item.score);
+    case 'repo':
+      return values.some((v) => (item.repo ?? '').toLowerCase().includes(v.toLowerCase()));
+    case 'sprint':
+      return values.some((v) =>
+        v === 'current' ? item.sprintIteration === context.currentSprintIteration : item.sprintIteration === v
+      );
+    case 'is':
+      return values.some((v) => {
+        if (v === 'starred') return item.starred;
+        if (v === 'snoozed') return isSnoozed(item.snoozedUntil, context.now);
+        if (v === 'done') return item.triageState === 'done';
+        if (v === 'stale') {
+          const days = ageDays(item.rawUpdatedAt, context.now);
+          return days !== null && days > DEFAULT_STALE_DAYS;
+        }
+        return false;
+      });
+    case 'stale': {
+      const threshold = Number(values[0].slice(1, -1));
+      const days = ageDays(item.rawUpdatedAt, context.now);
+      return days !== null && days > threshold;
+    }
+    case 'reason':
+      return values.some((v) => item.reason === (v as Reason));
+  }
+}
+
+export function applyQuery(items: ScoredItem[], parsed: ParsedQuery, context: QueryContext): ScoredItem[] {
+  return items.filter((item) => {
+    for (const filter of parsed.filters) {
+      const matched = matchesFilter(item, filter, context);
+      if (filter.negate ? matched : !matched) return false;
+    }
+    return parsed.bareWords.every((word) => item.title.toLowerCase().includes(word.toLowerCase()));
+  });
+}
+
+export function stateOf(item: Pick<Item, 'source' | 'adoStatus' | 'prStatus'>): QueryState | null {
+  if (item.source === 'ado_workitem' && item.adoStatus) {
+    const s = item.adoStatus.toLowerCase();
+    if (/block/.test(s)) return 'blocked';
+    if (/review/.test(s)) return 'review';
+    if (/active|committ|doing|progress/.test(s)) return 'progress';
+    if (/to ?do|new/.test(s)) return 'todo';
+    return null;
+  }
+  if (item.source === 'github_pr' && item.prStatus) {
+    if (item.prStatus === 'draft') return 'draft';
+    if (item.prStatus === 'ready_for_review' || item.prStatus === 'changes_requested') return 'review';
+    return null;
+  }
+  return null;
+}
+
+// Round-trips a parsed query back to editable text -- used when a filter
+// chip is clicked, so the query bar and the chips stay one bidirectional
+// state rather than two representations that can drift.
+export function queryToString(parsed: ParsedQuery): string {
+  const filterTokens = parsed.filters.map((f) => `${f.negate ? '-' : ''}${f.prefix}:${f.values.join(',')}`);
+  return [...filterTokens, ...parsed.bareWords].join(' ');
+}

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -142,9 +142,16 @@ function matchesFilter(item: ScoredItem, filter: ParsedFilter, context: QueryCon
     case 'repo':
       return values.some((v) => (item.repo ?? '').toLowerCase().includes(v.toLowerCase()));
     case 'sprint':
-      return values.some((v) =>
-        v === 'current' ? item.sprintIteration === context.currentSprintIteration : item.sprintIteration === v
-      );
+      return values.some((v) => {
+        if (v !== 'current') return item.sprintIteration === v;
+        const current = context.currentSprintIteration;
+        if (!current || !item.sprintIteration) return false;
+        // sprint.name (e.g. "Sprint 42") is a short display name; an ADO
+        // item's sprintIteration is the full iteration path (e.g.
+        // "Project\Sprint 42") -- mirrors getSprintProgress's own matching
+        // in lib/sprint.ts so "current" means the same thing everywhere.
+        return item.sprintIteration === current || item.sprintIteration.endsWith('\\' + current);
+      });
     case 'is':
       return values.some((v) => {
         if (v === 'starred') return item.starred;

--- a/lib/saved-views.test.ts
+++ b/lib/saved-views.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openDb } from './db';
+import { getSavedViews, addSavedView, removeSavedView, reorderSavedViews } from './saved-views';
+import type Database from 'better-sqlite3';
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = openDb(':memory:');
+});
+
+describe('saved views', () => {
+  it('starts empty', () => {
+    expect(getSavedViews(db)).toEqual([]);
+  });
+
+  it('adds a view and persists it', () => {
+    addSavedView(db, { label: 'Blocked in sprint', query: 'group:blocked sprint:current', shortcut: '2' });
+    const views = getSavedViews(db);
+    expect(views).toHaveLength(1);
+    expect(views[0]).toMatchObject({ label: 'Blocked in sprint', query: 'group:blocked sprint:current', shortcut: '2' });
+    expect(views[0].id).toBeTruthy();
+  });
+
+  it('has no arbitrary cap', () => {
+    for (let i = 0; i < 30; i++) {
+      addSavedView(db, { label: `View ${i}`, query: `repo:x${i}`, shortcut: null });
+    }
+    expect(getSavedViews(db)).toHaveLength(30);
+  });
+
+  it('removes a view by id', () => {
+    const [added] = addSavedView(db, { label: 'Quiet 5 days+', query: 'stale:>5d', shortcut: '3' });
+    const remaining = removeSavedView(db, added.id);
+    expect(remaining).toEqual([]);
+  });
+
+  it('reorders views', () => {
+    const afterFirst = addSavedView(db, { label: 'A', query: 'is:starred', shortcut: '1' });
+    const afterSecond = addSavedView(db, { label: 'B', query: 'is:snoozed', shortcut: '2' });
+    const idA = afterFirst[0].id;
+    const idB = afterSecond[1].id;
+    const reordered = reorderSavedViews(db, [idB, idA]);
+    expect(reordered.map((v) => v.id)).toEqual([idB, idA]);
+  });
+});

--- a/lib/saved-views.ts
+++ b/lib/saved-views.ts
@@ -1,0 +1,56 @@
+import type Database from 'better-sqlite3';
+import { getSetting, setSetting } from './settings-repo';
+import { SETTINGS_KEYS } from './config';
+
+export interface SavedView {
+  id: string;
+  label: string;
+  query: string;
+  shortcut: string | null;
+}
+
+function readViews(db: Database.Database): SavedView[] {
+  const raw = getSetting(db, SETTINGS_KEYS.savedViews);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as SavedView[];
+  } catch {
+    return [];
+  }
+}
+
+function writeViews(db: Database.Database, views: SavedView[]): void {
+  setSetting(db, SETTINGS_KEYS.savedViews, JSON.stringify(views));
+}
+
+export function getSavedViews(db: Database.Database): SavedView[] {
+  return readViews(db);
+}
+
+export function setSavedViews(db: Database.Database, views: SavedView[]): void {
+  writeViews(db, views);
+}
+
+// Unlimited by design -- the 15-saved-filter cap some providers impose
+// exists to protect their shared infrastructure; a local SQLite file has no
+// such constraint (see docs/wireframes/phase-2-speed-and-control.html).
+export function addSavedView(db: Database.Database, view: Omit<SavedView, 'id'>): SavedView[] {
+  const views = readViews(db);
+  const withNew = [...views, { ...view, id: crypto.randomUUID() }];
+  writeViews(db, withNew);
+  return withNew;
+}
+
+export function removeSavedView(db: Database.Database, id: string): SavedView[] {
+  const remaining = readViews(db).filter((v) => v.id !== id);
+  writeViews(db, remaining);
+  return remaining;
+}
+
+export function reorderSavedViews(db: Database.Database, orderedIds: string[]): SavedView[] {
+  const views = readViews(db);
+  const byId = new Map(views.map((v) => [v.id, v]));
+  const reordered = orderedIds.map((id) => byId.get(id)).filter((v): v is SavedView => Boolean(v));
+  writeViews(db, reordered);
+  return reordered;
+}

--- a/lib/snooze.test.ts
+++ b/lib/snooze.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { computeSnoozeUntil, isSnoozed, INDEFINITE_SNOOZE } from './snooze';
+
+describe('computeSnoozeUntil', () => {
+  const morning = new Date('2026-08-14T09:00:00.000Z'); // Friday
+
+  it('later_today snoozes to 17:00 the same day when before 17:00', () => {
+    const until = new Date(computeSnoozeUntil('later_today', morning));
+    expect(until.getDate()).toBe(morning.getDate());
+    expect(until.getHours()).toBe(17);
+  });
+
+  it('later_today rolls to tomorrow 17:00 when already past 17:00', () => {
+    const evening = new Date('2026-08-14T20:00:00.000Z');
+    const until = new Date(computeSnoozeUntil('later_today', evening));
+    expect(until.getDate()).toBe(15);
+    expect(until.getHours()).toBe(17);
+  });
+
+  it('tomorrow snoozes to 09:00 the next day', () => {
+    const until = new Date(computeSnoozeUntil('tomorrow', morning));
+    expect(until.getDate()).toBe(15);
+    expect(until.getHours()).toBe(9);
+  });
+
+  it('next_week snoozes to 09:00 next Monday', () => {
+    const until = new Date(computeSnoozeUntil('next_week', morning)); // Friday -> Monday
+    expect(until.getDay()).toBe(1);
+    expect(until.getHours()).toBe(9);
+    expect(until.getTime()).toBeGreaterThan(morning.getTime());
+  });
+
+  it('until_activity returns the indefinite sentinel', () => {
+    expect(computeSnoozeUntil('until_activity', morning)).toBe(INDEFINITE_SNOOZE);
+  });
+});
+
+describe('isSnoozed', () => {
+  const now = new Date('2026-08-14T12:00:00.000Z');
+
+  it('is false when there is no snooze', () => {
+    expect(isSnoozed(null, now)).toBe(false);
+  });
+
+  it('is true when snoozed_until is in the future', () => {
+    expect(isSnoozed('2026-08-15T00:00:00.000Z', now)).toBe(true);
+  });
+
+  it('is false when snoozed_until has already passed', () => {
+    expect(isSnoozed('2026-08-13T00:00:00.000Z', now)).toBe(false);
+  });
+
+  it('is true for the indefinite sentinel', () => {
+    expect(isSnoozed(INDEFINITE_SNOOZE, now)).toBe(true);
+  });
+});

--- a/lib/snooze.ts
+++ b/lib/snooze.ts
@@ -1,0 +1,47 @@
+export type SnoozeOption = 'later_today' | 'tomorrow' | 'next_week' | 'until_activity';
+
+export const SNOOZE_LABEL: Record<SnoozeOption, string> = {
+  later_today: 'Later today',
+  tomorrow: 'Tomorrow',
+  next_week: 'Next week',
+  until_activity: "Until there's activity",
+};
+
+// "Until there's activity" has no fixed end time -- it's represented as a
+// far-future timestamp so `isSnoozed` treats it identically to a finite
+// snooze everywhere it's checked. The ONLY way it clears is the upstream
+// wake-early path in upsertSyncedItem (see items-repo.ts), never a timer.
+export const INDEFINITE_SNOOZE = '9999-12-31T23:59:59.000Z';
+
+function at(date: Date, hours: number): Date {
+  const d = new Date(date);
+  d.setHours(hours, 0, 0, 0);
+  return d;
+}
+
+export function computeSnoozeUntil(option: SnoozeOption, now: Date): string {
+  switch (option) {
+    case 'later_today': {
+      const today5pm = at(now, 17);
+      return (today5pm > now ? today5pm : new Date(today5pm.getTime() + 86_400_000)).toISOString();
+    }
+    case 'tomorrow': {
+      const tomorrow = at(now, 9);
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      return tomorrow.toISOString();
+    }
+    case 'next_week': {
+      const nextMonday = at(now, 9);
+      const daysUntilMonday = ((8 - now.getDay()) % 7) || 7;
+      nextMonday.setDate(nextMonday.getDate() + daysUntilMonday);
+      return nextMonday.toISOString();
+    }
+    case 'until_activity':
+      return INDEFINITE_SNOOZE;
+  }
+}
+
+export function isSnoozed(snoozedUntil: string | null, now: Date): boolean {
+  if (!snoozedUntil) return false;
+  return new Date(snoozedUntil).getTime() > now.getTime();
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,6 +9,7 @@ export type Reason =
   | 'approved_unmerged';
 export type PrStatus = 'draft' | 'ready_for_review' | 'changes_requested' | 'approved' | 'merged';
 export type Status = 'inbox' | 'in_progress' | 'done';
+export type TriageState = 'none' | 'done';
 
 export interface Item {
   id: number;
@@ -30,6 +31,10 @@ export interface Item {
   hasUnresolvedConversations: boolean;
   parked: boolean;
   todayDate: string | null;
+  starred: boolean;
+  snoozedUntil: string | null;
+  triageState: TriageState;
+  wokeEarly: boolean;
 }
 
 export interface NewSyncedItemInput {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "better-sqlite3": "^11.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lucide-react": "^0.400.0",
         "next": "^14.2.0",
         "next-themes": "^0.4.6",
@@ -3413,6 +3414,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "better-sqlite3": "^11.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.400.0",
     "next": "^14.2.0",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary
- Row-level keyboard layer: `j`/`k` move focus with a visible ring + 2px leading bar, `o`/Enter opens upstream, `x` shows the score breakdown, `s`/`e`/`d`/`t` star/snooze/mark-done/pin. `lib/keymap.ts` is the single declared source, backing both the `?` cheat sheet and future shortcut hints (P3).
- Local-only triage: `starred`, `snoozed_until`, `triage_state`, `woke_early` columns (reversible migration), never touching GitHub/Azure DevOps — enforced by an HTTP-boundary guard test and a CI grep. Snooze options (later today / tomorrow / next week / until activity), 10s undo toasts, and a snoozed item wakes early with a labelled "woke early" marker if it changes upstream before its snooze ends (P5).
- A closed nine-prefix query language (`source`, `group`, `state`, `score`, `repo`, `sprint`, `is`, `stale`, `reason`, plus negation and comma-OR) filters the Signals list client-side, with query text and filter chips as one bidirectional state. Saved views persist via the existing settings table, unlimited and reorderable (P6).
- A `⌘K` command palette (Signals / Filter / Saved views / Go to / Rituals) replaces the old 390px header search input; typing a recognized prefix hands off to the same P6 parser (P12).

## Deliberate scope narrowings (documented in the plan)
- `space` (timer) and `P` (plan the day) are omitted from the keymap — those features don't exist until Phase 3.
- The palette's "Rituals" category only lists "Wrap up the day" for the same reason.
- `sprint:current` matches a full ADO iteration path against the configured sprint name, mirroring `lib/sprint.ts`'s existing logic.

## Test plan
- [x] `npm test` — 294/294 passing
- [x] `npx tsc --noEmit` — no errors
- [x] CI workflow added (`.github/workflows/ci.yml`) with a grep guard against non-GET calls in the provider clients — verified locally
- [x] Manual dev-server walkthrough: seeded items across all four obligation groups and two sprints, confirmed group order, `is:`/`group:`/`state:`/`sprint:` semantics via unit tests, default view hides snoozed/done, starred-first sort, ⌘K affordance renders on every route, `/settings` unaffected

Closes #22