### PR TITLE
fix: grant issues/pull-requests write for semantic-release's comment step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- The `v1.0.0` release run (after #40's Node 22 fix) actually succeeded end to end: tag `v1.0.0` created, GitHub Release published, `CHANGELOG.md`/`package.json` bumped, and the Docker image pushed to both `ghcr.io/chriskievit/ariadne:1.0.0` and `:latest`.
- The job still showed red because `@semantic-release/github`'s `success` step tries to comment "released in v1.0.0" on every issue/PR referenced in the released commits (213 commits in this first release). The `release` job's `permissions:` block only granted `contents: write` and `packages: write`, so each comment attempt failed with `403 Resource not accessible by integration`.
- Adds `issues: write` and `pull-requests: write` to the job's permissions.

## Test plan
- [x] `actionlint` on `release.yml` — clean
- [ ] Next push to `main` (this fix commit is itself a `fix:`, so it will trigger `v1.0.1`) should complete the `release` job fully green, including the issue/PR comments