### PR TITLE
Phase 3: the shape of a day

### DIFF
--- a/app/api/calibration/route.test.ts
+++ b/app/api/calibration/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem } from '@/lib/items-repo';
+import { addPlanItem, setPlanItemEstimate } from '@/lib/plans-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { GET } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM time_logs; DELETE FROM plan_items; DELETE FROM items;');
+});
+
+describe('GET /api/calibration', () => {
+  it('returns an empty array when there is nothing planned in range', async () => {
+    const res = await GET(new Request('http://localhost/api/calibration?start=2026-08-14&end=2026-08-14'));
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it('returns a calibration entry once a plan_item with logged time exists in range', async () => {
+    const item = createAdhocItem(testDb, { title: 'Review this' });
+    addPlanItem(testDb, '2026-08-14', item.id);
+    setPlanItemEstimate(testDb, '2026-08-14', item.id, 30);
+    testDb
+      .prepare('INSERT INTO time_logs (item_id, started_at, ended_at, duration_hours) VALUES (?, ?, ?, ?)')
+      .run(item.id, '2026-08-14T10:00:00.000Z', '2026-08-14T11:00:00.000Z', 1);
+
+    const res = await GET(new Request('http://localhost/api/calibration?start=2026-08-14&end=2026-08-14'));
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0].estimateMinutes).toBe(30);
+    expect(body[0].actualMinutes).toBe(60);
+  });
+});

--- a/app/api/calibration/route.ts
+++ b/app/api/calibration/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { getCalibrationSummary } from '@/lib/calibration';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const start = url.searchParams.get('start') ?? '';
+  const end = url.searchParams.get('end') ?? '';
+  return NextResponse.json(getCalibrationSummary(db, start, end));
+}

--- a/app/api/items/[id]/park/route.test.ts
+++ b/app/api/items/[id]/park/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { upsertSyncedItem, setStatus } from '@/lib/items-repo';
+import { startTimer, listLogsByItem } from '@/lib/time-logs-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM time_logs; DELETE FROM items;');
+});
+
+describe('POST /api/items/:id/park', () => {
+  it('stops the running timer when parking', async () => {
+    const item = upsertSyncedItem(testDb, {
+      source: 'ado_workitem',
+      externalId: '1',
+      title: 'Parked with a running timer',
+      url: null,
+      reason: 'assigned',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: null,
+      repo: null,
+    });
+    setStatus(testDb, item.id, 'in_progress');
+    startTimer(testDb, item.id);
+
+    await POST(new Request('http://localhost', { method: 'POST' }), { params: { id: String(item.id) } });
+
+    const logs = listLogsByItem(testDb, item.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].endedAt).not.toBeNull();
+  });
+});

--- a/app/api/items/[id]/park/route.ts
+++ b/app/api/items/[id]/park/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { setParked, getItemById } from '@/lib/items-repo';
+import { stopTimer } from '@/lib/time-logs-repo';
 
 export async function POST(_request: Request, { params }: { params: { id: string } }) {
   const id = Number(params.id);
+  stopTimer(db, id);
   setParked(db, id, true);
   return NextResponse.json(getItemById(db, id));
 }

--- a/app/api/items/[id]/stop-timer/route.test.ts
+++ b/app/api/items/[id]/stop-timer/route.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem, setStatus } from '@/lib/items-repo';
+import { startTimer, listLogsByItem } from '@/lib/time-logs-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM time_logs; DELETE FROM items;');
+});
+
+describe('POST /api/items/:id/stop-timer', () => {
+  it('stops the running timer without changing status', async () => {
+    const item = createAdhocItem(testDb, { title: 'Running' });
+    setStatus(testDb, item.id, 'in_progress');
+    startTimer(testDb, item.id);
+
+    const res = await POST(new Request('http://localhost', { method: 'POST' }), { params: { id: String(item.id) } });
+    const body = await res.json();
+    expect(body.status).toBe('in_progress');
+    expect(listLogsByItem(testDb, item.id)[0].endedAt).not.toBeNull();
+  });
+});

--- a/app/api/items/[id]/stop-timer/route.ts
+++ b/app/api/items/[id]/stop-timer/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { getItemById } from '@/lib/items-repo';
+import { stopTimer } from '@/lib/time-logs-repo';
+
+export async function POST(_request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  stopTimer(db, id);
+  return NextResponse.json(getItemById(db, id));
+}

--- a/app/api/items/[id]/today/route.test.ts
+++ b/app/api/items/[id]/today/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { openDb } from '@/lib/db';
 import { createAdhocItem, getItemById } from '@/lib/items-repo';
 import { localDateString, addDays } from '@/lib/date';
+import { getPlanItems } from '@/lib/plans-repo';
 
 const testDb = openDb(':memory:');
 vi.mock('@/lib/db-instance', () => ({ db: testDb }));
@@ -11,7 +12,7 @@ const { POST: pinToday, DELETE: unpinToday } = await import('./route');
 let itemId: number;
 
 beforeEach(() => {
-  testDb.exec('DELETE FROM time_logs; DELETE FROM items;');
+  testDb.exec('DELETE FROM time_logs; DELETE FROM plan_items; DELETE FROM plans; DELETE FROM items;');
   itemId = createAdhocItem(testDb, { title: 'Test item' }).id;
 });
 
@@ -42,5 +43,25 @@ describe('DELETE /api/items/[id]/today', () => {
     });
     expect((await res.json()).todayDate).toBeNull();
     expect(getItemById(testDb, itemId)?.todayDate).toBeNull();
+  });
+});
+
+describe('POST /api/items/[id]/today plan integration', () => {
+  it('adds the item to the plan for the pinned date', async () => {
+    await pinToday(
+      new Request('http://localhost', { method: 'POST', body: JSON.stringify({ date: '2026-08-20' }) }),
+      { params: { id: String(itemId) } }
+    );
+    const items = getPlanItems(testDb, '2026-08-20');
+    expect(items.map((i) => i.itemId)).toEqual([itemId]);
+  });
+});
+
+describe('DELETE /api/items/[id]/today plan integration', () => {
+  it('removes the item from its plan when unpinned', async () => {
+    await pinToday(new Request('http://localhost', { method: 'POST', body: '{}' }), { params: { id: String(itemId) } });
+    const today = localDateString(new Date());
+    await unpinToday(new Request('http://localhost', { method: 'DELETE' }), { params: { id: String(itemId) } });
+    expect(getPlanItems(testDb, today)).toEqual([]);
   });
 });

--- a/app/api/items/[id]/today/route.ts
+++ b/app/api/items/[id]/today/route.ts
@@ -2,17 +2,21 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { setTodayDate, getItemById } from '@/lib/items-repo';
 import { localDateString } from '@/lib/date';
+import { addPlanItem, removePlanItem } from '@/lib/plans-repo';
 
 export async function POST(request: Request, { params }: { params: { id: string } }) {
   const id = Number(params.id);
   const body = (await request.json().catch(() => ({}))) as { date?: string };
   const date = body.date ?? localDateString(new Date());
   setTodayDate(db, id, date);
+  addPlanItem(db, date, id);
   return NextResponse.json(getItemById(db, id));
 }
 
 export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
   const id = Number(params.id);
+  const item = getItemById(db, id);
+  if (item?.todayDate) removePlanItem(db, item.todayDate, id);
   setTodayDate(db, id, null);
   return NextResponse.json(getItemById(db, id));
 }

--- a/app/api/plan/items/estimate/route.test.ts
+++ b/app/api/plan/items/estimate/route.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem } from '@/lib/items-repo';
+import { addPlanItem, getPlanItems } from '@/lib/plans-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM plan_items; DELETE FROM plans; DELETE FROM items;');
+});
+
+describe('POST /api/plan/items/estimate', () => {
+  it('sets an estimate in minutes', async () => {
+    const item = createAdhocItem(testDb, { title: 'Estimate me' });
+    addPlanItem(testDb, '2026-08-14', item.id);
+    await POST(
+      new Request('http://localhost/api/plan/items/estimate', {
+        method: 'POST',
+        body: JSON.stringify({ date: '2026-08-14', itemId: item.id, minutes: 90 }),
+      })
+    );
+    expect(getPlanItems(testDb, '2026-08-14')[0].estimateMinutes).toBe(90);
+  });
+});

--- a/app/api/plan/items/estimate/route.ts
+++ b/app/api/plan/items/estimate/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { setPlanItemEstimate } from '@/lib/plans-repo';
+
+export async function POST(request: Request) {
+  const { date, itemId, minutes } = await request.json();
+  setPlanItemEstimate(db, date, itemId, minutes);
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/plan/items/reorder/route.test.ts
+++ b/app/api/plan/items/reorder/route.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem } from '@/lib/items-repo';
+import { addPlanItem } from '@/lib/plans-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { PUT } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM plan_items; DELETE FROM plans; DELETE FROM items;');
+});
+
+describe('PUT /api/plan/items/reorder', () => {
+  it('reassigns sort order', async () => {
+    const a = createAdhocItem(testDb, { title: 'A' });
+    const b = createAdhocItem(testDb, { title: 'B' });
+    addPlanItem(testDb, '2026-08-14', a.id);
+    addPlanItem(testDb, '2026-08-14', b.id);
+
+    const res = await PUT(
+      new Request('http://localhost/api/plan/items/reorder', {
+        method: 'PUT',
+        body: JSON.stringify({ date: '2026-08-14', orderedItemIds: [b.id, a.id] }),
+      })
+    );
+    const body = await res.json();
+    expect(body.map((i: any) => i.itemId)).toEqual([b.id, a.id]);
+  });
+});

--- a/app/api/plan/items/reorder/route.ts
+++ b/app/api/plan/items/reorder/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { reorderPlanItems } from '@/lib/plans-repo';
+
+export async function PUT(request: Request) {
+  const { date, orderedItemIds } = await request.json();
+  return NextResponse.json(reorderPlanItems(db, date, orderedItemIds));
+}

--- a/app/api/plan/items/route.test.ts
+++ b/app/api/plan/items/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem } from '@/lib/items-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST, DELETE } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM plan_items; DELETE FROM plans; DELETE FROM items;');
+});
+
+describe('/api/plan/items', () => {
+  it('adds an item to the plan', async () => {
+    const item = createAdhocItem(testDb, { title: 'Pick me' });
+    const res = await POST(
+      new Request('http://localhost/api/plan/items', {
+        method: 'POST',
+        body: JSON.stringify({ date: '2026-08-14', itemId: item.id }),
+      })
+    );
+    expect((await res.json()).itemId).toBe(item.id);
+  });
+
+  it('removes an item from the plan', async () => {
+    const item = createAdhocItem(testDb, { title: 'Remove me' });
+    await POST(
+      new Request('http://localhost/api/plan/items', {
+        method: 'POST',
+        body: JSON.stringify({ date: '2026-08-14', itemId: item.id }),
+      })
+    );
+    const res = await DELETE(
+      new Request('http://localhost/api/plan/items?date=2026-08-14&itemId=' + item.id, { method: 'DELETE' })
+    );
+    expect(res.status).toBe(204);
+  });
+});

--- a/app/api/plan/items/route.ts
+++ b/app/api/plan/items/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { addPlanItem, removePlanItem } from '@/lib/plans-repo';
+
+export async function POST(request: Request) {
+  const { date, itemId } = await request.json();
+  return NextResponse.json(addPlanItem(db, date, itemId));
+}
+
+export async function DELETE(request: Request) {
+  const url = new URL(request.url);
+  const date = url.searchParams.get('date') ?? '';
+  const itemId = Number(url.searchParams.get('itemId'));
+  removePlanItem(db, date, itemId);
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/plan/route.test.ts
+++ b/app/api/plan/route.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { GET, POST } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM plan_items; DELETE FROM plans;');
+});
+
+describe('/api/plan', () => {
+  it('returns the default plan and empty items for an unplanned date', async () => {
+    const res = await GET(new Request('http://localhost/api/plan?date=2026-08-14'));
+    const body = await res.json();
+    expect(body.plan.date).toBe('2026-08-14');
+    expect(body.items).toEqual([]);
+  });
+
+  it('updates capacity and note', async () => {
+    const res = await POST(
+      new Request('http://localhost/api/plan', {
+        method: 'POST',
+        body: JSON.stringify({ date: '2026-08-14', capacityMinutes: 240, note: 'Light day' }),
+      })
+    );
+    const body = await res.json();
+    expect(body).toEqual({ date: '2026-08-14', capacityMinutes: 240, note: 'Light day' });
+  });
+});

--- a/app/api/plan/route.ts
+++ b/app/api/plan/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { getPlan, upsertPlan, getPlanItems } from '@/lib/plans-repo';
+
+export async function GET(request: Request) {
+  const date = new URL(request.url).searchParams.get('date') ?? '';
+  return NextResponse.json({ plan: getPlan(db, date), items: getPlanItems(db, date) });
+}
+
+export async function POST(request: Request) {
+  const { date, capacityMinutes, note } = await request.json();
+  return NextResponse.json(upsertPlan(db, date, { capacityMinutes, note }));
+}

--- a/app/api/sync-status/route.test.ts
+++ b/app/api/sync-status/route.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import { openDb } from '@/lib/db';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { GET } = await import('./route');
+
+describe('GET /api/sync-status', () => {
+  it('returns both sources', async () => {
+    const body = await (await GET()).json();
+    expect(body.map((s: any) => s.source)).toEqual(['github', 'ado']);
+  });
+});

--- a/app/api/sync-status/route.ts
+++ b/app/api/sync-status/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { getAllSourceStatuses } from '@/lib/sync-status';
+
+export async function GET() {
+  return NextResponse.json(getAllSourceStatuses(db, new Date()));
+}

--- a/app/api/timer/running/route.test.ts
+++ b/app/api/timer/running/route.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem, setStatus } from '@/lib/items-repo';
+import { startTimer } from '@/lib/time-logs-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { GET } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM time_logs; DELETE FROM items;');
+});
+
+describe('GET /api/timer/running', () => {
+  it('returns null when nothing is running', async () => {
+    expect(await (await GET()).json()).toBeNull();
+  });
+
+  it('returns the running item', async () => {
+    const item = createAdhocItem(testDb, { title: 'Running' });
+    setStatus(testDb, item.id, 'in_progress');
+    startTimer(testDb, item.id);
+    const body = await (await GET()).json();
+    expect(body.itemId).toBe(item.id);
+  });
+});

--- a/app/api/timer/running/route.ts
+++ b/app/api/timer/running/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { getRunningTimer } from '@/lib/time-logs-repo';
+
+export async function GET() {
+  return NextResponse.json(getRunningTimer(db));
+}

--- a/app/api/today/summary/route.test.ts
+++ b/app/api/today/summary/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { openDb } from '@/lib/db';
 import { createAdhocItem, setStatus } from '@/lib/items-repo';
+import { addPlanItem, setPlanItemEstimate } from '@/lib/plans-repo';
 import { localDateString } from '@/lib/date';
 
 const testDb = openDb(':memory:');
