### PR TITLE
fix: stop header timer chip immediately when timer stops elsewhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ node_modules
 docs/superpowers/
 docs/wireframes/
 .DS_Store
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from '@/components/ui/sonner';
 import { SearchProvider } from '@/components/SearchProvider';
 import { CommandPaletteProvider } from '@/components/CommandPaletteProvider';
 import { DensityProvider } from '@/components/DensityProvider';
+import { RunningTimerProvider } from '@/components/RunningTimerProvider';
 import TopBar from '@/components/TopBar';
 import { db } from '@/lib/db-instance';
 import { getSetting } from '@/lib/settings-repo';
@@ -36,8 +37,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <DensityProvider density={density}>
             <SearchProvider>
               <CommandPaletteProvider>
-                <TopBar />
-                {children}
+                <RunningTimerProvider>
+                  <TopBar />
+                  {children}
+                </RunningTimerProvider>
               </CommandPaletteProvider>
             </SearchProvider>
           </DensityProvider>

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -7,6 +7,7 @@ import { Accordion } from '@/components/ui/accordion';
 import { Card, CardContent } from '@/components/ui/card';
 import { useSearch } from './SearchProvider';
 import { useCommandPalette } from './CommandPaletteProvider';
+import { useRunningTimer } from './RunningTimerProvider';
 import { matchesQuery } from '@/lib/search';
 import SprintProgressHeader from './SprintProgressHeader';
 import ItemSection from './ItemSection';
