### PR TITLE
feat: add Docker packaging and self-host setup docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+.git
+.github
+.superpowers
+docs
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+.env*.local
+tsconfig.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npx", "next", "start", "-H", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,29 @@ variables.
 Data refresh is manual: use the **Refresh** button on the dashboard to pull
 the latest PRs, work items, and sprint status.
 
+## Self-hosting with Docker
+
+```bash
+docker compose up
+```
+
+This builds the image and starts Ariadne at `http://127.0.0.1:3000`. The
+SQLite database lives at `./data/ariadne.db` on the host (via a bind mount),
+so it persists across container restarts and rebuilds.
+
+By default the port is only published on the host's loopback interface
+(`127.0.0.1`), matching Ariadne's local-only philosophy. If you want to
+reach it from other devices on your network, change the port mapping in
+`docker-compose.yml` from `"127.0.0.1:3000:3000"` to `"3000:3000"`.
+
+Without compose:
+
+```bash
+docker build -t ariadne .
+docker run -d -p 127.0.0.1:3000:3000 -v $(pwd)/data:/data \
+  -e ARIADNE_DB_PATH=/data/ariadne.db ariadne
+```
+
 ## Scripts
 
 | Command | Description |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  ariadne:
+    build: .
+    ports:
+      # Loopback-only by default. Change to "3000:3000" to reach Ariadne
+      # from other devices on your network.
+      - "127.0.0.1:3000:3000"
+    volumes:
+      - ./data:/data
+    environment:
+      - ARIADNE_DB_PATH=/data/ariadne.db
+    restart: unless-stopped

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Builds the Docker image, runs it, and checks it serves the dashboard.
+set -euo pipefail
+
+IMAGE=ariadne-smoke-test
+CONTAINER=ariadne-smoke-test
+PORT="${PORT:-3010}"
+TIMEOUT=60
+
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Building image..."
+docker build -t "$IMAGE" .
+
+echo "Starting container..."
+docker run -d --name "$CONTAINER" -p "127.0.0.1:${PORT}:3000" "$IMAGE" >/dev/null
+
+echo "Waiting for the app to respond on http://127.0.0.1:${PORT} ..."
+elapsed=0
+until curl -sf "http://127.0.0.1:${PORT}" >/dev/null; do
+  if [ "$elapsed" -ge "$TIMEOUT" ]; then
+    echo "Timed out after ${TIMEOUT}s waiting for the app to respond."
+    docker logs "$CONTAINER"
+    exit 1
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+
+echo "OK: container served a response on http://127.0.0.1:${PORT}"


### PR DESCRIPTION
## Summary
- Add a minimal `Dockerfile` (single-stage, builds `better-sqlite3` from source) and `.dockerignore`
- Add `docker-compose.yml` with a bind-mounted `./data` volume for the SQLite file, port published to `127.0.0.1` by default (LAN exposure documented as an opt-in change)
- Add `scripts/docker-smoke-test.sh` to build, run, and curl-check the image
- Document self-hosting in the README

Packaging only, no architecture change.

Closes #13

## Test plan
- [x] Ran `scripts/docker-smoke-test.sh` locally: image builds, `better-sqlite3` compiles and loads, container responds on the mapped port
- [x] Verified `ARIADNE_DB_PATH` + bind mount persists the SQLite file to the host