@@ -9,7 +10,7 @@ vi.mock('@/lib/db-instance', () => ({ db: testDb }));
 const { GET: summary } = await import('./route');
 
 beforeEach(() => {
-  testDb.exec('DELETE FROM time_logs; DELETE FROM items;');
+  testDb.exec('DELETE FROM time_logs; DELETE FROM plan_items; DELETE FROM items;');
 });
 
 describe('GET /api/today/summary', () => {
@@ -27,6 +28,26 @@ describe('GET /api/today/summary', () => {
     expect(body.doneToday).toHaveLength(1);
     expect(body.doneToday[0].hoursLoggedToday).toBe(2);
     expect(body.hoursLoggedToday).toBe(2);
+  });
+
+  it('carries the plan_items estimate for a done item, and null when there is none', async () => {
+    const dateStr = localDateString(new Date());
+    const estimated = createAdhocItem(testDb, { title: 'Estimated' });
+    addPlanItem(testDb, dateStr, estimated.id);
+    setPlanItemEstimate(testDb, dateStr, estimated.id, 30);
+    setStatus(testDb, estimated.id, 'in_progress');
+    setStatus(testDb, estimated.id, 'done', new Date().toISOString());
+
+    const unestimated = createAdhocItem(testDb, { title: 'Unestimated' });
+    testDb.prepare('UPDATE items SET today_date = ? WHERE id = ?').run(dateStr, unestimated.id);
+    setStatus(testDb, unestimated.id, 'in_progress');
+    setStatus(testDb, unestimated.id, 'done', new Date().toISOString());
+
+    const res = await summary();
+    const body = await res.json();
+    const byTitle = (title: string) => body.doneToday.find((i: { title: string }) => i.title === title);
+    expect(byTitle('Estimated').estimateMinutes).toBe(30);
+    expect(byTitle('Unestimated').estimateMinutes).toBeNull();
   });
 
   it('returns a still-open planned item with no hoursLoggedToday enrichment needed', async () => {

--- a/app/api/today/summary/route.test.ts
+++ b/app/api/today/summary/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { openDb } from '@/lib/db';
 import { createAdhocItem, setStatus } from '@/lib/items-repo';
 import { addPlanItem, setPlanItemEstimate } from '@/lib/plans-repo';
-import { localDateString } from '@/lib/date';
+import { localDateString, addDays } from '@/lib/date';
 
 const testDb = openDb(':memory:');
 vi.mock('@/lib/db-instance', () => ({ db: testDb }));
@@ -23,7 +23,7 @@ describe('GET /api/today/summary', () => {
       .prepare('INSERT INTO time_logs (item_id, started_at, ended_at, duration_hours) VALUES (?, ?, ?, ?)')
       .run(item.id, new Date().toISOString(), new Date().toISOString(), 2);
 
-    const res = await summary();
+    const res = await summary(new Request('http://localhost/api/today/summary'));
     const body = await res.json();
     expect(body.doneToday).toHaveLength(1);
     expect(body.doneToday[0].hoursLoggedToday).toBe(2);
@@ -43,18 +43,29 @@ describe('GET /api/today/summary', () => {
     setStatus(testDb, unestimated.id, 'in_progress');
     setStatus(testDb, unestimated.id, 'done', new Date().toISOString());
 
-    const res = await summary();
+    const res = await summary(new Request('http://localhost/api/today/summary'));
     const body = await res.json();
     const byTitle = (title: string) => body.doneToday.find((i: { title: string }) => i.title === title);
     expect(byTitle('Estimated').estimateMinutes).toBe(30);
     expect(byTitle('Unestimated').estimateMinutes).toBeNull();
   });
 
+  it('reads the date from the ?date= query param instead of always using today', async () => {
+    const yesterday = addDays(localDateString(new Date()), -1);
+    const item = createAdhocItem(testDb, { title: 'Yesterday item' });
+    testDb.prepare('UPDATE items SET today_date = ? WHERE id = ?').run(yesterday, item.id);
+
+    const res = await summary(new Request(`http://localhost/api/today/summary?date=${yesterday}`));
+    const body = await res.json();
+    expect(body.planned).toHaveLength(1);
+    expect(body.planned[0].id).toBe(item.id);
+  });
+
   it('returns a still-open planned item with no hoursLoggedToday enrichment needed', async () => {
     const item = createAdhocItem(testDb, { title: 'Still open' });
     testDb.prepare('UPDATE items SET today_date = ? WHERE id = ?').run(localDateString(new Date()), item.id);
 
-    const res = await summary();
+    const res = await summary(new Request('http://localhost/api/today/summary'));
     const body = await res.json();
     expect(body.planned).toHaveLength(1);
     expect(body.planned[0].id).toBe(item.id);

--- a/app/api/today/summary/route.ts
+++ b/app/api/today/summary/route.ts
@@ -5,9 +5,10 @@ import { sumHoursLoggedOnByItem } from '@/lib/time-logs-repo';
 import { getPlanItems } from '@/lib/plans-repo';
 import { localDateString } from '@/lib/date';
 
-export async function GET() {
+export async function GET(request: Request) {
   const now = new Date();
-  const date = localDateString(now);
+  const dateParam = new URL(request.url).searchParams.get('date');
+  const date = dateParam ?? localDateString(now);
   const summary = getTodaySummary(db, date, now);
   const hoursByItem = sumHoursLoggedOnByItem(db, date);
   const estimateByItem = new Map(getPlanItems(db, date).map((pi) => [pi.itemId, pi.estimateMinutes]));

--- a/app/api/today/summary/route.ts
+++ b/app/api/today/summary/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { getTodaySummary } from '@/lib/dashboard';
 import { sumHoursLoggedOnByItem } from '@/lib/time-logs-repo';
+import { getPlanItems } from '@/lib/plans-repo';
 import { localDateString } from '@/lib/date';
 
 export async function GET() {
@@ -9,12 +10,14 @@ export async function GET() {
   const date = localDateString(now);
   const summary = getTodaySummary(db, date, now);
   const hoursByItem = sumHoursLoggedOnByItem(db, date);
+  const estimateByItem = new Map(getPlanItems(db, date).map((pi) => [pi.itemId, pi.estimateMinutes]));
 
   return NextResponse.json({
     ...summary,
     doneToday: summary.doneToday.map((item) => ({
       ...item,
       hoursLoggedToday: hoursByItem.get(item.id) ?? 0,
+      estimateMinutes: estimateByItem.get(item.id) ?? null,
     })),
   });
 }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -36,11 +36,14 @@ import {
   unsnoozeItem,
   setItemDone,
   fetchSavedViews,
+  fetchSourceStatuses,
 } from '@/lib/api-client';
 import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
+import { groupOf } from '@/lib/grouping';
 import type { ScoredItem } from '@/lib/dashboard';
 import type { SprintProgress } from '@/lib/sprint';
 import type { SavedView } from '@/lib/saved-views';
+import type { SourceStatus } from '@/lib/sync-status';
 
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -55,13 +58,13 @@ interface DashboardData {
 export default function Dashboard({ initialData }: { initialData: DashboardData }) {
   const [data, setData] = useState<DashboardData>(initialData);
   const [syncing, setSyncing] = useState(false);
-  const [syncErrors, setSyncErrors] = useState<string[]>([]);
   const [reviewDayOpen, setReviewDayOpen] = useState(false);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [inProgressAccordion, setInProgressAccordion] = useState<string[]>(['in-progress']);
   const [helpOpen, setHelpOpen] = useState(false);
   const [signalsQuery, setSignalsQuery] = useState('');
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
+  const [sourceStatuses, setSourceStatuses] = useState<SourceStatus[]>([]);
 
   const autoSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
@@ -75,6 +78,7 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
 
   useEffect(() => {
     fetchSavedViews().then(setSavedViews);
+    fetchSourceStatuses().then(setSourceStatuses);
   }, []);
 
   function scheduleAutoSync() {
@@ -86,19 +90,16 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   }
 
   async function refresh() {
-    const fresh = await fetchDashboardData();
+    const [fresh, statuses] = await Promise.all([fetchDashboardData(), fetchSourceStatuses()]);
     setData(fresh);
+    setSourceStatuses(statuses);
   }
 
   async function handleRefresh() {
     setSyncing(true);
-    setSyncErrors([]);
     try {
-      const { outcomes } = await triggerSync();
-      setSyncErrors(outcomes.filter((o: any) => o.error).map((o: any) => `${o.source}: ${o.error}`));
+      await triggerSync();
       await refresh();
-    } catch (err) {
-      setSyncErrors([`Sync failed: ${err instanceof Error ? err.message : 'unknown error'}`]);
     } finally {
       setSyncing(false);
       scheduleAutoSync();
@@ -252,6 +253,8 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, data]);
 
+  const needsYouCount = data.signals.filter((i) => groupOf(i) === 'blocked' || groupOf(i) === 'waiting_on_you').length;
+
   const trimmedQuery = query.trim();
   const hasAnyMatch =
     trimmedQuery === '' ||
@@ -271,9 +274,10 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
     <main className="mx-auto max-w-6xl space-y-6 p-6">
       <SprintProgressHeader
         sprint={data.sprint}
+        sourceStatuses={sourceStatuses}
+        needsYouCount={needsYouCount}
         onRefresh={handleRefresh}
         syncing={syncing}
-        errors={syncErrors}
         onAddClick={() => setQuickAddOpen(true)}
       />
       <QuickAddForm open={quickAddOpen} onOpenChange={setQuickAddOpen} onSubmit={handleQuickAdd} />

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -14,6 +14,8 @@ import SignalsBoard from './SignalsBoard';
 import QuickAddForm from './QuickAddForm';
 import TodaySection from './TodaySection';
 import ShutdownDialog from './ShutdownDialog';
+import PlanDayDialog from './PlanDayDialog';
+import SwitchTimerDialog from './SwitchTimerDialog';
 import GlobalKeymapProvider from './GlobalKeymapProvider';
 import KeymapHelpDialog from './KeymapHelpDialog';
 import CommandPalette from './CommandPalette';
@@ -37,14 +39,26 @@ import {
   setItemDone,
   fetchSavedViews,
   fetchSourceStatuses,
+  fetchRunningTimer,
+  stopTimerRequest,
+  fetchPlan,
+  updatePlan,
+  reorderPlan,
+  setEstimate,
+  fetchTodaySummaryFor,
+  fetchCalibration,
 } from '@/lib/api-client';
 import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
 import { groupOf } from '@/lib/grouping';
+import { localDateString, addDays } from '@/lib/date';
+import { DEFAULT_CAPACITY_MINUTES } from '@/lib/config';
+import type { RunningTimer } from '@/lib/time-logs-repo';
+import type { CalibrationEntry } from '@/lib/calibration';
 import type { ScoredItem } from '@/lib/dashboard';
 import type { SprintProgress } from '@/lib/sprint';
 import type { SavedView } from '@/lib/saved-views';
 import type { SourceStatus } from '@/lib/sync-status';
-import type { Item } from '@/lib/types';
+import type { Item, Plan, PlanItem } from '@/lib/types';
 
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -66,6 +80,18 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   const [signalsQuery, setSignalsQuery] = useState('');
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
   const [sourceStatuses, setSourceStatuses] = useState<SourceStatus[]>([]);
+  const [planDayOpen, setPlanDayOpen] = useState(false);
+  const [runningTimer, setRunningTimer] = useState<RunningTimer | null>(null);
+  const [switchTimerOpen, setSwitchTimerOpen] = useState(false);
+  const [pendingStartId, setPendingStartId] = useState<number | null>(null);
+  const [yesterdayItems, setYesterdayItems] = useState<Item[]>([]);
+  const [plan, setPlan] = useState<Plan>({
+    date: localDateString(new Date()),
+    capacityMinutes: DEFAULT_CAPACITY_MINUTES,
+    note: null,
+  });
+  const [planItems, setPlanItems] = useState<PlanItem[]>([]);
+  const [calibration, setCalibration] = useState<CalibrationEntry[]>([]);
 
   const autoSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
@@ -79,7 +105,17 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
 
   useEffect(() => {
     fetchSavedViews().then(setSavedViews);
+    const today = localDateString(new Date());
+    const yesterday = addDays(today, -1);
     fetchSourceStatuses().then(setSourceStatuses);
+    fetchRunningTimer().then(setRunningTimer);
+    fetchPlan(today).then((planResponse) => {
+      setPlan(planResponse.plan);
+      setPlanItems(planResponse.items);
+    });
+    fetchTodaySummaryFor(yesterday).then((summary) => setYesterdayItems(summary.planned));
+    fetchCalibration(today, today).then(setCalibration);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function scheduleAutoSync() {
@@ -91,9 +127,23 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   }
 
   async function refresh() {
-    const [fresh, statuses] = await Promise.all([fetchDashboardData(), fetchSourceStatuses()]);
+    const today = localDateString(new Date());
+    const yesterday = addDays(today, -1);
+    const [fresh, statuses, timer, planResponse, yesterdaySummary, calibrationSummary] = await Promise.all([
+      fetchDashboardData(),
+      fetchSourceStatuses(),
+      fetchRunningTimer(),
+      fetchPlan(today),
+      fetchTodaySummaryFor(yesterday),
+      fetchCalibration(today, today),
+    ]);
     setData(fresh);
     setSourceStatuses(statuses);
+    setRunningTimer(timer);
+    setPlan(planResponse.plan);
+    setPlanItems(planResponse.items);
+    setYesterdayItems(yesterdaySummary.planned);
+    setCalibration(calibrationSummary);
   }
 
   async function handleRefresh() {
@@ -108,7 +158,43 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   }
 
   async function handleStart(id: number) {
+    if (runningTimer && runningTimer.itemId !== id) {
+      setPendingStartId(id);
+      setSwitchTimerOpen(true);
+      return;
+    }
     await startItem(id);
+    await refresh();
+  }
+
+  async function handleJustStopTimer() {
+    if (runningTimer) await stopTimerRequest(runningTimer.itemId);
+    setSwitchTimerOpen(false);
+    setPendingStartId(null);
+    await refresh();
+  }
+
+  async function handleSwitchTimer() {
+    if (runningTimer) await stopTimerRequest(runningTimer.itemId);
+    if (pendingStartId !== null) await startItem(pendingStartId);
+    setSwitchTimerOpen(false);
+    setPendingStartId(null);
+    await refresh();
+  }
+
+  async function handleReorderToday(orderedItemIds: number[]) {
+    const today = localDateString(new Date());
+    await reorderPlan(today, orderedItemIds);
+    await refresh();
+  }
+
+  async function handleSetEstimate(id: number, minutes: number | null) {
+    await setEstimate(localDateString(new Date()), id, minutes);
+    await refresh();
+  }
+
+  async function handleSetCapacity(minutes: number) {
+    await updatePlan(localDateString(new Date()), { capacityMinutes: minutes });
     await refresh();
   }
 
@@ -280,6 +366,7 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
       onOpenHelp={() => setHelpOpen(true)}
       onGoToDashboard={() => router.push('/')}
       onGoToSettings={() => router.push('/settings')}
+      onPlanDay={() => setPlanDayOpen(true)}
     >
     <main className="mx-auto max-w-6xl space-y-6 p-6">
       <SprintProgressHeader
@@ -294,12 +381,14 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
       {!hasAnyMatch && <p className="text-sm text-muted-foreground">No matches for &ldquo;{trimmedQuery}&rdquo;.</p>}
       <TodaySection
         items={data.today}
+        capacityMinutes={plan.capacityMinutes}
         onStart={handleStart}
         onComplete={handleComplete}
         onOpenClaude={handleOpenClaude}
         onDelete={handleDelete}
         onUnpinToday={handleUnpinToday}
-        onReviewDay={() => setReviewDayOpen(true)}
+        onPlanDay={() => setPlanDayOpen(true)}
+        onReorder={handleReorderToday}
         failingSources={failingSources}
       />
       <Card>
@@ -346,6 +435,32 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
         onCarried={refresh}
         onSnooze={handleSnooze}
         onDrop={handleUnpinToday}
+        calibration={calibration}
+      />
+      <PlanDayDialog
+        open={planDayOpen}
+        onOpenChange={setPlanDayOpen}
+        today={data.today}
+        signals={data.signals}
+        yesterday={yesterdayItems}
+        plan={plan}
+        planItems={planItems}
+        onKeep={handlePinToday}
+        onSnooze={handleSnooze}
+        onDone={handleDone}
+        onDrop={handleUnpinToday}
+        onAdd={handlePinToday}
+        onSetEstimate={handleSetEstimate}
+        onReorder={handleReorderToday}
+        onSetCapacity={handleSetCapacity}
+        calibration={calibration}
+      />
+      <SwitchTimerDialog
+        open={switchTimerOpen}
+        onOpenChange={setSwitchTimerOpen}
+        currentTitle={runningTimer?.itemTitle ?? ''}
+        onJustStop={handleJustStopTimer}
+        onSwitch={handleSwitchTimer}
       />
       <KeymapHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
       <CommandPalette

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -340,7 +340,13 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
         savedViews={savedViews}
         onSavedViewsChange={setSavedViews}
       />
-      <ShutdownDialog open={reviewDayOpen} onOpenChange={setReviewDayOpen} onCarried={refresh} />
+      <ShutdownDialog
+        open={reviewDayOpen}
+        onOpenChange={setReviewDayOpen}
+        onCarried={refresh}
+        onSnooze={handleSnooze}
+        onDrop={handleUnpinToday}
+      />
       <KeymapHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
       <CommandPalette
         open={paletteOpen}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -44,6 +44,7 @@ import type { ScoredItem } from '@/lib/dashboard';
 import type { SprintProgress } from '@/lib/sprint';
 import type { SavedView } from '@/lib/saved-views';
 import type { SourceStatus } from '@/lib/sync-status';
+import type { Item } from '@/lib/types';
 
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -254,6 +255,15 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
   }, [query, data]);
 
   const needsYouCount = data.signals.filter((i) => groupOf(i) === 'blocked' || groupOf(i) === 'waiting_on_you').length;
+  const SOURCE_STATUS_TO_ITEM_SOURCE: Record<SourceStatus['source'], Item['source']> = {
+    github: 'github_pr',
+    ado: 'ado_workitem',
+  };
+  const failingSources = new Set(
+    sourceStatuses
+      .filter((s) => s.state === 'error' || s.state === 'partial')
+      .map((s) => SOURCE_STATUS_TO_ITEM_SOURCE[s.source])
+  );
 
   const trimmedQuery = query.trim();
   const hasAnyMatch =
@@ -290,6 +300,7 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
         onDelete={handleDelete}
         onUnpinToday={handleUnpinToday}
         onReviewDay={() => setReviewDayOpen(true)}
+        failingSources={failingSources}
       />
       <Card>
         <CardContent className="pt-6">
@@ -306,6 +317,7 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
               onRequeue={handleRequeue}
               onPark={handlePark}
               onUnpark={handleUnpark}
+              failingSources={failingSources}
             />
           </Accordion>
         </CardContent>
@@ -317,6 +329,7 @@ export default function Dashboard({ initialData }: { initialData: DashboardData 
         onOpenClaude={handleOpenClaude}
         onDelete={handleDelete}
         onPinToday={handlePinToday}
+        failingSources={failingSources}
         onStar={handleStar}
         onSnooze={handleSnooze}
         onUnsnooze={handleUnsnooze}

--- a/components/GlobalKeymapProvider.tsx
+++ b/components/GlobalKeymapProvider.tsx
@@ -13,6 +13,7 @@ interface Props {
   onOpenHelp: () => void;
   onGoToDashboard: () => void;
   onGoToSettings: () => void;
+  onPlanDay: () => void;
 }
 
 export default function GlobalKeymapProvider({
@@ -25,6 +26,7 @@ export default function GlobalKeymapProvider({
   onOpenHelp,
   onGoToDashboard,
   onGoToSettings,
+  onPlanDay,
 }: Props) {
   useEffect(() => {
     let pendingG = false;
@@ -68,6 +70,9 @@ export default function GlobalKeymapProvider({
         case 'w':
           onWrapUp();
           return;
+        case 'p':
+          onPlanDay();
+          return;
         case 'g':
           pendingG = true;
           pendingGTimeout = setTimeout(() => {
@@ -82,7 +87,17 @@ export default function GlobalKeymapProvider({
       document.removeEventListener('keydown', handleKeyDown);
       if (pendingGTimeout) clearTimeout(pendingGTimeout);
     };
-  }, [onOpenPalette, onFocusQueryBar, onUndo, onRefresh, onWrapUp, onOpenHelp, onGoToDashboard, onGoToSettings]);
+  }, [
+    onOpenPalette,
+    onFocusQueryBar,
+    onUndo,
+    onRefresh,
+    onWrapUp,
+    onOpenHelp,
+    onGoToDashboard,
+    onGoToSettings,
+    onPlanDay,
+  ]);
 
   return <>{children}</>;
 }

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -110,7 +110,13 @@ export const SOURCE_ICON = {
 } as const;
 
 interface Props {
-  item: Item & { score: number; scoreBreakdown?: ScoreBreakdownEntry[]; notFired?: string[]; links?: LinkedRef[] };
+  item: Item & {
+    score: number;
+    scoreBreakdown?: ScoreBreakdownEntry[];
+    notFired?: string[];
+    links?: LinkedRef[];
+    estimateMinutes?: number | null;
+  };
   onStart?: (id: number) => void;
   onRequeue?: (id: number) => void;
   onComplete: (id: number, durationHours: number, note?: string) => void;
@@ -438,6 +444,11 @@ export default function ItemRow({
           <DialogTitle>Mark complete</DialogTitle>
         </DialogHeader>
         <div className="grid gap-4 py-2">
+          {item.estimateMinutes != null && (
+            <p className="text-sm text-muted-foreground">
+              Estimated {Math.floor(item.estimateMinutes / 60)}h {item.estimateMinutes % 60}m
+            </p>
+          )}
           <div className="grid gap-1.5">
             <Label htmlFor={`duration-${item.id}`}>Hours spent</Label>
             <Input

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -37,7 +37,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { cn } from '@/lib/utils';
+import { cn, formatRelativeTime } from '@/lib/utils';
 import { REASON_LABEL, type ScoreBreakdownEntry } from '@/lib/scoring';
 import { getStatusPill, type BadgeVariant } from '@/lib/status-pill';
 import { isKeptVisible } from '@/lib/grouping';
@@ -124,6 +124,7 @@ interface Props {
   onSnooze?: (id: number, option: SnoozeOption) => void;
   onUnsnooze?: (id: number) => void;
   onDone?: (id: number, done: boolean) => void;
+  sourceIsStale?: boolean;
 }
 
 function actionableLinks(links: LinkedRef[] | undefined, targetStatus: Status): LinkedRef[] {
@@ -317,6 +318,7 @@ export default function ItemRow({
   onSnooze,
   onUnsnooze,
   onDone,
+  sourceIsStale,
 }: Props) {
   const Icon = SOURCE_ICON[item.source];
   const { query } = useSearch();
@@ -710,11 +712,15 @@ export default function ItemRow({
               </Badge>
             )}
           </div>
-          {(item.repo || item.wokeEarly) && density === 'comfortable' && (
+          {(item.repo || item.wokeEarly || sourceIsStale) && density === 'comfortable' && (
             <span className="block truncate text-xs text-muted-foreground" title={item.repo ?? undefined}>
               {item.repo}
-              {item.repo && item.wokeEarly && ' · '}
+              {item.repo && (item.wokeEarly || sourceIsStale) && ' · '}
               {item.wokeEarly && 'woke early'}
+              {item.wokeEarly && sourceIsStale && ' · '}
+              {sourceIsStale && item.rawUpdatedAt && (
+                <span className="text-warning">stale · read {formatRelativeTime(new Date(item.rawUpdatedAt).getTime())}</span>
+              )}
             </span>
           )}
         </div>

--- a/components/ItemSection.tsx
+++ b/components/ItemSection.tsx
@@ -3,6 +3,7 @@
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import ItemRow from './ItemRow';
 import type { ScoredItem } from '@/lib/dashboard';
+import type { Source } from '@/lib/types';
 
 interface Props {
   value: string;
@@ -19,6 +20,7 @@ interface Props {
   onUnpark?: (id: number) => void;
   onPinToday?: (id: number) => void;
   onUnpinToday?: (id: number) => void;
+  failingSources?: Set<Source>;
 }
 
 export default function ItemSection({
@@ -36,6 +38,7 @@ export default function ItemSection({
   onUnpark,
   onPinToday,
   onUnpinToday,
+  failingSources,
 }: Props) {
   const isEmpty = items.length === 0 && (!parkedItems || parkedItems.length === 0);
   return (
@@ -66,6 +69,7 @@ export default function ItemSection({
                 onUnpark={onUnpark}
                 onPinToday={onPinToday}
                 onUnpinToday={onUnpinToday}
+                sourceIsStale={failingSources?.has(item.source)}
               />
             ))}
             {parkedItems && parkedItems.length > 0 && (

--- a/components/PlanDayDialog.tsx
+++ b/components/PlanDayDialog.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import ScoreChip from './ScoreChip';
+import { GROUP_ORDER, GROUP_LABEL, groupOf } from '@/lib/grouping';
+import { formatCalibrationSentence, type CalibrationEntry } from '@/lib/calibration';
+import type { ScoredItem } from '@/lib/dashboard';
+import type { Item, Plan, PlanItem } from '@/lib/types';
+import type { SnoozeOption } from '@/lib/snooze';
+
+type Step = 1 | 2 | 3 | 4;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  today: ScoredItem[];
+  signals: ScoredItem[];
+  yesterday: Item[];
+  plan: Plan;
+  planItems: PlanItem[];
+  onKeep: (id: number) => void;
+  onSnooze: (id: number, option: SnoozeOption) => void;
+  onDone: (id: number, done: boolean) => void;
+  onDrop: (id: number) => void;
+  onAdd: (id: number) => void;
+  onSetEstimate: (id: number, minutes: number | null) => void;
+  onReorder: (orderedIds: number[]) => void;
+  onSetCapacity: (minutes: number) => void;
+  calibration: CalibrationEntry[];
+}
+
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+
+function parseDurationInput(raw: string): number | null {
+  const match = raw.match(/^(?:(\d+)h)?\s*(?:(\d+)m)?$/i);
+  if (!match) return null;
+  const hours = Number(match[1] ?? 0);
+  const minutes = Number(match[2] ?? 0);
+  if (hours === 0 && minutes === 0) return null;
+  return hours * 60 + minutes;
+}
+
+export default function PlanDayDialog({
+  open,
+  onOpenChange,
+  today,
+  signals,
+  yesterday,
+  plan,
+  planItems,
+  onKeep,
+  onSnooze,
+  onDone,
+  onDrop,
+  onAdd,
+  onSetEstimate,
+  onReorder,
+  onSetCapacity,
+  calibration,
+}: Props) {
+  const [step, setStep] = useState<Step>(1);
+  const pickedIds = new Set(today.map((i) => i.id));
+  const totalEstimateMinutes = today.reduce((sum, i) => sum + (i.estimateMinutes ?? 0), 0);
+  const overMinutes = totalEstimateMinutes - plan.capacityMinutes;
+
+  function close() {
+    onOpenChange(false);
+    setStep(1);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(true) : close())}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Plan the day — step {step} of 4</DialogTitle>
+        </DialogHeader>
+
+        {step === 1 && (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              {yesterday.length === 0
+                ? "Nothing left over from yesterday."
+                : `${yesterday.length} of yesterday's picks are still open.`}
+            </p>
+            <div className="space-y-2">
+              {yesterday.map((item) => (
+                <div key={item.id} className="flex items-center justify-between gap-2 border-b pb-2 text-sm">
+                  <span className="min-w-0 truncate">{item.title}</span>
+                  <div className="flex shrink-0 gap-1">
+                    <Button type="button" size="sm" variant="outline" onClick={() => onKeep(item.id)}>
+                      Keep
+                    </Button>
+                    <Button type="button" size="sm" variant="outline" onClick={() => onSnooze(item.id, 'tomorrow')}>
+                      Snooze
+                    </Button>
+                    <Button type="button" size="sm" variant="outline" onClick={() => onDone(item.id, true)}>
+                      Done
+                    </Button>
+                    <Button type="button" size="sm" variant="ghost" onClick={() => onDrop(item.id)}>
+                      Drop
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-between pt-2">
+              <span />
+              <Button type="button" onClick={() => setStep(2)}>
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>Ordered by score. Nothing is recommended.</span>
+              <span className="font-mono tabular-nums">{today.length} picked</span>
+            </div>
+            <div className="max-h-80 space-y-3 overflow-y-auto">
+              {GROUP_ORDER.map((group) => {
+                const groupItems = signals.filter((i) => groupOf(i) === group);
+                if (groupItems.length === 0) return null;
+                return (
+                  <div key={group}>
+                    <p className="mb-1 text-xs font-medium text-muted-foreground">
+                      {GROUP_LABEL[group]} · {groupItems.length}
+                    </p>
+                    {groupItems.map((item) => (
+                      <div key={item.id} className="flex items-center justify-between gap-2 py-1 text-sm">
+                        <span className="flex min-w-0 items-center gap-2">
+                          <ScoreChip
+                            score={item.score}
+                            scoreBreakdown={item.scoreBreakdown}
+                            notFired={item.notFired}
+                            keptVisible={false}
+                            open={false}
+                            onOpenChange={() => {}}
+                          />
+                          <span className="min-w-0 truncate">{item.title}</span>
+                        </span>
+                        {pickedIds.has(item.id) ? (
+                          <span className="shrink-0 text-xs text-muted-foreground">Pinned ✓</span>
+                        ) : (
+                          <Button type="button" size="sm" variant="outline" onClick={() => onAdd(item.id)}>
+                            Add <kbd className="ml-1 font-mono text-xs">t</kbd>
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+            <div className="flex items-center justify-between pt-2">
+              <Button type="button" variant="ghost" onClick={() => setStep(1)}>
+                Back
+              </Button>
+              <Button type="button" onClick={() => setStep(3)}>
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">Optional. Drag to reorder, or use the arrows in Today.</p>
+            <div className="space-y-2">
+              {today.map((item) => (
+                <div key={item.id} className="flex items-center justify-between gap-2 border-b pb-2 text-sm">
+                  <span className="min-w-0 truncate">{item.title}</span>
+                  <Input
+                    defaultValue={item.estimateMinutes ? formatMinutes(item.estimateMinutes) : ''}
+                    placeholder="e.g. 1h 30m"
+                    className="h-8 w-28 text-right font-mono text-sm"
+                    onBlur={(e) => onSetEstimate(item.id, parseDurationInput(e.target.value))}
+                  />
+                </div>
+              ))}
+            </div>
+            {calibration.map((entry) => {
+              const sentence = formatCalibrationSentence(entry);
+              return sentence ? (
+                <p key={entry.workType} className="text-xs text-muted-foreground">
+                  {sentence} That&apos;s from your own logs.
+                </p>
+              ) : null;
+            })}
+            <div className="flex items-center justify-between pt-2">
+              <Button type="button" variant="ghost" onClick={() => setStep(2)}>
+                Back
+              </Button>
+              <Button type="button" onClick={() => setStep(4)}>
+                Next
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {step === 4 && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Planned</span>
+              <span className="font-mono text-lg tabular-nums text-[hsl(var(--brand-gold))]">
+                {formatMinutes(totalEstimateMinutes)}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-muted-foreground">Capacity</span>
+              <Input
+                type="number"
+                min="0"
+                step="15"
+                defaultValue={plan.capacityMinutes}
+                className="h-8 w-24 font-mono text-sm"
+                onBlur={(e) => {
+                  const minutes = Number(e.target.value);
+                  if (Number.isFinite(minutes) && minutes >= 0) onSetCapacity(minutes);
+                }}
+              />
+              <span className="text-muted-foreground">minutes</span>
+            </div>
+            {overMinutes > 0 && (
+              <p className="text-sm">
+                That&apos;s <span className="font-medium">{formatMinutes(overMinutes)}</span> more than your day.{' '}
+                <span className="font-medium">Your call.</span>
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              Nothing has been removed or reordered. Capacity is a number you set — change it above.
+            </p>
+            <div className="flex items-center justify-between pt-2">
+              <Button type="button" variant="ghost" onClick={() => setStep(3)}>
+                Back and adjust
+              </Button>
+              <Button type="button" onClick={close}>
+                Looks right
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/RunningTimerChip.tsx
+++ b/components/RunningTimerChip.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Pause } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/sonner';
+import type { RunningTimer } from '@/lib/time-logs-repo';
+
+interface Props {
+  runningTimer: RunningTimer | null;
+  onStop: () => void;
+  longRunNudgeHours: number;
+}
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}
+
+export default function RunningTimerChip({ runningTimer, onStop, longRunNudgeHours }: Props) {
+  const [now, setNow] = useState(() => Date.now());
+  const [nudgedFor, setNudgedFor] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!runningTimer) return;
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [runningTimer]);
+
+  useEffect(() => {
+    if (!runningTimer) {
+      setNudgedFor(null);
+      return;
+    }
+    const elapsedHours = (now - new Date(runningTimer.startedAt).getTime()) / 3_600_000;
+    if (elapsedHours >= longRunNudgeHours && nudgedFor !== runningTimer.itemId) {
+      setNudgedFor(runningTimer.itemId);
+      toast(`Still on "${runningTimer.itemTitle}"?`, { duration: 10_000 });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [now, runningTimer, longRunNudgeHours]);
+
+  if (!runningTimer) return null;
+
+  const elapsedMs = now - new Date(runningTimer.startedAt).getTime();
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-input px-2.5 py-1 text-sm">
+      <span
+        className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-[hsl(var(--brand-gold))]"
+        aria-hidden="true"
+      />
+      <span className="max-w-[10rem] truncate">{runningTimer.itemTitle}</span>
+      <span className="font-mono tabular-nums text-muted-foreground">{formatElapsed(elapsedMs)}</span>
+      <Button type="button" variant="ghost" size="icon" className="h-6 w-6" aria-label="Pause timer" onClick={onStop}>
+        <Pause className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/components/ShutdownDialog.tsx
+++ b/components/ShutdownDialog.tsx
@@ -4,48 +4,106 @@ import { useEffect, useState } from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { fetchTodaySummary, carryToTomorrow, type TodaySummaryResponse } from '@/lib/api-client';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  fetchTodaySummary,
+  carryToTomorrow,
+  saveWrapUpNote,
+  type TodaySummaryResponse,
+} from '@/lib/api-client';
+import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
+import { formatCalibrationSentence, type CalibrationEntry } from '@/lib/calibration';
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCarried: () => void;
+  onSnooze: (id: number, option: SnoozeOption) => void;
+  onDrop: (id: number) => void;
+  calibration?: CalibrationEntry[];
 }
 
-export default function ShutdownDialog({ open, onOpenChange, onCarried }: Props) {
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
+
+function formatWrapUpDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+export default function ShutdownDialog({ open, onOpenChange, onCarried, onSnooze, onDrop, calibration = [] }: Props) {
   const [summary, setSummary] = useState<TodaySummaryResponse | null>(null);
+  const [note, setNote] = useState('');
+  const [snoozingId, setSnoozingId] = useState<number | null>(null);
 
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     fetchTodaySummary().then((data) => {
-      if (!cancelled) setSummary(data);
+      if (!cancelled) {
+        setSummary(data);
+        setNote(data.plan.note ?? '');
+      }
     });
     return () => {
       cancelled = true;
     };
   }, [open]);
 
-  async function handleCarry(id: number) {
-    await carryToTomorrow(id);
-    onCarried();
+  async function refetch() {
     const fresh = await fetchTodaySummary();
     setSummary(fresh);
   }
 
+  async function handleCarry(id: number) {
+    await carryToTomorrow(id);
+    onCarried();
+    await refetch();
+  }
+
+  async function handleSnoozeOption(id: number, option: SnoozeOption) {
+    onSnooze(id, option);
+    setSnoozingId(null);
+    await refetch();
+  }
+
+  async function handleDrop(id: number) {
+    onDrop(id);
+    await refetch();
+  }
+
+  function handleNoteBlur() {
+    if (!summary) return;
+    if (note === (summary.plan.note ?? '')) return;
+    saveWrapUpNote(summary.plan.date, note);
+  }
+
   const total = summary ? summary.planned.length + summary.doneToday.length : 0;
   const doneCount = summary?.doneToday.length ?? 0;
+  const loggedMinutes = summary ? Math.round(summary.hoursLoggedToday * 60) : 0;
+  const calibrationSentences = calibration.map(formatCalibrationSentence).filter((s): s is string => s !== null);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Review my day</DialogTitle>
+          <DialogTitle>Wrap up the day</DialogTitle>
+          {summary && <DialogDescription>{formatWrapUpDate(summary.plan.date)}</DialogDescription>}
         </DialogHeader>
         {summary && (
           <div className="space-y-4">
@@ -55,6 +113,17 @@ export default function ShutdownDialog({ open, onOpenChange, onCarried }: Props)
               </span>{' '}
               planned item{total === 1 ? '' : 's'} done
             </p>
+            <p className="text-sm text-muted-foreground">
+              Logged today: <span className="font-mono tabular-nums">{formatMinutes(loggedMinutes)}</span> · Planned
+              this morning: <span className="font-mono tabular-nums">{formatMinutes(summary.plannedMinutes)}</span>
+            </p>
+            {calibrationSentences.length > 0 && (
+              <ul className="space-y-1 text-sm text-muted-foreground">
+                {calibrationSentences.map((sentence) => (
+                  <li key={sentence}>{sentence}</li>
+                ))}
+              </ul>
+            )}
             <div>
               <h3 className="mb-1.5 text-sm font-semibold text-muted-foreground">Done</h3>
               {summary.doneToday.length === 0 ? (
@@ -65,7 +134,9 @@ export default function ShutdownDialog({ open, onOpenChange, onCarried }: Props)
                     <li key={item.id} className="flex items-center justify-between gap-2 text-sm">
                       <span className="min-w-0 truncate">{item.title}</span>
                       <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
-                        {item.hoursLoggedToday.toFixed(2)}h
+                        {item.estimateMinutes != null
+                          ? `${item.hoursLoggedToday.toFixed(2)}h / ${formatMinutes(item.estimateMinutes)} est`
+                          : `${item.hoursLoggedToday.toFixed(2)}h`}
                       </span>
                     </li>
                   ))}
@@ -81,25 +152,61 @@ export default function ShutdownDialog({ open, onOpenChange, onCarried }: Props)
                   {summary.planned.map((item) => (
                     <li key={item.id} className="flex items-center justify-between gap-2 text-sm">
                       <span className="min-w-0 truncate">{item.title}</span>
-                      <Button type="button" variant="outline" size="sm" onClick={() => handleCarry(item.id)}>
-                        Carry to tomorrow
-                      </Button>
+                      {snoozingId === item.id ? (
+                        <div className="flex shrink-0 flex-wrap items-center justify-end gap-1">
+                          {(Object.keys(SNOOZE_LABEL) as SnoozeOption[]).map((option) => (
+                            <Button
+                              key={option}
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleSnoozeOption(item.id, option)}
+                            >
+                              {SNOOZE_LABEL[option]}
+                            </Button>
+                          ))}
+                          <Button type="button" variant="ghost" size="sm" onClick={() => setSnoozingId(null)}>
+                            Cancel
+                          </Button>
+                        </div>
+                      ) : (
+                        <div className="flex shrink-0 items-center gap-1">
+                          <Button type="button" variant="outline" size="sm" onClick={() => handleCarry(item.id)}>
+                            Tomorrow
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setSnoozingId(item.id)}
+                          >
+                            Snooze
+                          </Button>
+                          <Button type="button" variant="outline" size="sm" onClick={() => handleDrop(item.id)}>
+                            Drop
+                          </Button>
+                        </div>
+                      )}
                     </li>
                   ))}
                 </ul>
               )}
             </div>
+            <div>
+              <h3 className="mb-1.5 text-sm font-semibold text-muted-foreground">Note</h3>
+              <Textarea
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                onBlur={handleNoteBlur}
+                placeholder="Anything worth remembering about today?"
+                rows={3}
+              />
+            </div>
           </div>
         )}
-        <DialogFooter className="sm:justify-between">
-          <span className="text-sm text-muted-foreground">
-            Total hours logged today:{' '}
-            <span className="font-mono tabular-nums">
-              {summary ? summary.hoursLoggedToday.toFixed(2) : '0.00'}h
-            </span>
-          </span>
+        <DialogFooter>
           <Button type="button" onClick={() => onOpenChange(false)}>
-            Close
+            Close the day
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -73,6 +73,7 @@ interface Props {
   onQueryTextChange: (raw: string) => void;
   savedViews: SavedView[];
   onSavedViewsChange: (views: SavedView[]) => void;
+  failingSources?: Set<Source>;
 }
 
 export default function SignalsBoard({
@@ -91,6 +92,7 @@ export default function SignalsBoard({
   onQueryTextChange,
   savedViews,
   onSavedViewsChange,
+  failingSources,
 }: Props) {
   const [expanded, setExpanded] = useState<Record<ObligationGroup, boolean>>({
     waiting_on_you: false,
@@ -221,6 +223,7 @@ export default function SignalsBoard({
                   onSnooze={onSnooze}
                   onUnsnooze={onUnsnooze}
                   onDone={onDone}
+                  sourceIsStale={failingSources?.has(item.source)}
                 />
               ))}
             </div>

--- a/components/SprintProgressHeader.tsx
+++ b/components/SprintProgressHeader.tsx
@@ -1,50 +1,105 @@
 'use client';
 
-import { Loader2, Plus, RefreshCw } from 'lucide-react';
+import { Loader2, Plus, RefreshCw, CircleCheck, CircleAlert, CircleX } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { formatRelativeTime } from '@/lib/utils';
+import { classifyError, type SourceStatus } from '@/lib/sync-status';
 import type { SprintProgress } from '@/lib/sprint';
 
 interface Props {
   sprint: SprintProgress;
+  sourceStatuses: SourceStatus[];
+  needsYouCount: number;
   onRefresh: () => void;
   syncing: boolean;
-  errors: string[];
   onAddClick: () => void;
 }
 
-export default function SprintProgressHeader({ sprint, onRefresh, syncing, errors, onAddClick }: Props) {
+const SOURCE_LABEL: Record<SourceStatus['source'], string> = { github: 'GitHub', ado: 'Azure DevOps' };
+
+const STATE_ICON = { ok: CircleCheck, stale: CircleAlert, error: CircleX, partial: CircleAlert } as const;
+const STATE_TEXT_CLASS = {
+  ok: 'text-muted-foreground',
+  stale: 'text-warning',
+  error: 'text-destructive',
+  partial: 'text-warning',
+} as const;
+
+function SourceChip({ status }: { status: SourceStatus }) {
+  const Icon = STATE_ICON[status.state];
+  const label =
+    status.state === 'error' || status.state === 'partial'
+      ? `${SOURCE_LABEL[status.source]} failed`
+      : status.lastSyncedAt
+        ? `${SOURCE_LABEL[status.source]} ${formatRelativeTime(new Date(status.lastSyncedAt).getTime())}`
+        : `${SOURCE_LABEL[status.source]} never synced`;
+  return (
+    <span className={`flex items-center gap-1 text-xs ${STATE_TEXT_CLASS[status.state]}`}>
+      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+export default function SprintProgressHeader({
+  sprint,
+  sourceStatuses,
+  needsYouCount,
+  onRefresh,
+  syncing,
+  onAddClick,
+}: Props) {
   const daysRemaining = sprint.endDate
     ? Math.max(0, Math.ceil((new Date(sprint.endDate).getTime() - Date.now()) / 86_400_000))
     : null;
-  const percent = sprint.totalCount > 0 ? Math.round((sprint.completedCount / sprint.totalCount) * 100) : 0;
-  const lastSyncedLabel = sprint.lastSyncedAt
-    ? `Last synced: ${formatRelativeTime(new Date(sprint.lastSyncedAt).getTime())}`
-    : 'Never synced';
+  const percentDone = sprint.totalCount > 0 ? Math.round((sprint.completedCount / sprint.totalCount) * 100) : 0;
+  const percentElapsed =
+    sprint.startDate && sprint.endDate
+      ? Math.min(
+          100,
+          Math.max(
+            0,
+            Math.round(
+              ((Date.now() - new Date(sprint.startDate).getTime()) /
+                (new Date(sprint.endDate).getTime() - new Date(sprint.startDate).getTime())) *
+                100
+            )
+          )
+        )
+      : null;
+
+  const failing = sourceStatuses.filter((s) => s.state === 'error' || s.state === 'partial');
 
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-3">
-        <p className="min-w-0 truncate text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">{sprint.name ?? 'No active sprint'}</span>
-          {' · '}
-          <span className="font-mono tabular-nums">
-            {sprint.completedCount}/{sprint.totalCount}
-          </span>{' '}
-          sprint items done
-          {daysRemaining !== null ? (
-            <>
-              {' · '}
-              <span className="font-mono tabular-nums">{daysRemaining}</span> days left
-            </>
-          ) : (
-            ''
-          )}
-          {' · '}
-          {lastSyncedLabel}
-        </p>
-        <div className="flex shrink-0 items-center gap-1">
+        <div className="min-w-0">
+          <p className="min-w-0 truncate text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{sprint.name ?? 'No active sprint'}</span>
+            {' · '}
+            <span className="font-mono tabular-nums">
+              {sprint.completedCount}/{sprint.totalCount}
+            </span>{' '}
+            sprint items done
+            {daysRemaining !== null ? (
+              <>
+                {' · '}
+                <span className="font-mono tabular-nums">{daysRemaining}</span> days left
+              </>
+            ) : (
+              ''
+            )}
+            {' · '}
+            <span className="text-warning">
+              <span className="font-mono tabular-nums">{needsYouCount}</span> waiting on you
+            </span>
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          {sourceStatuses.map((status) => (
+            <SourceChip key={status.source} status={status} />
+          ))}
           <Button
             type="button"
             variant="ghost"
@@ -55,20 +110,50 @@ export default function SprintProgressHeader({ sprint, onRefresh, syncing, error
           >
             <Plus className="h-4 w-4" />
           </Button>
-          <Button type="button" onClick={onRefresh} disabled={syncing}>
+          <Button type="button" variant="ghost" onClick={onRefresh} disabled={syncing}>
             {syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
             {syncing ? 'Syncing…' : 'Refresh'}
           </Button>
         </div>
       </div>
-      <Progress value={percent} className="h-[2px]" />
-      {errors.length > 0 && (
-        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-          {errors.map((error) => (
-            <p key={error}>{error}</p>
-          ))}
-        </div>
-      )}
+      <div className="relative">
+        <Progress value={percentDone} className="h-[3px]" aria-valuenow={percentDone} role="progressbar" />
+        {percentElapsed !== null && (
+          <div
+            className="absolute top-0 h-[3px] w-px bg-foreground"
+            style={{ left: `${percentElapsed}%` }}
+            aria-hidden="true"
+          />
+        )}
+        <span className="sr-only">
+          {sprint.completedCount} of {sprint.totalCount} sprint items done, {percentElapsed ?? 0}% of the sprint elapsed
+        </span>
+      </div>
+      {failing.map((status) => {
+        const { cause, remedy } = classifyError(status.lastError ?? '', SOURCE_LABEL[status.source]);
+        const ageLabel = status.lastSyncedAt ? formatRelativeTime(new Date(status.lastSyncedAt).getTime()) : 'never';
+        return (
+          <div key={status.source} className="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm">
+            <p>
+              <span className="font-medium">
+                {SOURCE_LABEL[status.source]}{' '}
+                {cause === 'auth'
+                  ? 'rejected the token'
+                  : cause === 'rate_limit'
+                    ? 'rate limit was hit'
+                    : cause === 'network'
+                      ? 'could not be reached'
+                      : 'failed to sync'}
+                .
+              </span>{' '}
+              {status.lastSyncedAt
+                ? `The items below were read ${ageLabel} and are marked stale.`
+                : 'No data has been read from this source yet.'}{' '}
+              {remedy}
+            </p>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/components/SwitchTimerDialog.tsx
+++ b/components/SwitchTimerDialog.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentTitle: string;
+  onJustStop: () => void;
+  onSwitch: () => void;
+}
+
+export default function SwitchTimerDialog({ open, onOpenChange, currentTitle, onJustStop, onSwitch }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>A timer is already running</DialogTitle>
+          <DialogDescription>
+            &ldquo;{currentTitle}&rdquo; is still timing. Stop it, or switch to the new item?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={onJustStop}>
+            Just stop it
+          </Button>
+          <Button type="button" onClick={onSwitch}>
+            Switch
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -1,61 +1,126 @@
 'use client';
 
-import { Card, CardContent } from '@/components/ui/card';
+import { useState } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import ItemRow from './ItemRow';
 import type { ScoredItem } from '@/lib/dashboard';
-import type { Source } from '@/lib/types';
+import type { Item } from '@/lib/types';
 
 interface Props {
   items: ScoredItem[];
-  onStart: (id: number) => void;
+  capacityMinutes: number;
+  onStart?: (id: number) => void;
   onComplete: (id: number, durationHours: number, note?: string) => void;
   onOpenClaude: (id: number, workingDir?: string) => void;
-  onDelete: (id: number) => void;
-  onUnpinToday: (id: number) => void;
-  onReviewDay: () => void;
-  failingSources?: Set<Source>;
+  onDelete?: (id: number) => void;
+  onUnpinToday?: (id: number) => void;
+  onPlanDay: () => void;
+  onReorder: (orderedItemIds: number[]) => void;
+  failingSources?: Set<Item['source']>;
+}
+
+function formatMinutes(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
 }
 
 export default function TodaySection({
   items,
+  capacityMinutes,
   onStart,
   onComplete,
   onOpenClaude,
   onDelete,
   onUnpinToday,
-  onReviewDay,
+  onPlanDay,
+  onReorder,
   failingSources,
 }: Props) {
+  const plannedMinutes = items.reduce((sum, i) => sum + (i.estimateMinutes ?? 0), 0);
+  const loggedMinutes = items.reduce((sum, i) => sum + i.loggedMinutesToday, 0);
+
+  function move(id: number, direction: -1 | 1) {
+    const order = items.map((i) => i.id);
+    const index = order.indexOf(id);
+    const swapWith = index + direction;
+    if (swapWith < 0 || swapWith >= order.length) return;
+    [order[index], order[swapWith]] = [order[swapWith], order[index]];
+    onReorder(order);
+  }
+
   return (
-    <Card>
-      <CardContent className="pt-6">
-        <div className="mb-3 flex items-center justify-between gap-2">
-          <h2 className="flex items-center gap-2 text-base font-semibold">
-            Today
-            <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs tabular-nums text-muted-foreground">
-              {items.length}
-            </span>
-          </h2>
-          <Button type="button" variant="ghost" size="sm" onClick={onReviewDay}>
-            Review my day
-          </Button>
+    <Card className="border-l-2 border-l-[hsl(var(--brand-gold))]">
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 p-4">
+        <div className="flex items-center gap-2">
+          <h2 className="text-base font-semibold">Today</h2>
+          <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-xs tabular-nums text-muted-foreground">
+            {items.length}
+          </span>
         </div>
+        <p className="font-mono text-xs tabular-nums text-muted-foreground">
+          {formatMinutes(loggedMinutes)} logged of {formatMinutes(plannedMinutes)} planned ·{' '}
+          <span className="text-[hsl(var(--brand-gold))]">{formatMinutes(capacityMinutes)} capacity</span>
+        </p>
+      </CardHeader>
+      <CardContent className="p-4 pt-0">
         {items.length === 0 ? (
-          <p className="text-sm text-muted-foreground">Nothing chosen for today — pin something from below.</p>
+          <div className="space-y-3 py-2">
+            <p className="text-sm text-muted-foreground">Nothing chosen yet.</p>
+            <Button type="button" size="lg" onClick={onPlanDay}>
+              Plan the day <kbd className="ml-2 font-mono text-xs opacity-70">P</kbd>
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              or pin anything below with <kbd className="font-mono">t</kbd>
+            </p>
+          </div>
         ) : (
           <div>
-            {items.map((item) => (
-              <ItemRow
-                key={item.id}
-                item={item}
-                onStart={onStart}
-                onComplete={onComplete}
-                onOpenClaude={onOpenClaude}
-                onDelete={onDelete}
-                onUnpinToday={onUnpinToday}
-                sourceIsStale={failingSources?.has(item.source)}
-              />
+            {items.map((item, index) => (
+              <div key={item.id} className="flex items-center gap-1">
+                <div className="flex shrink-0 flex-col">
+                  <button
+                    type="button"
+                    aria-label={`Move ${item.title} up`}
+                    disabled={index === 0}
+                    onClick={() => move(item.id, -1)}
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+                  >
+                    <ChevronUp className="h-3 w-3" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Move ${item.title} down`}
+                    disabled={index === items.length - 1}
+                    onClick={() => move(item.id, 1)}
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+                  >
+                    <ChevronDown className="h-3 w-3" />
+                  </button>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <ItemRow
+                    item={item}
+                    onStart={onStart}
+                    onComplete={onComplete}
+                    onOpenClaude={onOpenClaude}
+                    onDelete={onDelete}
+                    onUnpinToday={onUnpinToday}
+                    sourceIsStale={failingSources?.has(item.source)}
+                  />
+                </div>
+                {item.estimateMinutes !== null && (
+                  <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                    {item.loggedMinutesToday > 0
+                      ? `${formatMinutes(item.loggedMinutesToday)} / ${formatMinutes(item.estimateMinutes)}`
+                      : formatMinutes(item.estimateMinutes)}
+                  </span>
+                )}
+              </div>
             ))}
           </div>
         )}

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import ItemRow from './ItemRow';
 import type { ScoredItem } from '@/lib/dashboard';
+import type { Source } from '@/lib/types';
 
 interface Props {
   items: ScoredItem[];
@@ -13,6 +14,7 @@ interface Props {
   onDelete: (id: number) => void;
   onUnpinToday: (id: number) => void;
   onReviewDay: () => void;
+  failingSources?: Set<Source>;
 }
 
 export default function TodaySection({
@@ -23,6 +25,7 @@ export default function TodaySection({
   onDelete,
   onUnpinToday,
   onReviewDay,
+  failingSources,
 }: Props) {
   return (
     <Card>
@@ -51,6 +54,7 @@ export default function TodaySection({
                 onOpenClaude={onOpenClaude}
                 onDelete={onDelete}
                 onUnpinToday={onUnpinToday}
+                sourceIsStale={failingSources?.has(item.source)}
               />
             ))}
           </div>

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -1,18 +1,59 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { BarChart3, Search, Settings } from 'lucide-react';
 import { AriadneMark } from '@/components/icons/ariadne-mark';
 import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { useCommandPalette } from '@/components/CommandPaletteProvider';
+import RunningTimerChip from '@/components/RunningTimerChip';
+import { fetchRunningTimer, stopTimerRequest, fetchSettings } from '@/lib/api-client';
+import { SETTINGS_KEYS, DEFAULT_LONG_RUN_NUDGE_HOURS } from '@/lib/config';
+import type { RunningTimer } from '@/lib/time-logs-repo';
+
+const RUNNING_TIMER_POLL_MS = 5000;
 
 export default function TopBar() {
   const { setOpen } = useCommandPalette();
+  const [runningTimer, setRunningTimer] = useState<RunningTimer | null>(null);
+  const [longRunNudgeHours, setLongRunNudgeHours] = useState(DEFAULT_LONG_RUN_NUDGE_HOURS);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchSettings().then((settings) => {
+      if (cancelled) return;
+      const raw = settings[SETTINGS_KEYS.longRunNudgeHours];
+      if (raw) setLongRunNudgeHours(Number(raw));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function poll() {
+      const timer = await fetchRunningTimer();
+      if (!cancelled) setRunningTimer(timer);
+    }
+    poll();
+    const interval = setInterval(poll, RUNNING_TIMER_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  async function handleStopTimer() {
+    if (!runningTimer) return;
+    await stopTimerRequest(runningTimer.itemId);
+    setRunningTimer(await fetchRunningTimer());
+  }
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-      <div className="mx-auto grid h-16 max-w-6xl grid-cols-[1fr_minmax(0,28rem)_1fr] items-center gap-6 px-6">
+      <div className="mx-auto grid h-16 max-w-6xl grid-cols-[1fr_auto_minmax(0,24rem)_1fr] items-center gap-4 px-6">
         <Link
           href="/"
           className="group flex w-fit items-center gap-2.5 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--brand-gold))] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
@@ -20,6 +61,8 @@ export default function TopBar() {
           <AriadneMark className="h-7 w-7 shrink-0 text-[hsl(var(--brand-gold))] transition-transform motion-safe:group-hover:scale-105" />
           <span className="font-display text-xl leading-none tracking-wide text-foreground">Ariadne</span>
         </Link>
+
+        <RunningTimerChip runningTimer={runningTimer} onStop={handleStopTimer} longRunNudgeHours={longRunNudgeHours} />
 
         <button
           type="button"

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -44,8 +44,10 @@ export async function unparkItem(id: number) {
 
 export interface TodaySummaryResponse {
   planned: Item[];
-  doneToday: (Item & { hoursLoggedToday: number })[];
+  doneToday: (Item & { hoursLoggedToday: number; estimateMinutes: number | null })[];
   hoursLoggedToday: number;
+  plan: Plan;
+  plannedMinutes: number;
 }
 
 export async function pinToday(id: number, date?: string) {
@@ -143,6 +145,10 @@ export async function fetchPlan(date: string) {
 export async function updatePlan(date: string, input: { capacityMinutes?: number; note?: string | null }): Promise<Plan> {
   const res = await fetch('/api/plan', { method: 'POST', body: JSON.stringify({ date, ...input }) });
   return res.json();
+}
+
+export async function saveWrapUpNote(date: string, note: string) {
+  return updatePlan(date, { note });
 }
 
 export async function addToPlan(date: string, itemId: number) {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -185,3 +185,8 @@ export async function fetchSourceStatuses(): Promise<SourceStatus[]> {
   const res = await fetch('/api/sync-status');
   return res.json();
 }
+
+export async function fetchSettings(): Promise<Record<string, string>> {
+  const res = await fetch('/api/settings');
+  return res.json();
+}

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,7 +1,7 @@
 import type { TimeReport } from '@/lib/report';
 import type { LocalRepo } from '@/lib/warp';
 import { localDateString, addDays } from '@/lib/date';
-import type { Item } from '@/lib/types';
+import type { Item, Plan } from '@/lib/types';
 import type { SnoozeOption } from '@/lib/snooze';
 
 export async function fetchDashboardData() {
@@ -132,4 +132,44 @@ export async function fetchTimeReport(start: string, end: string): Promise<TimeR
     throw new Error(`Failed to fetch time report: ${res.status}`);
   }
   return res.json();
+}
+
+export async function fetchPlan(date: string) {
+  const res = await fetch(`/api/plan?date=${date}`);
+  return res.json();
+}
+
+export async function updatePlan(date: string, input: { capacityMinutes?: number; note?: string | null }): Promise<Plan> {
+  const res = await fetch('/api/plan', { method: 'POST', body: JSON.stringify({ date, ...input }) });
+  return res.json();
+}
+
+export async function addToPlan(date: string, itemId: number) {
+  const res = await fetch('/api/plan/items', { method: 'POST', body: JSON.stringify({ date, itemId }) });
+  return res.json();
+}
+
+export async function removeFromPlan(date: string, itemId: number) {
+  await fetch(`/api/plan/items?date=${date}&itemId=${itemId}`, { method: 'DELETE' });
+}
+
+export async function reorderPlan(date: string, orderedItemIds: number[]) {
+  const res = await fetch('/api/plan/items/reorder', {
+    method: 'PUT',
+    body: JSON.stringify({ date, orderedItemIds }),
+  });
+  return res.json();
+}
+
+export async function setEstimate(date: string, itemId: number, minutes: number | null) {
+  await fetch('/api/plan/items/estimate', { method: 'POST', body: JSON.stringify({ date, itemId, minutes }) });
+}
+
+export async function fetchRunningTimer() {
+  const res = await fetch('/api/timer/running');
+  return res.json();
+}
+
+export async function stopTimerRequest(id: number) {
+  await fetch(`/api/items/${id}/stop-timer`, { method: 'POST' });
 }

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -4,6 +4,7 @@ import { localDateString, addDays } from '@/lib/date';
 import type { Item, Plan } from '@/lib/types';
 import type { SnoozeOption } from '@/lib/snooze';
 import type { SourceStatus } from '@/lib/sync-status';
+import type { CalibrationEntry } from '@/lib/calibration';
 
 export async function fetchDashboardData() {
   const [itemsRes, sprintRes] = await Promise.all([fetch('/api/items'), fetch('/api/sprint')]);
@@ -104,6 +105,11 @@ export async function fetchTodaySummary(): Promise<TodaySummaryResponse> {
   return res.json();
 }
 
+export async function fetchTodaySummaryFor(date: string): Promise<TodaySummaryResponse> {
+  const res = await fetch(`/api/today/summary?date=${date}`);
+  return res.json();
+}
+
 export async function fetchLocalRepos(): Promise<LocalRepo[]> {
   const res = await fetch('/api/local-repos');
   return res.json();
@@ -188,5 +194,10 @@ export async function fetchSourceStatuses(): Promise<SourceStatus[]> {
 
 export async function fetchSettings(): Promise<Record<string, string>> {
   const res = await fetch('/api/settings');
+  return res.json();
+}
+
+export async function fetchCalibration(start: string, end: string): Promise<CalibrationEntry[]> {
+  const res = await fetch(`/api/calibration?start=${start}&end=${end}`);
   return res.json();
 }

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -3,6 +3,7 @@ import type { LocalRepo } from '@/lib/warp';
 import { localDateString, addDays } from '@/lib/date';
 import type { Item, Plan } from '@/lib/types';
 import type { SnoozeOption } from '@/lib/snooze';
+import type { SourceStatus } from '@/lib/sync-status';
 
 export async function fetchDashboardData() {
   const [itemsRes, sprintRes] = await Promise.all([fetch('/api/items'), fetch('/api/sprint')]);
@@ -172,4 +173,9 @@ export async function fetchRunningTimer() {
 
 export async function stopTimerRequest(id: number) {
   await fetch(`/api/items/${id}/stop-timer`, { method: 'POST' });
+}
+
+export async function fetchSourceStatuses(): Promise<SourceStatus[]> {
+  const res = await fetch('/api/sync-status');
+  return res.json();
 }

--- a/lib/calibration.test.ts
+++ b/lib/calibration.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openDb } from './db';
+import { upsertSyncedItem, createAdhocItem } from './items-repo';
+import { addPlanItem, setPlanItemEstimate } from './plans-repo';
+import { startTimer, completeTimer } from './time-logs-repo';
+import { classifyWorkType, getCalibrationSummary, formatCalibrationSentence } from './calibration';
+import type Database from 'better-sqlite3';
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = openDb(':memory:');
+});
+
+describe('classifyWorkType', () => {
+  it('classifies review_requested and approved_unmerged as review', () => {
+    expect(classifyWorkType('review_requested')).toBe('review');
+    expect(classifyWorkType('approved_unmerged')).toBe('review');
+  });
+
+  it('classifies stale_own_pr and authored as own_work', () => {
+    expect(classifyWorkType('stale_own_pr')).toBe('own_work');
+    expect(classifyWorkType('authored')).toBe('own_work');
+  });
+
+  it('classifies assigned and mention as assigned', () => {
+    expect(classifyWorkType('assigned')).toBe('assigned');
+    expect(classifyWorkType('mention')).toBe('assigned');
+  });
+
+  it('classifies manual as ad_hoc', () => {
+    expect(classifyWorkType('manual')).toBe('ad_hoc');
+  });
+});
+
+describe('getCalibrationSummary', () => {
+  it('sums estimate and actual minutes per work type for the date range', () => {
+    const pr = upsertSyncedItem(db, {
+      source: 'github_pr',
+      externalId: '1@a/b',
+      title: 'Review this',
+      url: null,
+      reason: 'review_requested',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: null,
+      repo: null,
+    });
+    addPlanItem(db, '2026-08-14', pr.id);
+    setPlanItemEstimate(db, '2026-08-14', pr.id, 60);
+    startTimer(db, pr.id);
+    completeTimer(db, pr.id, { durationHours: 1.5 });
+    // Backdate the log to the plan date so the join lines up in the test.
+    db.prepare("UPDATE time_logs SET started_at = '2026-08-14T09:00:00.000Z' WHERE item_id = ?").run(pr.id);
+
+    const summary = getCalibrationSummary(db, '2026-08-14', '2026-08-14');
+    const review = summary.find((s) => s.workType === 'review');
+    expect(review).toEqual({ workType: 'review', label: 'Review-type work', estimateMinutes: 60, actualMinutes: 90 });
+  });
+
+  it('returns an empty array when there is no plan data in range', () => {
+    expect(getCalibrationSummary(db, '2026-01-01', '2026-01-02')).toEqual([]);
+  });
+});
+
+describe('formatCalibrationSentence', () => {
+  it('states the percentage over estimate when actual exceeds estimate', () => {
+    const sentence = formatCalibrationSentence({
+      workType: 'review',
+      label: 'Review-type work',
+      estimateMinutes: 60,
+      actualMinutes: 90,
+    });
+    expect(sentence).toBe('Review-type work ran 50% over estimate.');
+  });
+
+  it('returns null when estimate is zero (nothing to compare against)', () => {
+    expect(
+      formatCalibrationSentence({ workType: 'review', label: 'Review-type work', estimateMinutes: 0, actualMinutes: 30 })
+    ).toBeNull();
+  });
+
+  it('returns null when actual is at or under estimate (nothing worth flagging)', () => {
+    expect(
+      formatCalibrationSentence({ workType: 'review', label: 'Review-type work', estimateMinutes: 60, actualMinutes: 60 })
+    ).toBeNull();
+  });
+});

--- a/lib/calibration.ts
+++ b/lib/calibration.ts
@@ -1,0 +1,82 @@
+import type Database from 'better-sqlite3';
+import type { Reason } from './types';
+
+export type WorkType = 'review' | 'own_work' | 'assigned' | 'ad_hoc';
+
+export const WORK_TYPE_LABEL: Record<WorkType, string> = {
+  review: 'Review-type work',
+  own_work: 'Your own work',
+  assigned: 'Assigned work',
+  ad_hoc: 'Ad-hoc work',
+};
+
+const REASON_WORK_TYPE: Record<Reason, WorkType> = {
+  review_requested: 'review',
+  approved_unmerged: 'review',
+  stale_own_pr: 'own_work',
+  authored: 'own_work',
+  assigned: 'assigned',
+  mention: 'assigned',
+  manual: 'ad_hoc',
+};
+
+export function classifyWorkType(reason: Reason): WorkType {
+  return REASON_WORK_TYPE[reason];
+}
+
+export interface CalibrationEntry {
+  workType: WorkType;
+  label: string;
+  estimateMinutes: number;
+  actualMinutes: number;
+}
+
+// Estimate vs actual, grouped by work type, for plan_items in [startDate,
+// endDate]. Actual time is time_logs on the SAME plan date for that item --
+// a scoped, precise definition ("today's plan vs today's logged time for
+// that item"), not a lifetime total.
+export function getCalibrationSummary(db: Database.Database, startDate: string, endDate: string): CalibrationEntry[] {
+  const rows = db
+    .prepare(
+      `SELECT
+         i.reason as reason,
+         COALESCE(pi.estimate_minutes, 0) as estimateMinutes,
+         COALESCE((
+           SELECT SUM(tl.duration_hours) * 60 FROM time_logs tl
+           WHERE tl.item_id = pi.item_id
+             AND tl.duration_hours IS NOT NULL
+             AND substr(tl.started_at, 1, 10) = pi.plan_date
+         ), 0) as actualMinutes
+       FROM plan_items pi
+       JOIN items i ON i.id = pi.item_id
+       WHERE pi.plan_date >= ? AND pi.plan_date <= ?`
+    )
+    .all(startDate, endDate) as { reason: Reason; estimateMinutes: number; actualMinutes: number }[];
+
+  const totals = new Map<WorkType, { estimateMinutes: number; actualMinutes: number }>();
+  for (const row of rows) {
+    const workType = classifyWorkType(row.reason);
+    const current = totals.get(workType) ?? { estimateMinutes: 0, actualMinutes: 0 };
+    totals.set(workType, {
+      estimateMinutes: current.estimateMinutes + row.estimateMinutes,
+      actualMinutes: current.actualMinutes + row.actualMinutes,
+    });
+  }
+
+  return Array.from(totals.entries()).map(([workType, sums]) => ({
+    workType,
+    label: WORK_TYPE_LABEL[workType],
+    ...sums,
+  }));
+}
+
+// Silence over a shaky number: no estimate to compare against, or actual
+// didn't exceed it, means there is nothing worth saying -- "no productivity
+// grades" extends to not manufacturing a sentence when the data doesn't
+// support one.
+export function formatCalibrationSentence(entry: CalibrationEntry): string | null {
+  if (entry.estimateMinutes <= 0) return null;
+  if (entry.actualMinutes <= entry.estimateMinutes) return null;
+  const overPct = Math.round(((entry.actualMinutes - entry.estimateMinutes) / entry.estimateMinutes) * 100);
+  return `${entry.label} ran ${overPct}% over estimate.`;
+}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -12,10 +12,14 @@ export const SETTINGS_KEYS = {
   repoPathOverrides: 'warp.repoPathOverrides',
   density: 'ui.density',
   savedViews: 'ui.savedViews',
+  dailyCapacityMinutes: 'plan.dailyCapacityMinutes',
+  longRunNudgeHours: 'plan.longRunNudgeHours',
 } as const;
 
 export const DEFAULT_STALE_DAYS = 3;
 export const NEEDS_ATTENTION_THRESHOLD = 25;
+export const DEFAULT_CAPACITY_MINUTES = 360; // 6h, per the wireframe's default
+export const DEFAULT_LONG_RUN_NUDGE_HOURS = 2;
 
 export type Density = 'comfortable' | 'compact';
 

--- a/lib/dashboard.test.ts
+++ b/lib/dashboard.test.ts
@@ -3,6 +3,9 @@ import Database from 'better-sqlite3';
 import { openDb } from './db';
 import { upsertSyncedItem, createAdhocItem, setStatus, setParked, setTodayDate } from './items-repo';
 import { getGroupedItems, getTodaySummary } from './dashboard';
+import { localDateString } from './date';
+import { addPlanItem, setPlanItemEstimate, reorderPlanItems } from './plans-repo';
+import { startTimer, completeTimer } from './time-logs-repo';
 
 let db: Database.Database;
 
@@ -266,5 +269,64 @@ describe('getTodaySummary', () => {
     const now = new Date(2026, 7, 13, 20, 0);
     const summary = getTodaySummary(db, '2026-08-13', now);
     expect(summary.hoursLoggedToday).toBe(1.25);
+  });
+});
+
+describe('getGroupedItems today ordering', () => {
+  it('orders today items by plan_items.sort_order, not by score', () => {
+    const now = new Date(2026, 7, 14, 9, 0);
+    const todayStr = localDateString(now);
+
+    const highScore = upsertSyncedItem(db, {
+      source: 'github_pr',
+      externalId: '1@a/b',
+      title: 'High score, picked second',
+      url: null,
+      reason: 'approved_unmerged',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: null,
+      repo: null,
+    });
+    const lowScore = upsertSyncedItem(db, {
+      source: 'ado_workitem',
+      externalId: '2',
+      title: 'Low score, picked first',
+      url: null,
+      reason: 'assigned',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: null,
+      repo: null,
+    });
+    setTodayDate(db, highScore.id, todayStr);
+    setTodayDate(db, lowScore.id, todayStr);
+    addPlanItem(db, todayStr, highScore.id);
+    addPlanItem(db, todayStr, lowScore.id);
+    reorderPlanItems(db, todayStr, [lowScore.id, highScore.id]);
+
+    const grouped = getGroupedItems(db, now);
+    expect(grouped.today.map((i) => i.id)).toEqual([lowScore.id, highScore.id]);
+  });
+
+  it('carries estimateMinutes and loggedMinutesToday onto each today item', () => {
+    const now = new Date(2026, 7, 14, 9, 0);
+    const todayStr = localDateString(now);
+    const item = createAdhocItem(db, { title: 'Estimated' });
+    setTodayDate(db, item.id, todayStr);
+    addPlanItem(db, todayStr, item.id);
+    setPlanItemEstimate(db, todayStr, item.id, 90);
+    startTimer(db, item.id);
+    completeTimer(db, item.id, { durationHours: 0.5 });
+    db.prepare('UPDATE time_logs SET started_at = ?, ended_at = ? WHERE item_id = ?').run(
+      now.toISOString(),
+      now.toISOString(),
+      item.id
+    );
+
+    const grouped = getGroupedItems(db, now);
+    const found = grouped.today.find((i) => i.id === item.id);
+    expect(found?.estimateMinutes).toBe(90);
+    expect(found?.loggedMinutesToday).toBe(30);
   });
 });

--- a/lib/dashboard.test.ts
+++ b/lib/dashboard.test.ts
@@ -330,3 +330,18 @@ describe('getGroupedItems today ordering', () => {
     expect(found?.loggedMinutesToday).toBe(30);
   });
 });
+
+describe('getTodaySummary plan integration', () => {
+  it('includes the plan and its planned minutes total', () => {
+    const now = new Date(2026, 7, 14, 20, 0);
+    const dateStr = localDateString(now);
+    const item = createAdhocItem(db, { title: 'Planned' });
+    setTodayDate(db, item.id, dateStr);
+    addPlanItem(db, dateStr, item.id);
+    setPlanItemEstimate(db, dateStr, item.id, 45);
+
+    const summary = getTodaySummary(db, dateStr, now);
+    expect(summary.plan.capacityMinutes).toBeGreaterThan(0);
+    expect(summary.plannedMinutes).toBe(45);
+  });
+});

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -5,9 +5,9 @@ import { sortByUrgency, type ScoreBreakdownEntry } from './scoring';
 import { getLinksForItems, type LinkedRef } from './links-repo';
 import { localDateString } from './date';
 import { sumHoursLoggedOn, sumHoursLoggedOnByItem } from './time-logs-repo';
-import { getPlanItems } from './plans-repo';
+import { getPlan, getPlanItems } from './plans-repo';
 import { SETTINGS_KEYS } from './config';
-import type { Item } from './types';
+import type { Item, Plan } from './types';
 
 export type ScoredItem = Item & {
   score: number;
@@ -66,6 +66,8 @@ export interface TodaySummary {
   planned: Item[];
   doneToday: Item[];
   hoursLoggedToday: number;
+  plan: Plan;
+  plannedMinutes: number;
 }
 
 // `now` is accepted (not just `date`) to mirror getGroupedItems's signature
@@ -78,6 +80,8 @@ export function getTodaySummary(db: Database.Database, date: string, now: Date):
     (i) => i.status === 'done' && i.completedAt !== null && localDateString(new Date(i.completedAt)) === date
   );
   const hoursLoggedToday = sumHoursLoggedOn(db, date);
+  const plan = getPlan(db, date);
+  const plannedMinutes = getPlanItems(db, date).reduce((sum, pi) => sum + (pi.estimateMinutes ?? 0), 0);
   void now;
-  return { planned, doneToday, hoursLoggedToday };
+  return { planned, doneToday, hoursLoggedToday, plan, plannedMinutes };
 }

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -4,11 +4,19 @@ import { getSetting } from './settings-repo';
 import { sortByUrgency, type ScoreBreakdownEntry } from './scoring';
 import { getLinksForItems, type LinkedRef } from './links-repo';
 import { localDateString } from './date';
-import { sumHoursLoggedOn } from './time-logs-repo';
+import { sumHoursLoggedOn, sumHoursLoggedOnByItem } from './time-logs-repo';
+import { getPlanItems } from './plans-repo';
 import { SETTINGS_KEYS } from './config';
 import type { Item } from './types';
 
-export type ScoredItem = Item & { score: number; scoreBreakdown: ScoreBreakdownEntry[]; notFired: string[]; links: LinkedRef[] };
+export type ScoredItem = Item & {
+  score: number;
+  scoreBreakdown: ScoreBreakdownEntry[];
+  notFired: string[];
+  links: LinkedRef[];
+  estimateMinutes: number | null;
+  loggedMinutesToday: number;
+};
 
 export interface GroupedItems {
   today: ScoredItem[];
@@ -21,18 +29,29 @@ export function getGroupedItems(db: Database.Database, now: Date): GroupedItems 
   const items = listItems(db);
   const sprintEnd = getSetting(db, SETTINGS_KEYS.sprintEnd);
   const links = getLinksForItems(db, items);
+  const todayStr = localDateString(now);
+  const planItems = getPlanItems(db, todayStr);
+  const sortOrderByItemId = new Map(planItems.map((pi) => [pi.itemId, pi.sortOrder]));
+  const estimateByItemId = new Map(planItems.map((pi) => [pi.itemId, pi.estimateMinutes]));
+  const loggedTodayByItemId = sumHoursLoggedOnByItem(db, todayStr);
+
   const scored = sortByUrgency(items.map((item) => ({ ...item, sprintEnd })), now).map((item) => ({
     ...item,
     links: links.get(item.id) ?? [],
+    estimateMinutes: estimateByItemId.get(item.id) ?? null,
+    loggedMinutesToday: Math.round((loggedTodayByItemId.get(item.id) ?? 0) * 60),
   }));
 
   // Today is checked before Signals so pinning an item is a move out of its
   // score bucket, not a copy -- an item never appears in two sections at
   // once. Requiring status === 'inbox' here is belt-and-suspenders on top of
   // setStatus's own auto-clear: an in-progress item never shows up in Today
-  // even if today_date somehow survived.
-  const todayStr = localDateString(now);
-  const today = scored.filter((i) => i.status === 'inbox' && i.todayDate === todayStr);
+  // even if today_date somehow survived. Today is ordered by plan_items'
+  // sort_order rather than score -- it's a hand-ordered list once chosen,
+  // not a re-derivation of the ranking that put it there.
+  const today = scored
+    .filter((i) => i.status === 'inbox' && i.todayDate === todayStr)
+    .sort((a, b) => (sortOrderByItemId.get(a.id) ?? Infinity) - (sortOrderByItemId.get(b.id) ?? Infinity));
   const todayIds = new Set(today.map((i) => i.id));
 
   return {

--- a/lib/db.test.ts
+++ b/lib/db.test.ts
@@ -12,7 +12,7 @@ describe('openDb', () => {
       .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
       .all()
       .map((row: any) => row.name);
-    expect(tables).toEqual(['item_links', 'items', 'settings', 'sync_log', 'time_logs']);
+    expect(tables).toEqual(['item_links', 'items', 'plan_items', 'plans', 'settings', 'sync_log', 'time_logs']);
     db.close();
   });
 
@@ -175,6 +175,37 @@ describe('items.starred / snoozed_until / triage_state / woke_early migration', 
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('plans / plan_items schema', () => {
+  it('creates the plans table with date as primary key', () => {
+    const db = openDb(':memory:');
+    const columns = (db.prepare('PRAGMA table_info(plans)').all() as { name: string }[]).map((c) => c.name);
+    expect(columns).toEqual(expect.arrayContaining(['date', 'capacity_minutes', 'note']));
+    db.close();
+  });
+
+  it('creates the plan_items table with no time-of-day column', () => {
+    const db = openDb(':memory:');
+    const columns = (db.prepare('PRAGMA table_info(plan_items)').all() as { name: string }[]).map((c) => c.name);
+    expect(columns).toEqual(expect.arrayContaining(['plan_date', 'item_id', 'sort_order', 'estimate_minutes']));
+    expect(columns).not.toContain('time_of_day');
+    expect(columns).not.toContain('scheduled_at');
+    expect(columns).not.toContain('start_time');
+    db.close();
+  });
+
+  it('allows only one plan_items row per (plan_date, item_id)', () => {
+    const db = openDb(':memory:');
+    db.prepare(
+      'INSERT INTO items (source, external_id, title, reason, status, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run('adhoc', null, 'Test', 'manual', 'inbox', new Date().toISOString());
+    db.prepare('INSERT INTO plan_items (plan_date, item_id, sort_order) VALUES (?, ?, ?)').run('2026-08-14', 1, 0);
+    expect(() =>
+      db.prepare('INSERT INTO plan_items (plan_date, item_id, sort_order) VALUES (?, ?, ?)').run('2026-08-14', 1, 1)
+    ).toThrow();
+    db.close();
   });
 });
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -51,6 +51,20 @@ CREATE TABLE IF NOT EXISTS settings (
   value TEXT,
   updated_at TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS plans (
+  date TEXT PRIMARY KEY,
+  capacity_minutes INTEGER NOT NULL,
+  note TEXT
+);
+
+CREATE TABLE IF NOT EXISTS plan_items (
+  plan_date TEXT NOT NULL,
+  item_id INTEGER NOT NULL REFERENCES items(id),
+  sort_order INTEGER NOT NULL,
+  estimate_minutes INTEGER,
+  PRIMARY KEY (plan_date, item_id)
+);
 `;
 
 function sleepSync(ms: number): void {

--- a/lib/keymap.ts
+++ b/lib/keymap.ts
@@ -27,6 +27,7 @@ export const KEYMAP: KeyBinding[] = [
   { keys: 'd', description: 'Mark done (local only)', scope: 'row' },
   { keys: 't', description: 'Pin to Today', scope: 'row' },
   { keys: '/', description: 'Focus the query bar', scope: 'global' },
+  { keys: 'P', description: 'Plan the day', scope: 'global' },
   { keys: '⌘K / Ctrl+K', description: 'Search or jump to', scope: 'global' },
   { keys: '⌘Z', description: 'Undo the last triage action', scope: 'global' },
   { keys: 'g d', description: 'Go to the dashboard', scope: 'global' },

--- a/lib/plans-repo.test.ts
+++ b/lib/plans-repo.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { openDb } from './db';
+import { createAdhocItem } from './items-repo';
+import {
+  getPlan,
+  upsertPlan,
+  getPlanItems,
+  addPlanItem,
+  removePlanItem,
+  setPlanItemEstimate,
+  reorderPlanItems,
+} from './plans-repo';
+import { DEFAULT_CAPACITY_MINUTES } from './config';
+import type Database from 'better-sqlite3';
+
+let db: Database.Database;
+const DATE = '2026-08-14';
+
+beforeEach(() => {
+  db = openDb(':memory:');
+});
+
+describe('getPlan', () => {
+  it('returns the default capacity and no note for a date with no plan row yet', () => {
+    expect(getPlan(db, DATE)).toEqual({ date: DATE, capacityMinutes: DEFAULT_CAPACITY_MINUTES, note: null });
+  });
+});
+
+describe('upsertPlan', () => {
+  it('creates a plan with a custom capacity', () => {
+    const plan = upsertPlan(db, DATE, { capacityMinutes: 240 });
+    expect(plan).toEqual({ date: DATE, capacityMinutes: 240, note: null });
+  });
+
+  it('updates only the given fields, leaving the rest as previously set', () => {
+    upsertPlan(db, DATE, { capacityMinutes: 240, note: 'Quiet Friday' });
+    const updated = upsertPlan(db, DATE, { capacityMinutes: 300 });
+    expect(updated).toEqual({ date: DATE, capacityMinutes: 300, note: 'Quiet Friday' });
+  });
+});
+
+describe('addPlanItem / getPlanItems', () => {
+  it('creates the plan row on first add if it does not exist, defaulting capacity', () => {
+    const item = createAdhocItem(db, { title: 'First pick' });
+    addPlanItem(db, DATE, item.id);
+    expect(getPlan(db, DATE).capacityMinutes).toBe(DEFAULT_CAPACITY_MINUTES);
+    expect(getPlanItems(db, DATE)).toEqual([{ planDate: DATE, itemId: item.id, sortOrder: 0, estimateMinutes: null }]);
+  });
+
+  it('appends subsequent items at increasing sort_order', () => {
+    const a = createAdhocItem(db, { title: 'A' });
+    const b = createAdhocItem(db, { title: 'B' });
+    addPlanItem(db, DATE, a.id);
+    addPlanItem(db, DATE, b.id);
+    expect(getPlanItems(db, DATE).map((i) => [i.itemId, i.sortOrder])).toEqual([
+      [a.id, 0],
+      [b.id, 1],
+    ]);
+  });
+
+  it('is idempotent — adding the same item twice does not duplicate or reorder it', () => {
+    const a = createAdhocItem(db, { title: 'A' });
+    addPlanItem(db, DATE, a.id);
+    addPlanItem(db, DATE, a.id);
+    expect(getPlanItems(db, DATE)).toHaveLength(1);
+  });
+});
+
+describe('removePlanItem', () => {
+  it('removes the item and leaves the others', () => {
+    const a = createAdhocItem(db, { title: 'A' });
+    const b = createAdhocItem(db, { title: 'B' });
+    addPlanItem(db, DATE, a.id);
+    addPlanItem(db, DATE, b.id);
+    removePlanItem(db, DATE, a.id);
+    expect(getPlanItems(db, DATE).map((i) => i.itemId)).toEqual([b.id]);
+  });
+});
+
+describe('setPlanItemEstimate', () => {
+  it('sets and clears an estimate', () => {
+    const a = createAdhocItem(db, { title: 'A' });
+    addPlanItem(db, DATE, a.id);
+    setPlanItemEstimate(db, DATE, a.id, 90);
+    expect(getPlanItems(db, DATE)[0].estimateMinutes).toBe(90);
+    setPlanItemEstimate(db, DATE, a.id, null);
+    expect(getPlanItems(db, DATE)[0].estimateMinutes).toBeNull();
+  });
+});
+
+describe('reorderPlanItems', () => {
+  it('reassigns sort_order to match the given item order', () => {
+    const a = createAdhocItem(db, { title: 'A' });
+    const b = createAdhocItem(db, { title: 'B' });
+    const c = createAdhocItem(db, { title: 'C' });
+    addPlanItem(db, DATE, a.id);
+    addPlanItem(db, DATE, b.id);
+    addPlanItem(db, DATE, c.id);
+    const reordered = reorderPlanItems(db, DATE, [c.id, a.id, b.id]);
+    expect(reordered.map((i) => i.itemId)).toEqual([c.id, a.id, b.id]);
+    expect(reordered.map((i) => i.sortOrder)).toEqual([0, 1, 2]);
+  });
+});

--- a/lib/plans-repo.ts
+++ b/lib/plans-repo.ts
@@ -1,0 +1,77 @@
+import type Database from 'better-sqlite3';
+import { DEFAULT_CAPACITY_MINUTES } from './config';
+import type { Plan, PlanItem } from './types';
+
+function rowToPlan(row: any, date: string): Plan {
+  if (!row) return { date, capacityMinutes: DEFAULT_CAPACITY_MINUTES, note: null };
+  return { date: row.date, capacityMinutes: row.capacity_minutes, note: row.note };
+}
+
+function rowToPlanItem(row: any): PlanItem {
+  return {
+    planDate: row.plan_date,
+    itemId: row.item_id,
+    sortOrder: row.sort_order,
+    estimateMinutes: row.estimate_minutes,
+  };
+}
+
+export function getPlan(db: Database.Database, date: string): Plan {
+  const row = db.prepare('SELECT * FROM plans WHERE date = ?').get(date);
+  return rowToPlan(row, date);
+}
+
+export function upsertPlan(
+  db: Database.Database,
+  date: string,
+  input: { capacityMinutes?: number; note?: string | null }
+): Plan {
+  const existing = getPlan(db, date);
+  const capacityMinutes = input.capacityMinutes ?? existing.capacityMinutes;
+  const note = input.note !== undefined ? input.note : existing.note;
+  db.prepare(
+    `INSERT INTO plans (date, capacity_minutes, note) VALUES (?, ?, ?)
+     ON CONFLICT(date) DO UPDATE SET capacity_minutes = excluded.capacity_minutes, note = excluded.note`
+  ).run(date, capacityMinutes, note);
+  return { date, capacityMinutes, note };
+}
+
+export function getPlanItems(db: Database.Database, date: string): PlanItem[] {
+  return db
+    .prepare('SELECT * FROM plan_items WHERE plan_date = ? ORDER BY sort_order')
+    .all(date)
+    .map(rowToPlanItem);
+}
+
+// Ensures the day's plan row exists (defaulting capacity), then appends the
+// item at the next sort position. Idempotent: adding an already-present
+// item is a no-op rather than a duplicate or a reorder, so the quick 't'
+// pin path and the ritual's Choose step can both call this safely.
+export function addPlanItem(db: Database.Database, date: string, itemId: number): PlanItem {
+  if (!db.prepare('SELECT 1 FROM plans WHERE date = ?').get(date)) {
+    upsertPlan(db, date, {});
+  }
+  const existing = db.prepare('SELECT * FROM plan_items WHERE plan_date = ? AND item_id = ?').get(date, itemId);
+  if (existing) return rowToPlanItem(existing);
+
+  const { maxOrder } = db
+    .prepare('SELECT MAX(sort_order) as maxOrder FROM plan_items WHERE plan_date = ?')
+    .get(date) as { maxOrder: number | null };
+  const sortOrder = maxOrder === null ? 0 : maxOrder + 1;
+  db.prepare('INSERT INTO plan_items (plan_date, item_id, sort_order) VALUES (?, ?, ?)').run(date, itemId, sortOrder);
+  return { planDate: date, itemId, sortOrder, estimateMinutes: null };
+}
+
+export function removePlanItem(db: Database.Database, date: string, itemId: number): void {
+  db.prepare('DELETE FROM plan_items WHERE plan_date = ? AND item_id = ?').run(date, itemId);
+}
+
+export function setPlanItemEstimate(db: Database.Database, date: string, itemId: number, minutes: number | null): void {
+  db.prepare('UPDATE plan_items SET estimate_minutes = ? WHERE plan_date = ? AND item_id = ?').run(minutes, date, itemId);
+}
+
+export function reorderPlanItems(db: Database.Database, date: string, orderedItemIds: number[]): PlanItem[] {
+  const update = db.prepare('UPDATE plan_items SET sort_order = ? WHERE plan_date = ? AND item_id = ?');
+  orderedItemIds.forEach((itemId, index) => update.run(index, date, itemId));
+  return getPlanItems(db, date);
+}

--- a/lib/query.test.ts
+++ b/lib/query.test.ts
@@ -33,6 +33,8 @@ function item(overrides: Partial<ScoredItem> = {}): ScoredItem {
     scoreBreakdown: [],
     notFired: [],
     links: [],
+    estimateMinutes: null,
+    loggedMinutesToday: 0,
     ...overrides,
   };
 }

--- a/lib/sync-status.test.ts
+++ b/lib/sync-status.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { openDb } from './db';
+import { logSyncResult } from './sync';
+import { getSourceStatus, getAllSourceStatuses, classifyError, STALE_AFTER_MINUTES } from './sync-status';
+import type Database from 'better-sqlite3';
+
+function db(): Database.Database {
+  return openDb(':memory:');
+}
+
+describe('getSourceStatus', () => {
+  it('is "error" when a source has never synced', () => {
+    const status = getSourceStatus(db(), 'github', new Date());
+    expect(status).toEqual({ source: 'github', lastSyncedAt: null, lastError: 'Never synced', state: 'error' });
+  });
+
+  it('is "ok" when the last sync succeeded recently', () => {
+    const conn = db();
+    const now = new Date('2026-08-14T12:00:00.000Z');
+    logSyncResult(conn, 'github', 5, null);
+    const status = getSourceStatus(conn, 'github', now);
+    expect(status.state).toBe('ok');
+    expect(status.lastError).toBeNull();
+  });
+
+  it('is "stale" when the last successful sync is older than the freshness window', () => {
+    const conn = db();
+    const past = new Date(Date.now() - (STALE_AFTER_MINUTES + 5) * 60_000);
+    conn
+      .prepare('INSERT INTO sync_log (source, ran_at, item_count, error) VALUES (?, ?, ?, NULL)')
+      .run('github', past.toISOString(), 5);
+    const status = getSourceStatus(conn, 'github', new Date());
+    expect(status.state).toBe('stale');
+  });
+
+  it('is "error" when the only attempt failed and there is no prior success', () => {
+    const conn = db();
+    logSyncResult(conn, 'ado', 0, 'Bad credentials');
+    const status = getSourceStatus(conn, 'ado', new Date());
+    expect(status.state).toBe('error');
+    expect(status.lastError).toBe('Bad credentials');
+  });
+
+  it('is "partial" when the latest attempt failed but an earlier one succeeded', () => {
+    const conn = db();
+    const now = new Date('2026-08-14T12:00:00.000Z');
+    conn
+      .prepare('INSERT INTO sync_log (source, ran_at, item_count, error) VALUES (?, ?, ?, NULL)')
+      .run('ado', '2026-08-14T10:00:00.000Z', 14);
+    conn
+      .prepare('INSERT INTO sync_log (source, ran_at, item_count, error) VALUES (?, ?, ?, ?)')
+      .run('ado', '2026-08-14T11:00:00.000Z', 0, 'Bad credentials');
+    const status = getSourceStatus(conn, 'ado', now);
+    expect(status.state).toBe('partial');
+    expect(status.lastSyncedAt).toBe('2026-08-14T10:00:00.000Z');
+    expect(status.lastError).toBe('Bad credentials');
+  });
+});
+
+describe('getAllSourceStatuses', () => {
+  it('returns both sources', () => {
+    const statuses = getAllSourceStatuses(db(), new Date());
+    expect(statuses.map((s) => s.source)).toEqual(['github', 'ado']);
+  });
+});
+
+describe('classifyError', () => {
+  it('classifies a bad-credentials message as auth', () => {
+    const result = classifyError('Bad credentials', 'Azure DevOps');
+    expect(result.cause).toBe('auth');
+    expect(result.remedy).toContain('Azure DevOps token');
+  });
+
+  it('classifies a 401 message as auth', () => {
+    expect(classifyError('Request failed with status 401', 'GitHub').cause).toBe('auth');
+  });
+
+  it('classifies a rate-limit message', () => {
+    expect(classifyError('API rate limit exceeded', 'GitHub').cause).toBe('rate_limit');
+  });
+
+  it('classifies a network failure message', () => {
+    expect(classifyError('fetch failed: ENOTFOUND api.github.com', 'GitHub').cause).toBe('network');
+  });
+
+  it('falls back to unknown for an unrecognized message', () => {
+    expect(classifyError('Something unexpected happened', 'GitHub').cause).toBe('unknown');
+  });
+});

--- a/lib/sync-status.ts
+++ b/lib/sync-status.ts
@@ -1,0 +1,71 @@
+import type Database from 'better-sqlite3';
+
+export type Source = 'github' | 'ado';
+export type SourceState = 'ok' | 'stale' | 'error' | 'partial';
+
+export interface SourceStatus {
+  source: Source;
+  lastSyncedAt: string | null;
+  lastError: string | null;
+  state: SourceState;
+}
+
+// A source is only "ok" inside this window; past it, the last-known data is
+// shown but marked stale rather than presented as current.
+export const STALE_AFTER_MINUTES = 15;
+
+export function getSourceStatus(db: Database.Database, source: Source, now: Date): SourceStatus {
+  const lastAttempt = db
+    .prepare('SELECT ran_at, error FROM sync_log WHERE source = ? ORDER BY ran_at DESC LIMIT 1')
+    .get(source) as { ran_at: string; error: string | null } | undefined;
+
+  if (!lastAttempt) {
+    return { source, lastSyncedAt: null, lastError: 'Never synced', state: 'error' };
+  }
+
+  const lastSuccess = db
+    .prepare('SELECT ran_at FROM sync_log WHERE source = ? AND error IS NULL ORDER BY ran_at DESC LIMIT 1')
+    .get(source) as { ran_at: string } | undefined;
+
+  if (lastAttempt.error !== null) {
+    return {
+      source,
+      lastSyncedAt: lastSuccess?.ran_at ?? null,
+      lastError: lastAttempt.error,
+      state: lastSuccess ? 'partial' : 'error',
+    };
+  }
+
+  const ageMinutes = (now.getTime() - new Date(lastAttempt.ran_at).getTime()) / 60_000;
+  return {
+    source,
+    lastSyncedAt: lastAttempt.ran_at,
+    lastError: null,
+    state: ageMinutes > STALE_AFTER_MINUTES ? 'stale' : 'ok',
+  };
+}
+
+export function getAllSourceStatuses(db: Database.Database, now: Date): SourceStatus[] {
+  return [getSourceStatus(db, 'github', now), getSourceStatus(db, 'ado', now)];
+}
+
+export interface ErrorClassification {
+  cause: 'auth' | 'rate_limit' | 'network' | 'unknown';
+  remedy: string;
+}
+
+// Gives a fix, not a countdown, per the issue's copy guardrail: "Try again
+// later" makes the user run the experiment themselves.
+export function classifyError(message: string, sourceLabel: string): ErrorClassification {
+  const m = message.toLowerCase();
+  if (/401|unauthoriz|bad credentials|token/.test(m)) {
+    return { cause: 'auth', remedy: `Update the ${sourceLabel} token in Settings, then refresh.` };
+  }
+  if (/403|rate limit/.test(m)) {
+    return { cause: 'rate_limit', remedy: `${sourceLabel}'s rate limit was hit. Refresh again in a few minutes.` };
+  }
+  if (/network|econnrefused|enotfound|fetch failed/.test(m)) {
+    return { cause: 'network', remedy: `Check your connection, then refresh.` };
+  }
+  return { cause: 'unknown', remedy: `Refresh to try again.` };
+}

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -11,7 +11,7 @@ export interface SyncOutcome {
   error: string | null;
 }
 
-function logSyncResult(db: Database.Database, source: string, itemCount: number, error: string | null): void {
+export function logSyncResult(db: Database.Database, source: string, itemCount: number, error: string | null): void {
   db.prepare('INSERT INTO sync_log (source, ran_at, item_count, error) VALUES (?, ?, ?, ?)').run(
     source,
     new Date().toISOString(),

--- a/lib/time-logs-repo.test.ts
+++ b/lib/time-logs-repo.test.ts
@@ -11,6 +11,8 @@ import {
   elapsedHoursSinceStart,
   sumHoursLoggedOn,
   sumHoursLoggedOnByItem,
+  stopTimer,
+  getRunningTimer,
 } from './time-logs-repo';
 
 let db: Database.Database;
@@ -112,5 +114,45 @@ describe('sumHoursLoggedOn / sumHoursLoggedOnByItem', () => {
     expect(sumHoursLoggedOn(testDb, '2026-08-13')).toBe(0);
     expect(sumHoursLoggedOnByItem(testDb, '2026-08-13').size).toBe(0);
     testDb.close();
+  });
+});
+
+describe('stopTimer', () => {
+  it('closes the open log and banks the elapsed time, without requiring a status change', () => {
+    const item = createAdhocItem(db, { title: 'Timed' });
+    startTimer(db, item.id);
+    stopTimer(db, item.id);
+    const logs = listLogsByItem(db, item.id);
+    expect(logs).toHaveLength(1);
+    expect(logs[0].endedAt).not.toBeNull();
+    expect(logs[0].durationHours).not.toBeNull();
+  });
+
+  it('is a no-op when there is no open timer', () => {
+    const item = createAdhocItem(db, { title: 'Never started' });
+    expect(() => stopTimer(db, item.id)).not.toThrow();
+    expect(listLogsByItem(db, item.id)).toHaveLength(0);
+  });
+});
+
+describe('getRunningTimer', () => {
+  it('returns null when nothing is running', () => {
+    expect(getRunningTimer(db)).toBeNull();
+  });
+
+  it('returns the running item id, title, and start time', () => {
+    const item = createAdhocItem(db, { title: 'Active work' });
+    startTimer(db, item.id);
+    const running = getRunningTimer(db);
+    expect(running?.itemId).toBe(item.id);
+    expect(running?.itemTitle).toBe('Active work');
+    expect(running?.startedAt).toBeTruthy();
+  });
+
+  it('returns null again after the timer is stopped', () => {
+    const item = createAdhocItem(db, { title: 'Active work' });
+    startTimer(db, item.id);
+    stopTimer(db, item.id);
+    expect(getRunningTimer(db)).toBeNull();
   });
 });

--- a/lib/time-logs-repo.ts
+++ b/lib/time-logs-repo.ts
@@ -64,6 +64,45 @@ export function elapsedHoursSinceStart(db: Database.Database, itemId: number): n
   return (Date.now() - new Date(openLog.started_at).getTime()) / 3_600_000;
 }
 
+// Closes the currently open timer for an item, banking elapsed time as a
+// log entry, without touching the item's status. This is "pause the
+// clock, not the work" -- used by park (which used to leave a timer open
+// indefinitely) and by the timer-switch flow when the user starts a
+// different item while one is already running.
+export function stopTimer(db: Database.Database, itemId: number): void {
+  const openLog = db
+    .prepare('SELECT * FROM time_logs WHERE item_id = ? AND ended_at IS NULL ORDER BY id DESC LIMIT 1')
+    .get(itemId) as any;
+  if (!openLog) return;
+  const elapsed = elapsedHoursSinceStart(db, itemId);
+  db.prepare('UPDATE time_logs SET ended_at = ?, duration_hours = ? WHERE id = ?').run(
+    new Date().toISOString(),
+    elapsed,
+    openLog.id
+  );
+}
+
+export interface RunningTimer {
+  itemId: number;
+  itemTitle: string;
+  startedAt: string;
+}
+
+// At most one row should ever satisfy ended_at IS NULL across the whole
+// table -- every path that starts a timer (start, and the switch flow)
+// stops whatever was running first.
+export function getRunningTimer(db: Database.Database): RunningTimer | null {
+  const row = db
+    .prepare(
+      `SELECT tl.item_id as itemId, tl.started_at as startedAt, i.title as itemTitle
+       FROM time_logs tl JOIN items i ON i.id = tl.item_id
+       WHERE tl.ended_at IS NULL
+       ORDER BY tl.started_at DESC LIMIT 1`
+    )
+    .get() as RunningTimer | undefined;
+  return row ?? null;
+}
+
 export function undoLastCompletion(db: Database.Database, itemId: number): void {
   const lastLog = db.prepare('SELECT * FROM time_logs WHERE item_id = ? ORDER BY id DESC LIMIT 1').get(itemId) as any;
   if (lastLog) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,3 +67,16 @@ export interface TimeLog {
   durationHours: number | null;
   note: string | null;
 }
+
+export interface Plan {
+  date: string;
+  capacityMinutes: number;
+  note: string | null;
+}
+
+export interface PlanItem {
+  planDate: string;
+  itemId: number;
+  sortOrder: number;
+  estimateMinutes: number | null;
+}


### PR DESCRIPTION
## Summary
- Per-source sync status (last-read time, state, remedy text) replacing the global "synced" sentence, with a sprint progress bar showing both completed and elapsed marks
- A daily plan (`plans`/`plan_items`) backing a real "Plan the day" ritual (`P`): review yesterday's leftovers, choose today's picks, estimate durations, check capacity against a stated arithmetic ("Your call.")
- Today is hand-ordered (not re-sorted by score) with per-item estimate/logged time, running-timer header chip with switch-timer flow and a long-run nudge, and calibration sentences (estimate vs actual by work type) surfaced in the ritual and the wrap-up dialog
- `ShutdownDialog` becomes "Wrap up the day": plan comparison, per-item estimate-vs-actual, Tomorrow/Snooze/Drop for still-open items, and a persisted note

## Test plan
- [x] `npm test` — 351 passing
- [x] `npx tsc --noEmit` — clean
- [x] Manual verification via dev server + direct API calls: plan/estimate/reorder round-trip, capacity overage math, wrap-up note persistence, running-timer start/stop, simulated auth/rate-limit/network sync failures with correct remedy text
- [x] Grepped the diff for "streak"/"suggest"/productivity-grade language — none found

Closes #23