### PR TITLE
fix: start both linked items when a timer is already running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       - run: npm test
       - run: npx tsc --noEmit
       - run: npm run build
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e
       - name: Guard against non-GET calls in the read-only provider clients
         run: |
           # Both files are read-only in effect. Each has exactly one

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -85,6 +85,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
   const { runningTimer, refreshRunningTimer } = useRunningTimer();
   const [switchTimerOpen, setSwitchTimerOpen] = useState(false);
   const [pendingStartId, setPendingStartId] = useState<number | null>(null);
+  const [pendingStartAlsoIds, setPendingStartAlsoIds] = useState<number[]>([]);
   const [yesterdayItems, setYesterdayItems] = useState<Item[]>([]);
   const [plan, setPlan] = useState<Plan>({
     date: localDateString(new Date()),
@@ -157,13 +158,17 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
     }
   }
 
-  async function handleStart(id: number) {
+  async function handleStart(id: number, alsoStartIds: number[] = []) {
     if (runningTimer && runningTimer.itemId !== id) {
       setPendingStartId(id);
+      setPendingStartAlsoIds(alsoStartIds);
       setSwitchTimerOpen(true);
       return;
     }
     await startItem(id);
+    for (const linkId of alsoStartIds) {
+      await startItem(linkId);
+    }
     await refresh();
   }
 
@@ -171,14 +176,21 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
     if (runningTimer) await stopTimerRequest(runningTimer.itemId);
     setSwitchTimerOpen(false);
     setPendingStartId(null);
+    setPendingStartAlsoIds([]);
     await refresh();
   }
 
   async function handleSwitchTimer() {
     if (runningTimer) await stopTimerRequest(runningTimer.itemId);
-    if (pendingStartId !== null) await startItem(pendingStartId);
+    if (pendingStartId !== null) {
+      await startItem(pendingStartId);
+      for (const linkId of pendingStartAlsoIds) {
+        await startItem(linkId);
+      }
+    }
     setSwitchTimerOpen(false);
     setPendingStartId(null);
+    setPendingStartAlsoIds([]);
     await refresh();
   }
 

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -121,7 +121,7 @@ interface Props {
     links?: LinkedRef[];
     estimateMinutes?: number | null;
   };
-  onStart?: (id: number) => void;
+  onStart?: (id: number, alsoStartIds?: number[]) => void;
   onRequeue?: (id: number) => void;
   onComplete: (id: number, durationHours: number, note?: string) => void;
   onOpenClaude: (id: number, workingDir?: string) => void;