@@ -41,7 +42,6 @@ import {
   setItemDone,
   fetchSavedViews,
   fetchSourceStatuses,
-  fetchRunningTimer,
   stopTimerRequest,
   fetchPlan,
   updatePlan,
@@ -54,7 +54,6 @@ import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
 import { groupOf } from '@/lib/grouping';
 import { localDateString, addDays } from '@/lib/date';
 import { DEFAULT_CAPACITY_MINUTES } from '@/lib/config';
-import type { RunningTimer } from '@/lib/time-logs-repo';
 import type { CalibrationEntry } from '@/lib/calibration';
 import type { ScoredItem } from '@/lib/dashboard';
 import type { SprintProgress } from '@/lib/sprint';
@@ -83,7 +82,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
   const [sourceStatuses, setSourceStatuses] = useState<SourceStatus[]>([]);
   const [planDayOpen, setPlanDayOpen] = useState(false);
-  const [runningTimer, setRunningTimer] = useState<RunningTimer | null>(null);
+  const { runningTimer, refreshRunningTimer } = useRunningTimer();
   const [switchTimerOpen, setSwitchTimerOpen] = useState(false);
   const [pendingStartId, setPendingStartId] = useState<number | null>(null);
   const [yesterdayItems, setYesterdayItems] = useState<Item[]>([]);
@@ -111,7 +110,6 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
     const today = localDateString(new Date());
     const yesterday = addDays(today, -1);
     fetchSourceStatuses().then(setSourceStatuses);
-    fetchRunningTimer().then(setRunningTimer);
     fetchPlan(today).then((planResponse) => {
       setPlan(planResponse.plan);
       setPlanItems(planResponse.items);
@@ -132,17 +130,16 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
   async function refresh() {
     const today = localDateString(new Date());
     const yesterday = addDays(today, -1);
-    const [fresh, statuses, timer, planResponse, yesterdaySummary, calibrationSummary] = await Promise.all([
+    const [fresh, statuses, , planResponse, yesterdaySummary, calibrationSummary] = await Promise.all([
       fetchDashboardData(),
       fetchSourceStatuses(),
-      fetchRunningTimer(),
+      refreshRunningTimer(),
       fetchPlan(today),
       fetchTodaySummaryFor(yesterday),
       fetchCalibration(today, today),
     ]);
     setData(fresh);
     setSourceStatuses(statuses);
-    setRunningTimer(timer);
     setPlan(planResponse.plan);
     setPlanItems(planResponse.items);
     setYesterdayItems(yesterdaySummary.planned);

--- a/components/RunningTimerProvider.tsx
+++ b/components/RunningTimerProvider.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { fetchRunningTimer } from '@/lib/api-client';
+import type { RunningTimer } from '@/lib/time-logs-repo';
+
+const RUNNING_TIMER_POLL_MS = 5000;
+
+interface RunningTimerContextValue {
+  runningTimer: RunningTimer | null;
+  refreshRunningTimer: () => Promise<RunningTimer | null>;
+}
+
+const RunningTimerContext = createContext<RunningTimerContextValue | null>(null);
+
+// A single poller + a single piece of state shared by every consumer (the
+// header's live chip, the dashboard's start/switch-timer logic, ...) so that
+// an action taken in one place (e.g. parking an item from its row menu)
+// updates everyone else immediately via refreshRunningTimer(), instead of
+// each consumer keeping its own copy that only catches up on its own next
+// poll tick.
+export function RunningTimerProvider({ children }: { children: React.ReactNode }) {
+  const [runningTimer, setRunningTimer] = useState<RunningTimer | null>(null);
+
+  const refreshRunningTimer = useCallback(async () => {
+    const timer = await fetchRunningTimer();
+    setRunningTimer(timer);
+    return timer;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function poll() {
+      const timer = await fetchRunningTimer();
+      if (!cancelled) setRunningTimer(timer);
+    }
+    poll();
+    const interval = setInterval(poll, RUNNING_TIMER_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return (
+    <RunningTimerContext.Provider value={{ runningTimer, refreshRunningTimer }}>
+      {children}
+    </RunningTimerContext.Provider>
+  );
+}
+
+export function useRunningTimer(): RunningTimerContextValue {
+  const ctx = useContext(RunningTimerContext);
+  if (!ctx) throw new Error('useRunningTimer must be used within a RunningTimerProvider');
+  return ctx;
+}

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -8,15 +8,13 @@ import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { useCommandPalette } from '@/components/CommandPaletteProvider';
 import RunningTimerChip from '@/components/RunningTimerChip';
-import { fetchRunningTimer, stopTimerRequest, fetchSettings } from '@/lib/api-client';
+import { useRunningTimer } from '@/components/RunningTimerProvider';
+import { stopTimerRequest, fetchSettings } from '@/lib/api-client';
 import { SETTINGS_KEYS, DEFAULT_LONG_RUN_NUDGE_HOURS } from '@/lib/config';
-import type { RunningTimer } from '@/lib/time-logs-repo';
-
-const RUNNING_TIMER_POLL_MS = 5000;
 
 export default function TopBar() {
   const { setOpen } = useCommandPalette();
-  const [runningTimer, setRunningTimer] = useState<RunningTimer | null>(null);
+  const { runningTimer, refreshRunningTimer } = useRunningTimer();
   const [longRunNudgeHours, setLongRunNudgeHours] = useState(DEFAULT_LONG_RUN_NUDGE_HOURS);
 
   useEffect(() => {
@@ -31,24 +29,10 @@ export default function TopBar() {
     };
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    async function poll() {
-      const timer = await fetchRunningTimer();
-      if (!cancelled) setRunningTimer(timer);
-    }
-    poll();
-    const interval = setInterval(poll, RUNNING_TIMER_POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, []);
-
   async function handleStopTimer() {
     if (!runningTimer) return;
     await stopTimerRequest(runningTimer.itemId);
-    setRunningTimer(await fetchRunningTimer());
+    await refreshRunningTimer();
   }
 
   return (

--- a/e2e/db-path.ts
+++ b/e2e/db-path.ts
@@ -1,0 +1,6 @@
+import path from 'node:path';
+import os from 'node:os';
+
+export const E2E_DB_PATH = path.join(os.tmpdir(), 'ariadne-e2e.db');
+export const E2E_PORT = 4180;
+export const E2E_BASE_URL = `http://127.0.0.1:${E2E_PORT}`;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,8 @@
+import fs from 'node:fs';
+import { E2E_DB_PATH } from './db-path';
+
+export default function globalSetup(): void {
+  for (const suffix of ['', '-wal', '-shm']) {
+    fs.rmSync(`${E2E_DB_PATH}${suffix}`, { force: true });
+  }
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,7 @@
+import type { APIRequestContext } from '@playwright/test';
+
+export async function createItem(request: APIRequestContext, title: string): Promise<number> {
+  const res = await request.post('/api/items', { data: { title } });
+  const item = await res.json();
+  return item.id;
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('dashboard loads', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('link', { name: 'Ariadne' })).toBeVisible();
+});

--- a/e2e/timer-pause.spec.ts
+++ b/e2e/timer-pause.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+import { createItem } from './helpers';
+
+test('header timer chip disappears immediately when an item is parked from its row menu', async ({
+  page,
+  request,
+}) => {
+  const title = `Timer pause test ${Date.now()}`;
+  const itemId = await createItem(request, title);
+
+  await page.goto('/');
+  const row = page.locator(`[data-row-id="${itemId}"]`);
+  await row.waitFor();
+  await row.getByRole('button', { name: /^Start$/ }).click();
+
+  const pauseBtn = page.getByRole('button', { name: 'Pause timer' });
+  await expect(pauseBtn).toBeVisible();
+  await expect(page.locator('header')).toContainText(title);
+
+  await row.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name: /Park/ }).click();
+
+  // The poll interval that used to gate this update is 5s -- assert it
+  // clears well before that so a regression back to poll-only updates fails.
+  await expect(pauseBtn).toBeHidden({ timeout: 2000 });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@semantic-release/changelog": "^7.0.0",
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/exec": "^7.1.0",
@@ -959,6 +960,22 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^28.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -9020,6 +9037,52 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.16",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -H 127.0.0.1",
     "build": "next build",
     "start": "next start -H 127.0.0.1",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",
@@ -35,6 +36,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@semantic-release/changelog": "^7.0.0",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^7.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+import { E2E_BASE_URL, E2E_DB_PATH, E2E_PORT } from './e2e/db-path';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: 'list',
+  globalSetup: './e2e/global-setup.ts',
+  use: {
+    baseURL: E2E_BASE_URL,
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: `npm run dev -- -p ${E2E_PORT}`,
+    url: E2E_BASE_URL,
+    reuseExistingServer: false,
+    timeout: 30_000,
+    env: { ARIADNE_DB_PATH: E2E_DB_PATH },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 export default defineConfig({
   test: {
     environment: 'node',
-    exclude: ['**/node_modules/**', '**/dist/**', '**/.git/**', '**/.claude/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.git/**', '**/.claude/**', '**/e2e/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Fixes #43

TopBar polled `/api/timer/running` on its own independent 5s interval, decoupled from Dashboard's own running-timer state. Parking (pausing) an item from its row menu stopped the timer server-side immediately, but the header chip kept ticking until TopBar's next poll — reading as "the pause button doesn't stop the timer."

## Fix
Added `RunningTimerProvider`, a shared context so TopBar and Dashboard read the same running-timer state. Any action that can change it (start, park, requeue, complete, switch, stop) now calls `refreshRunningTimer()`, so every consumer updates instantly instead of waiting on its own poll tick.

Also sets up Playwright for e2e testing (wasn't in the repo before) since this bug is fundamentally about cross-component timing, which unit tests can't catch.

## Test plan
- [x] `npm test` (366 unit tests pass)
- [x] `npm run test:e2e` — new `e2e/timer-pause.spec.ts` asserts the header chip disappears within 2s of parking (well under the old 5s poll interval)
- [x] Verified the new e2e test fails against the pre-fix code and passes against the fix