### PR TITLE
Fix search modal filtering and stuck faded state

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -482,7 +482,10 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
       <ScoringReferenceDialog open={scoringReferenceOpen} onOpenChange={setScoringReferenceOpen} />
       <CommandPalette
         open={paletteOpen}
-        onOpenChange={setPaletteOpen}
+        onOpenChange={(next) => {
+          setPaletteOpen(next);
+          if (!next) setQuery('');
+        }}
         items={data.signals}
         savedViews={savedViews}
         search={query}

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -30,7 +30,10 @@ function CommandDialog({ open, onOpenChange, children }: CommandDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="overflow-hidden p-0">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          shouldFilter={false}
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
           {children}
         </Command>
       </DialogContent>


### PR DESCRIPTION
## Summary
- `cmdk`'s own internal filter was scoring `CommandItem`s by their synthetic `value` (e.g. `item-42`), not the title text `CommandPalette.tsx` already filters on — so real matches never showed and the modal always rendered "No results." Fixed with `shouldFilter={false}` so the app's own filtering is authoritative.
- Dismissing the palette without selecting anything never cleared the search query, leaving background items stuck faded with no visible way to reset. Fixed by clearing the query whenever the palette closes, not just on selection.

Fixes #36

## Test plan
- [x] Reproduced both issues live with a Playwright script against the dev server before the fix
- [x] Re-ran the same script after the fix: matching signals now appear under "Signals" in the modal, and dismissing + reopening shows an empty search field with items back at full opacity
- [x] `npx vitest run` — 359 tests passing