@@ -585,10 +585,10 @@ export default function ItemRow({
           <Button
             type="button"
             onClick={() => {
-              onStart?.(item.id);
-              pendingStartLinks.forEach((link) => {
-                if (link.itemId !== null) onStart?.(link.itemId);
-              });
+              const linkIds = pendingStartLinks
+                .map((link) => link.itemId)
+                .filter((id): id is number => id !== null);
+              onStart?.(item.id, linkIds);
               setStartCascadeOpen(false);
             }}
           >

--- a/components/ItemSection.tsx
+++ b/components/ItemSection.tsx
@@ -12,7 +12,7 @@ interface Props {
   items: ScoredItem[];
   parkedItems?: ScoredItem[];
   emptyMessage: string;
-  onStart?: (id: number) => void;
+  onStart?: (id: number, alsoStartIds?: number[]) => void;
   onComplete: (id: number, durationHours: number, note?: string) => void;
   onOpenClaude: (id: number, workingDir?: string) => void;
   onDelete?: (id: number) => void;

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -59,7 +59,7 @@ function StatusKeyPopover() {
 
 interface Props {
   items: ScoredItem[];
-  onStart: (id: number) => void;
+  onStart: (id: number, alsoStartIds?: number[]) => void;
   onComplete: (id: number, durationHours: number, note?: string) => void;
   onOpenClaude: (id: number, workingDir?: string) => void;
   onDelete: (id: number) => void;

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -11,7 +11,7 @@ import type { Item } from '@/lib/types';
 interface Props {
   items: ScoredItem[];
   capacityMinutes: number;
-  onStart?: (id: number) => void;
+  onStart?: (id: number, alsoStartIds?: number[]) => void;
   onComplete: (id: number, durationHours: number, note?: string) => void;
   onOpenClaude: (id: number, workingDir?: string) => void;
   onDelete?: (id: number) => void;

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -5,3 +5,13 @@ export async function createItem(request: APIRequestContext, title: string): Pro
   const item = await res.json();
   return item.id;
 }
+
+// Tests share one dev server (and its "at most one running timer" global
+// state) across the whole run -- stop whatever a prior test left running so
+// each test starts from a known state instead of racing the switch-timer
+// dialog it didn't expect.
+export async function ensureNoRunningTimer(request: APIRequestContext): Promise<void> {
+  const res = await request.get('/api/timer/running');
+  const timer = await res.json();
+  if (timer) await request.post(`/api/items/${timer.itemId}/stop-timer`);
+}

--- a/e2e/linked-item-start.spec.ts
+++ b/e2e/linked-item-start.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { createItem, ensureNoRunningTimer } from './helpers';
+import { seedLinkedPair } from './seed-links';
+
+async function inProgressIds(request: import('@playwright/test').APIRequestContext): Promise<number[]> {
+  const res = await request.get('/api/items');
+  const body = await res.json();
+  return (body.inProgress as { id: number }[]).map((i) => i.id);
+}
+
+test('starting a linked item with "Start both" moves both to In Progress even while another item is already running', async ({
+  page,
+  request,
+}) => {
+  await ensureNoRunningTimer(request);
+  const suffix = String(Date.now());
+  const { prItemId, adoItemId, adoTitle } = seedLinkedPair(suffix);
+  const otherTitle = `Already running ${suffix}`;
+  const otherItemId = await createItem(request, otherTitle);
+
+  await page.goto('/');
+
+  // Start an unrelated item first so a timer is already running -- this is
+  // the condition the bug report says makes the cascade fail entirely.
+  const otherRow = page.locator(`[data-row-id="${otherItemId}"]`);
+  await otherRow.waitFor();
+  await otherRow.getByRole('button', { name: /^Start$/ }).click();
+  await expect(page.locator('header')).toContainText(otherTitle);
+
+  const prRow = page.locator(`[data-row-id="${prItemId}"]`);
+  await prRow.waitFor();
+  await prRow.getByRole('button', { name: /^Start$/ }).click();
+
+  await expect(page.getByRole('dialog', { name: /Start linked item/ })).toBeVisible();
+  await page.getByRole('button', { name: /^Start both$/ }).click();
+
+  await expect(page.getByRole('dialog', { name: 'A timer is already running' })).toBeVisible();
+  await page.getByRole('button', { name: 'Switch' }).click();
+
+  // The link's timer starts second (after the item that was clicked), so it
+  // ends up as the one live-running -- both still land in In Progress below.
+  await expect(page.locator('header')).toContainText(adoTitle);
+
+  const ids = await inProgressIds(request);
+  expect(ids).toContain(prItemId);
+  expect(ids).toContain(adoItemId);
+
+  await ensureNoRunningTimer(request);
+});

--- a/e2e/seed-links.ts
+++ b/e2e/seed-links.ts
@@ -1,0 +1,44 @@
+import { openDb } from '../lib/db';
+import { upsertSyncedItem } from '../lib/items-repo';
+import { E2E_DB_PATH } from './db-path';
+
+// Linked items (a GitHub PR <-> an ADO work item) only ever come from a real
+// sync against GitHub/ADO, which e2e tests can't do. Seed them directly
+// against the same sqlite file the dev server under test points at.
+export function seedLinkedPair(suffix: string): { prItemId: number; adoItemId: number; prTitle: string; adoTitle: string } {
+  const db = openDb(E2E_DB_PATH);
+  try {
+    const adoExternalId = `${Date.now()}${suffix}`;
+    const adoTitle = `Linked ADO item ${suffix}`;
+    const prTitle = `Linked PR item ${suffix}`;
+
+    const adoItem = upsertSyncedItem(db, {
+      source: 'ado_workitem',
+      externalId: adoExternalId,
+      title: adoTitle,
+      url: 'https://example.test/ado/1',
+      reason: 'assigned',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: new Date().toISOString(),
+      repo: null,
+    });
+
+    const prItem = upsertSyncedItem(db, {
+      source: 'github_pr',
+      externalId: `${adoExternalId}@pr`,
+      title: prTitle,
+      url: 'https://example.test/pr/1',
+      reason: 'authored',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: new Date().toISOString(),
+      repo: null,
+      linkedAdoExternalIds: [adoExternalId],
+    });
+
+    return { prItemId: prItem.id, adoItemId: adoItem.id, prTitle, adoTitle };
+  } finally {
+    db.close();
+  }
+}

--- a/e2e/timer-pause.spec.ts
+++ b/e2e/timer-pause.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { createItem } from './helpers';
+import { createItem, ensureNoRunningTimer } from './helpers';
 
 test('header timer chip disappears immediately when an item is parked from its row menu', async ({
   page,
   request,
 }) => {
+  await ensureNoRunningTimer(request);
   const title = `Timer pause test ${Date.now()}`;
   const itemId = await createItem(request, title);
 


### PR DESCRIPTION
Fixes #44

`handleStart(id)` opens the switch-timer confirmation and returns without starting anything whenever a different item's timer is already running. The "Start linked item(s) too?" dialog's buttons called `onStart()` once per item to start — each call independently hit that early return, stomped on the shared `pendingStartId`, and never actually called `startItem()` for any of them. Both "Just this one" and "Start both/all" silently did nothing whenever a timer was already running elsewhere, matching the report ("I think it never works if you have an existing running item").

## Fix
`onStart` now optionally takes the linked ids to start alongside the clicked item. Dashboard resolves the switch-timer confirmation once (stop the old timer, if any) and then starts the clicked item plus all its linked ids together, instead of each dialog button independently racing the same shared state.

## Test plan
- [x] `npm test` (366 unit tests pass)
- [x] `npm run test:e2e` — new `e2e/linked-item-start.spec.ts` seeds a linked GitHub PR / ADO work item pair, starts an unrelated item first (to reproduce "a timer is already running"), then clicks "Start both" and confirms the switch — asserts both linked items land in In Progress
- [x] Verified the new e2e test fails against the pre-fix code (neither item reached In Progress) and passes against the fix