### PR TITLE
fix: add active-filter pills and a persistent clear button to the filter bar

### DIFF
--- a/components/QueryBar.tsx
+++ b/components/QueryBar.tsx
@@ -4,7 +4,7 @@ import { useId } from 'react';
 import { Search, Star, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { parseQuery } from '@/lib/query';
+import { parseQuery, withoutFilter, withoutBareWord, type ParsedFilter } from '@/lib/query';
 import { useDensity } from '@/components/DensityProvider';
 import type { SavedView } from '@/lib/saved-views';
 import type { Source } from '@/lib/types';
@@ -40,6 +40,12 @@ export default function QueryBar({
   const errorId = useId();
   const density = useDensity();
   const activeSourceToken = SOURCE_TOKENS.find((t) => t.token && value.includes(t.token))?.source ?? 'all';
+  const parsed = parseQuery(value);
+  const hasActiveQuery = value.trim().length > 0;
+
+  function filterPillLabel(filter: ParsedFilter): string {
+    return `${filter.negate ? '-' : ''}${filter.prefix}:${filter.values.join(',')}`;
+  }
 
   function toggleSourceToken(token: string | null) {
     const withoutSourceTokens = value
@@ -72,6 +78,42 @@ export default function QueryBar({
             Clear the query
           </button>
         </p>
+      )}
+      {(parsed.filters.length > 0 || parsed.bareWords.length > 0) && (
+        <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Active filters">
+          {parsed.filters.map((filter) => (
+            <span
+              key={filterPillLabel(filter)}
+              className="flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 font-mono text-xs text-secondary-foreground"
+            >
+              {filterPillLabel(filter)}
+              <button
+                type="button"
+                aria-label={`Remove filter ${filterPillLabel(filter)}`}
+                className="rounded hover:bg-muted"
+                onClick={() => onChange(withoutFilter(value, filter))}
+              >
+                <X className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </span>
+          ))}
+          {parsed.bareWords.map((word, index) => (
+            <span
+              key={`${word}-${index}`}
+              className="flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs text-secondary-foreground"
+            >
+              {word}
+              <button
+                type="button"
+                aria-label={`Remove search word ${word}`}
+                className="rounded hover:bg-muted"
+                onClick={() => onChange(withoutBareWord(value, index))}
+              >
+                <X className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </span>
+          ))}
+        </div>
       )}
       <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by source and saved view">
         {SOURCE_TOKENS.map(({ source, label, token }) => (
@@ -120,9 +162,15 @@ export default function QueryBar({
             </span>
           </Button>
         ))}
-        {value.trim() && parseQuery(value).errors.length === 0 && (
+        {hasActiveQuery && parsed.errors.length === 0 && (
           <Button type="button" variant="ghost" size="sm" onClick={() => onSaveCurrentView(value.trim())}>
             Save this view
+          </Button>
+        )}
+        {hasActiveQuery && (
+          <Button type="button" variant="ghost" size="sm" className="ml-auto" onClick={() => onChange('')}>
+            <X className="h-3 w-3" aria-hidden="true" />
+            Clear filters
           </Button>
         )}
       </div>

--- a/e2e/filter-bar.spec.ts
+++ b/e2e/filter-bar.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { createItem } from './helpers';
+
+test('typing a filter shows a removable pill and a persistent clear button', async ({ page, request }) => {
+  // The dashboard replaces Signals (and its filter bar) with a first-run
+  // empty state when there are no items anywhere -- seed one so the bar is
+  // actually on the page regardless of what other tests have left behind.
+  await createItem(request, `Filter bar test ${Date.now()}`);
+
+  await page.goto('/');
+
+  const input = page.getByLabel('Filter signals');
+  await input.fill('source:github flaky');
+
+  const filterPill = page.getByRole('group', { name: 'Active filters' });
+  await expect(filterPill.getByText('source:github')).toBeVisible();
+  await expect(filterPill.getByText('flaky')).toBeVisible();
+
+  const clearButton = page.getByRole('button', { name: 'Clear filters' });
+  await expect(clearButton).toBeVisible();
+
+  await clearButton.click();
+  await expect(input).toHaveValue('');
+  await expect(page.getByRole('group', { name: 'Active filters' })).toHaveCount(0);
+});
+
+test('removing a single filter pill only drops that filter', async ({ page, request }) => {
+  await createItem(request, `Filter bar test ${Date.now()}`);
+
+  await page.goto('/');
+
+  const input = page.getByLabel('Filter signals');
+  await input.fill('source:github group:blocked');
+
+  await page.getByRole('button', { name: 'Remove filter source:github' }).click();
+  await expect(input).toHaveValue('group:blocked');
+});

--- a/lib/query.test.ts
+++ b/lib/query.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseQuery, applyQuery, stateOf, withoutFilter } from './query';
+import { parseQuery, applyQuery, stateOf, withoutFilter, withoutBareWord } from './query';
 import type { ScoredItem } from './dashboard';
 
 const NOW = new Date('2026-08-14T12:00:00.000Z');
@@ -203,5 +203,17 @@ describe('withoutFilter', () => {
   it('returns an empty string when the only filter is dropped', () => {
     const result = withoutFilter('source:github', { prefix: 'source', values: ['github'], negate: false });
     expect(result).toBe('');
+  });
+});
+
+describe('withoutBareWord', () => {
+  it('drops a bare word by position and keeps filters intact', () => {
+    const result = withoutBareWord('source:github flaky test', 0);
+    expect(result).toBe('source:github test');
+  });
+
+  it('drops the correct occurrence when the same word appears twice', () => {
+    const result = withoutBareWord('flaky flaky', 1);
+    expect(result).toBe('flaky');
   });
 });

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -219,3 +219,12 @@ export function withoutFilter(query: string, filter: ParsedFilter): string {
   );
   return queryToString({ filters: remaining, bareWords: parsed.bareWords, errors: [] });
 }
+
+// Drops one bare word by position (not just first-match-by-value), so
+// removing one of two identical bare words never removes the wrong one --
+// used by the filter bar's per-word pill.
+export function withoutBareWord(query: string, index: number): string {
+  const parsed = parseQuery(query);
+  const remaining = parsed.bareWords.filter((_, i) => i !== index);
+  return queryToString({ filters: parsed.filters, bareWords: remaining, errors: [] });
+}


### PR DESCRIPTION
Fixes #42

The only way to clear an applied filter was the "Clear the query" link in the zero-results empty state, which only ever appeared when a filter matched *nothing*. If a filter matched some items, there was no visible way to see what was active or clear it short of manually editing the query text.

## Fix
- Each parsed filter (`source:github`, `-is:done`, etc.) and bare search word now renders as a removable pill directly under the input.
- Added an always-visible "Clear filters" button at the end of the filter bar whenever the query is non-empty.
- Added `withoutBareWord` to `lib/query.ts` (by-position removal, mirroring the existing `withoutFilter`) so a pill removes exactly the word it represents, even with duplicates.

## Test plan
- [x] `npm test` (368 unit tests pass, incl. 2 new `withoutBareWord` cases)
- [x] `npm run test:e2e` — new `e2e/filter-bar.spec.ts` covers pills rendering, the persistent clear button, and removing a single pill without affecting others
- [x] Verified the new e2e tests fail against the pre-fix code and pass against the fix