### PR TITLE
fix: distinguish scope errors from rate limits in sync failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,29 @@ docker run -d -p 127.0.0.1:3000:3000 -v $(pwd)/data:/data \
   -e ARIADNE_DB_PATH=/data/ariadne.db ariadne
 ```
 
+## Troubleshooting
+
+### Sync suddenly stopped working
+
+The dashboard shows a banner naming the source (GitHub or Azure DevOps),
+what went wrong, and what to do about it. The underlying causes are usually
+one of:
+
+- **Expired or revoked token.** The token was deleted, expired, or the
+  account it belongs to lost access. Generate a new one and paste it into
+  **Settings**.
+- **Missing scope.** The token is valid but lacks a permission Ariadne
+  needs. For GitHub, a classic PAT needs the `repo` scope (or, for a
+  fine-grained PAT, read access to **Pull requests** and **Metadata**); for
+  Azure DevOps, the PAT needs **Work Items (Read)**. Re-generate the token
+  with the right scope and update it in Settings — refreshing the page
+  won't help here.
+- **Rate limit.** GitHub and Azure DevOps both throttle API calls. This
+  resolves on its own; wait a few minutes and click **Refresh**.
+
+Until it's fixed, Ariadne keeps showing the last data it read from that
+source, marked stale, rather than hiding it.
+
 ## Scripts
 
 | Command | Description |

--- a/components/SprintProgressHeader.tsx
+++ b/components/SprintProgressHeader.tsx
@@ -139,11 +139,13 @@ export default function SprintProgressHeader({
                 {SOURCE_LABEL[status.source]}{' '}
                 {cause === 'auth'
                   ? 'rejected the token'
-                  : cause === 'rate_limit'
-                    ? 'rate limit was hit'
-                    : cause === 'network'
-                      ? 'could not be reached'
-                      : 'failed to sync'}
+                  : cause === 'scope'
+                    ? 'token is missing a required permission'
+                    : cause === 'rate_limit'
+                      ? 'rate limit was hit'
+                      : cause === 'network'
+                        ? 'could not be reached'
+                        : 'failed to sync'}
                 .
               </span>{' '}
               {status.lastSyncedAt

--- a/lib/ado-client.test.ts
+++ b/lib/ado-client.test.ts
@@ -219,3 +219,32 @@ describe('read-only guard', () => {
     }
   });
 });
+
+function errorResponse(status: number, body: string, headers: Record<string, string> = {}) {
+  return {
+    ok: false,
+    status,
+    text: async () => body,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+  } as unknown as Response;
+}
+
+describe('Azure DevOps API error handling', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('reports a rate-limit error for a 429 response', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(errorResponse(429, 'Too many requests'));
+
+    await expect(fetchAdoData({ pat: 'x', org: 'org', project: 'project' })).rejects.toThrow(/rate limit/i);
+  });
+
+  it('reports a scope error for a 403 response', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(errorResponse(403, 'Access denied'));
+
+    await expect(fetchAdoData({ pat: 'x', org: 'org', project: 'project' })).rejects.toThrow(/missing a required scope/i);
+  });
+});

--- a/lib/ado-client.ts
+++ b/lib/ado-client.ts
@@ -16,6 +16,20 @@ function authHeader(pat: string): string {
   return 'Basic ' + Buffer.from(':' + pat).toString('base64');
 }
 
+// A 403 from Azure DevOps means the token is missing a required scope, not
+// that it hit a rate limit (ADO signals that with 429 instead) — classifyError()
+// needs the two told apart so the remedy points at the token, not a retry.
+async function adoApiError(res: Response): Promise<Error> {
+  const body = await res.text();
+  if (res.status === 429) {
+    return new Error(`Azure DevOps rate limit exceeded: ${body}`);
+  }
+  if (res.status === 403) {
+    return new Error(`Azure DevOps API error 403 (token may be missing a required scope): ${body}`);
+  }
+  return new Error(`Azure DevOps API error ${res.status}: ${body}`);
+}
+
 async function adoFetch(config: AdoConfig, url: string, init: RequestInit = {}): Promise<any> {
   const res = await fetch(url, {
     ...init,
@@ -26,7 +40,7 @@ async function adoFetch(config: AdoConfig, url: string, init: RequestInit = {}):
     },
   });
   if (!res.ok) {
-    throw new Error(`Azure DevOps API error ${res.status}: ${await res.text()}`);
+    throw await adoApiError(res);
   }
   return res.json();
 }

--- a/lib/github-client.test.ts
+++ b/lib/github-client.test.ts
@@ -579,3 +579,39 @@ describe('fetchMergedExternalIds', () => {
     expect(result.size).toBe(0);
   });
 });
+
+function errorResponse(status: number, body: string, headers: Record<string, string> = {}) {
+  return {
+    ok: false,
+    status,
+    text: async () => body,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+  } as unknown as Response;
+}
+
+describe('GitHub API error handling', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('reports a rate-limit error when a 403 carries an exhausted rate-limit header', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(errorResponse(403, 'Forbidden', { 'x-ratelimit-remaining': '0' }));
+
+    await expect(fetchGithubItems({ pat: 'x', staleDays: 3 })).rejects.toThrow(/rate limit/i);
+  });
+
+  it('reports a scope error when a 403 has no rate-limit signal', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(errorResponse(403, 'Resource not accessible by personal access token'));
+
+    await expect(fetchGithubItems({ pat: 'x', staleDays: 3 })).rejects.toThrow(/missing a required scope/i);
+  });
+
+  it('reports a rate-limit error for a 429 response', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue(errorResponse(429, 'Too many requests'));
+
+    await expect(fetchGithubItems({ pat: 'x', staleDays: 3 })).rejects.toThrow(/rate limit/i);
+  });
+});

--- a/lib/github-client.ts
+++ b/lib/github-client.ts
@@ -7,6 +7,21 @@ export interface GithubConfig {
   staleDays: number;
 }
 
+// GitHub returns 403 for both an exhausted rate limit and a token that's
+// missing a required scope; only the rate-limit headers tell them apart, and
+// classifyError() needs that distinction to avoid a "just refresh" remedy on
+// a permissions problem refreshing can't fix.
+async function githubApiError(res: Response, label: string): Promise<Error> {
+  const body = await res.text();
+  if (res.status === 429 || (res.status === 403 && res.headers?.get('x-ratelimit-remaining') === '0')) {
+    return new Error(`GitHub rate limit exceeded (${label}): ${body}`);
+  }
+  if (res.status === 403) {
+    return new Error(`GitHub API error 403 (token may be missing a required scope): ${body}`);
+  }
+  return new Error(`GitHub API error ${res.status}: ${body}`);
+}
+
 async function githubFetch(pat: string, path: string): Promise<any> {
   const res = await fetch(`${GITHUB_API}${path}`, {
     headers: {
@@ -15,7 +30,7 @@ async function githubFetch(pat: string, path: string): Promise<any> {
     },
   });
   if (!res.ok) {
-    throw new Error(`GitHub API error ${res.status}: ${await res.text()}`);
+    throw await githubApiError(res, path);
   }
   return res.json();
 }
@@ -30,7 +45,7 @@ async function githubGraphql(pat: string, query: string, variables: Record<strin
     body: JSON.stringify({ query, variables }),
   });
   if (!res.ok) {
-    throw new Error(`GitHub GraphQL error ${res.status}: ${await res.text()}`);
+    throw await githubApiError(res, 'graphql');
   }
   return res.json();
 }

--- a/lib/sync-status.test.ts
+++ b/lib/sync-status.test.ts
@@ -86,4 +86,16 @@ describe('classifyError', () => {
   it('falls back to unknown for an unrecognized message', () => {
     expect(classifyError('Something unexpected happened', 'GitHub').cause).toBe('unknown');
   });
+
+  it('classifies a missing-scope message as scope, not rate_limit', () => {
+    const result = classifyError('GitHub API error 403 (token may be missing a required scope): Forbidden', 'GitHub');
+    expect(result.cause).toBe('scope');
+    expect(result.remedy).toContain('scope');
+  });
+
+  it('classifies a plain 403 without rate-limit wording as scope', () => {
+    expect(classifyError('Azure DevOps API error 403 (token may be missing a required scope): Access denied', 'Azure DevOps').cause).toBe(
+      'scope'
+    );
+  });
 });

--- a/lib/sync-status.ts
+++ b/lib/sync-status.ts
@@ -50,19 +50,27 @@ export function getAllSourceStatuses(db: Database.Database, now: Date): SourceSt
 }
 
 export interface ErrorClassification {
-  cause: 'auth' | 'rate_limit' | 'network' | 'unknown';
+  cause: 'auth' | 'scope' | 'rate_limit' | 'network' | 'unknown';
   remedy: string;
 }
 
 // Gives a fix, not a countdown, per the issue's copy guardrail: "Try again
 // later" makes the user run the experiment themselves.
+//
+// Order matters: rate_limit and scope are both checked before auth because
+// the github/ado clients report both as HTTP 403, and a bare 403 message
+// happens to contain the word "token" too — checked first, "auth" would
+// swallow both and tell the user to refresh a token that isn't the problem.
 export function classifyError(message: string, sourceLabel: string): ErrorClassification {
   const m = message.toLowerCase();
+  if (/rate limit/.test(m)) {
+    return { cause: 'rate_limit', remedy: `${sourceLabel}'s rate limit was hit. Refresh again in a few minutes.` };
+  }
+  if (/missing a required scope/.test(m)) {
+    return { cause: 'scope', remedy: `Check that your ${sourceLabel} token has the required read scope, then update it in Settings.` };
+  }
   if (/401|unauthoriz|bad credentials|token/.test(m)) {
     return { cause: 'auth', remedy: `Update the ${sourceLabel} token in Settings, then refresh.` };
-  }
-  if (/403|rate limit/.test(m)) {
-    return { cause: 'rate_limit', remedy: `${sourceLabel}'s rate limit was hit. Refresh again in a few minutes.` };
   }
   if (/network|econnrefused|enotfound|fetch failed/.test(m)) {
     return { cause: 'network', remedy: `Check your connection, then refresh.` };


### PR DESCRIPTION
## Summary
- GitHub and Azure DevOps both surface an insufficient-scope token and an exhausted rate limit as HTTP 403, so `classifyError()` was labeling any 403 as a rate limit and telling the user to just refresh — which does nothing for a token missing a permission.
- `github-client.ts`/`ado-client.ts` now use the response status and headers (GitHub's `x-ratelimit-remaining`, ADO's 429) to tell the two apart, and `classifyError()` gets a new `scope` cause with its own remedy.
- Added a README troubleshooting section for "sync suddenly stopped working" covering expired PAT, missing scope, and rate limits.

Closes #10.

## Test plan
- [x] `npm test` (366 tests, all passing)
- [x] `npx tsc --noEmit` (clean)