### PR TITLE
fix: give snoozed items their own visible sub-list

### DIFF
--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -103,6 +103,7 @@ export default function SignalsBoard({
     lower_priority: false,
   });
   const [lastValidParsed, setLastValidParsed] = useState(parseQuery(''));
+  const [snoozedOpen, setSnoozedOpen] = useState(false);
 
   const parsed = parseQuery(queryText);
   const activeParsed = parsed.errors.length === 0 ? parsed : lastValidParsed;
@@ -120,6 +121,14 @@ export default function SignalsBoard({
       (activeParsed.filters.some((f) => f.prefix === 'is' && f.values.includes('done')) || item.triageState !== 'done')
   );
   const filtered = applyQuery(withoutHiddenTriage, activeParsed, context);
+
+  // Snoozed items get their own always-visible sub-list (same pattern as
+  // Paused in ItemSection) instead of only being reachable by typing
+  // `is:snoozed` -- otherwise a snoozed item just disappears with no
+  // indication it still exists.
+  const snoozedItems = items.filter(
+    (item) => isSnoozed(item.snoozedUntil, context.now) && item.triageState !== 'done'
+  );
 
   const needsYouCount = useMemo(
     () => withoutHiddenTriage.filter((item) => groupOf(item) === 'blocked' || groupOf(item) === 'waiting_on_you').length,
@@ -280,6 +289,40 @@ export default function SignalsBoard({
           </section>
         );
       })}
+      {snoozedItems.length > 0 && (
+        <section className="mb-4">
+          <button
+            type="button"
+            aria-expanded={snoozedOpen}
+            aria-controls="signals-snoozed"
+            onClick={() => setSnoozedOpen((prev) => !prev)}
+            className="flex w-full items-center pb-1 pt-3 text-xs font-medium text-muted-foreground hover:text-foreground"
+          >
+            Snoozed · <span className="ml-1 font-mono tabular-nums">{snoozedItems.length}</span>
+          </button>
+          {snoozedOpen && (
+            <div id="signals-snoozed">
+              {snoozedItems.map((item) => (
+                <ItemRow
+                  key={item.id}
+                  item={item}
+                  onStart={onStart}
+                  onComplete={onComplete}
+                  onOpenClaude={onOpenClaude}
+                  onDelete={onDelete}
+                  onPinToday={onPinToday}
+                  onStar={onStar}
+                  onSnooze={onSnooze}
+                  onUnsnooze={onUnsnooze}
+                  onDone={onDone}
+                  sourceIsStale={failingSources?.has(item.source)}
+                  onOpenScoringReference={onOpenScoringReference}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
     </div>
   );
 }

--- a/e2e/snoozed-visibility.spec.ts
+++ b/e2e/snoozed-visibility.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { createItem } from './helpers';
+
+test('snoozed items are reachable from a Snoozed sub-list without typing a filter', async ({ page, request }) => {
+  const title = `Snooze visibility test ${Date.now()}`;
+  const itemId = await createItem(request, title);
+  await request.post(`/api/items/${itemId}/snooze`, { data: { option: 'next_week' } });
+
+  await page.goto('/');
+
+  // Not visible in the main signals list without any filter applied.
+  await expect(page.locator(`[data-row-id="${itemId}"]`)).toHaveCount(0);
+
+  const snoozedToggle = page.getByRole('button', { name: /^Snoozed ·/ });
+  await expect(snoozedToggle).toBeVisible();
+  await snoozedToggle.click();
+
+  const row = page.locator(`[data-row-id="${itemId}"]`);
+  await expect(row).toBeVisible();
+  await expect(row).toContainText(title);
+});


### PR DESCRIPTION
Fixes #45

Snoozed items were fully invisible in Signals unless you knew to type `is:snoozed` in the filter bar — there was no on-screen hint they existed at all, which read as a semantic clash with Paused (parked in-progress items), which already gets a discoverable dimmed sub-list.

## Fix
Added a "Snoozed · N" collapsible sub-list to Signals (same pattern as the existing "Paused · N" sub-list in ItemSection), so snoozed items have a persistent, obvious home regardless of the active query — no filter syntax required.

Scoped this to the concrete, actionable part of the report (visibility). The `is:snoozed` filter still works as before for anyone who wants to query for it directly.

## Test plan
- [x] `npm test` (366 unit tests pass)
- [x] `npm run test:e2e` — new `e2e/snoozed-visibility.spec.ts` snoozes an item, confirms it's absent from the main list, then confirms it's visible after expanding the new "Snoozed" toggle
- [x] Verified the new e2e test fails against the pre-fix code and passes against the fix