### PR TITLE
fix: security hardening from issue #34 review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      - run: npm audit --omit=dev --audit-level=high
       - run: npm test
       - run: npx tsc --noEmit
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      - run: npm audit --omit=dev --audit-level=high
       - run: npx tsc --noEmit
       - run: npm test
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ By default the port is only published on the host's loopback interface
 reach it from other devices on your network, change the port mapping in
 `docker-compose.yml` from `"127.0.0.1:3000:3000"` to `"3000:3000"`.
 
+Ariadne has no login of its own — anyone who can reach the port has full
+access, including to your GitHub/Azure DevOps tokens. **Before exposing it
+beyond loopback**, set an `ARIADNE_AUTH_TOKEN` environment variable; every
+request then needs it as a Basic Auth password (any username works):
+
+```bash
+docker run -d -p 3000:3000 -v $(pwd)/data:/data \
+  -e ARIADNE_DB_PATH=/data/ariadne.db \
+  -e ARIADNE_AUTH_TOKEN=<a long random value> ariadne
+```
+
 Without compose:
 
 ```bash

--- a/app/api/items/[id]/actions.test.ts
+++ b/app/api/items/[id]/actions.test.ts
@@ -21,18 +21,18 @@ beforeEach(() => {
 
 describe('start -> complete -> undo', () => {
   it('walks an item through the full lifecycle', async () => {
-    const startRes = await start(new Request('http://localhost'), { params: { id: String(itemId) } });
+    const startRes = await start(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
     expect((await startRes.json()).status).toBe('in_progress');
 
     const completeRes = await complete(
       new Request('http://localhost', { method: 'POST', body: JSON.stringify({ durationHours: 1.5 }) }),
-      { params: { id: String(itemId) } }
+      { params: Promise.resolve({ id: String(itemId) }) }
     );
     const completeBody = await completeRes.json();
     expect(completeBody.item.status).toBe('done');
     expect(completeBody.timeLog.durationHours).toBe(1.5);
 
-    const undoRes = await undo(new Request('http://localhost'), { params: { id: String(itemId) } });
+    const undoRes = await undo(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
     const undoBody = await undoRes.json();
     expect(undoBody.status).toBe('in_progress');
     expect(undoBody.completedAt).toBeNull();
@@ -41,23 +41,23 @@ describe('start -> complete -> undo', () => {
 
 describe('start -> park -> unpark', () => {
   it('parks an in-progress item and can unpark it again', async () => {
-    await start(new Request('http://localhost'), { params: { id: String(itemId) } });
+    await start(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
 
-    const parkRes = await park(new Request('http://localhost'), { params: { id: String(itemId) } });
+    const parkRes = await park(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
     const parkBody = await parkRes.json();
     expect(parkBody.status).toBe('in_progress');
     expect(parkBody.parked).toBe(true);
 
-    const unparkRes = await unpark(new Request('http://localhost'), { params: { id: String(itemId) } });
+    const unparkRes = await unpark(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
     const unparkBody = await unparkRes.json();
     expect(unparkBody.parked).toBe(false);
   });
 
   it('requeuing a parked item clears parked', async () => {
-    await start(new Request('http://localhost'), { params: { id: String(itemId) } });
-    await park(new Request('http://localhost'), { params: { id: String(itemId) } });
+    await start(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
+    await park(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
 
-    const requeueRes = await requeue(new Request('http://localhost'), { params: { id: String(itemId) } });
+    const requeueRes = await requeue(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
     const requeueBody = await requeueRes.json();
     expect(requeueBody.status).toBe('inbox');
     expect(requeueBody.parked).toBe(false);
@@ -66,10 +66,10 @@ describe('start -> park -> unpark', () => {
 
 describe('start -> requeue', () => {
   it('returns an in-progress item to inbox and logs the elapsed time', async () => {
-    const startRes = await start(new Request('http://localhost'), { params: { id: String(itemId) } });
+    const startRes = await start(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
     expect((await startRes.json()).status).toBe('in_progress');
 
-    const requeueRes = await requeue(new Request('http://localhost'), { params: { id: String(itemId) } });
+    const requeueRes = await requeue(new Request('http://localhost'), { params: Promise.resolve({ id: String(itemId) }) });
     const requeueBody = await requeueRes.json();
     expect(requeueBody.status).toBe('inbox');
     expect(requeueBody.completedAt).toBeNull();

--- a/app/api/items/[id]/complete/route.ts
+++ b/app/api/items/[id]/complete/route.ts
@@ -3,8 +3,9 @@ import { db } from '@/lib/db-instance';
 import { setStatus, getItemById } from '@/lib/items-repo';
 import { completeTimer } from '@/lib/time-logs-repo';
 
-export async function POST(request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   const body = (await request.json().catch(() => ({}))) as { durationHours?: number; note?: string };
 
   if (typeof body.durationHours !== 'number' || !Number.isFinite(body.durationHours) || body.durationHours < 0) {

--- a/app/api/items/[id]/done/route.test.ts
+++ b/app/api/items/[id]/done/route.test.ts
@@ -16,13 +16,13 @@ describe('POST /api/items/:id/done', () => {
     const item = createAdhocItem(testDb, { title: 'Done me' });
     const res = await POST(
       new Request('http://localhost/api/items/1/done', { method: 'POST', body: JSON.stringify({ done: true }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
     expect((await res.json()).triageState).toBe('done');
 
     const undone = await POST(
       new Request('http://localhost/api/items/1/done', { method: 'POST', body: JSON.stringify({ done: false }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
     expect((await undone.json()).triageState).toBe('none');
   });

--- a/app/api/items/[id]/done/route.ts
+++ b/app/api/items/[id]/done/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { setTriageState, getItemById } from '@/lib/items-repo';
 
-export async function POST(request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   const { done } = await request.json();
   setTriageState(db, id, done ? 'done' : 'none');
   return NextResponse.json(getItemById(db, id));

--- a/app/api/items/[id]/open-claude/route.test.ts
+++ b/app/api/items/[id]/open-claude/route.test.ts
@@ -36,7 +36,7 @@ describe('POST /api/items/[id]/open-claude', () => {
     });
 
     const res = await POST(new Request('http://localhost', { method: 'POST', body: '{}' }), {
-      params: { id: String(item.id) },
+      params: Promise.resolve({ id: String(item.id) }),
     });
 
     expect(res.status).toBe(200);
@@ -50,7 +50,7 @@ describe('POST /api/items/[id]/open-claude', () => {
 
     const res = await POST(
       new Request('http://localhost', { method: 'POST', body: JSON.stringify({ workingDir: '/explicit/path' }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
 
     expect(res.status).toBe(200);
@@ -65,7 +65,7 @@ describe('POST /api/items/[id]/open-claude', () => {
         method: 'POST',
         body: JSON.stringify({ workingDir: '/some/attacker/path' }),
       }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
 
     expect(res.status).toBe(400);
@@ -76,7 +76,7 @@ describe('POST /api/items/[id]/open-claude', () => {
     const item = createAdhocItem(testDb, { title: 'Ad-hoc' });
 
     const res = await POST(new Request('http://localhost', { method: 'POST', body: '{}' }), {
-      params: { id: String(item.id) },
+      params: Promise.resolve({ id: String(item.id) }),
     });
 
     expect(res.status).toBe(400);
@@ -85,7 +85,7 @@ describe('POST /api/items/[id]/open-claude', () => {
 
   it('returns 404 for a missing item', async () => {
     const res = await POST(new Request('http://localhost', { method: 'POST', body: '{}' }), {
-      params: { id: '999999' },
+      params: Promise.resolve({ id: '999999' }),
     });
 
     expect(res.status).toBe(404);
@@ -100,7 +100,7 @@ describe('POST /api/items/[id]/open-claude', () => {
 
     const res = await POST(
       new Request('http://localhost', { method: 'POST', body: JSON.stringify({ workingDir: '/explicit/path' }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
 
     expect(res.status).toBe(500);

--- a/app/api/items/[id]/open-claude/route.test.ts
+++ b/app/api/items/[id]/open-claude/route.test.ts
@@ -44,7 +44,8 @@ describe('POST /api/items/[id]/open-claude', () => {
     expect(writeLaunchConfig).toHaveBeenCalledWith('/Users/chris/dev/github/repo-a');
   });
 
-  it('uses an explicit workingDir from the body over resolution', async () => {
+  it('uses an explicit workingDir from the body when it matches a configured local repo', async () => {
+    setSetting(testDb, SETTINGS_KEYS.repoPathOverrides, 'explicit-repo=/explicit/path');
     const item = createAdhocItem(testDb, { title: 'Ad-hoc' });
 
     const res = await POST(
@@ -54,6 +55,21 @@ describe('POST /api/items/[id]/open-claude', () => {
 
     expect(res.status).toBe(200);
     expect(writeLaunchConfig).toHaveBeenCalledWith('/explicit/path');
+  });
+
+  it('rejects an explicit workingDir that does not match a configured local repo', async () => {
+    const item = createAdhocItem(testDb, { title: 'Ad-hoc' });
+
+    const res = await POST(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify({ workingDir: '/some/attacker/path' }),
+      }),
+      { params: { id: String(item.id) } }
+    );
+
+    expect(res.status).toBe(400);
+    expect(writeLaunchConfig).not.toHaveBeenCalled();
   });
 
   it('returns 400 when no working directory can be resolved', async () => {
@@ -76,6 +92,7 @@ describe('POST /api/items/[id]/open-claude', () => {
   });
 
   it('returns 500 with an error message when writeLaunchConfig throws', async () => {
+    setSetting(testDb, SETTINGS_KEYS.repoPathOverrides, 'explicit-repo=/explicit/path');
     const item = createAdhocItem(testDb, { title: 'Ad-hoc' });
     writeLaunchConfig.mockImplementationOnce(() => {
       throw new Error('EACCES: permission denied');

--- a/app/api/items/[id]/open-claude/route.ts
+++ b/app/api/items/[id]/open-claude/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { getItemById } from '@/lib/items-repo';
-import { resolveWorkingDir } from '@/lib/warp';
+import { resolveWorkingDir, listLocalRepos } from '@/lib/warp';
 import { writeLaunchConfig, WARP_LAUNCH_URL } from '@/lib/warp-launch';
 
 export async function POST(request: Request, { params }: { params: { id: string } }) {
@@ -13,7 +13,23 @@ export async function POST(request: Request, { params }: { params: { id: string 
   }
 
   const body = (await request.json().catch(() => ({}))) as { workingDir?: string };
-  const workingDir = body.workingDir || resolveWorkingDir(db, item);
+  let workingDir: string | null;
+
+  if (body.workingDir) {
+    // workingDir must match a server-known local repo path — never trust an
+    // arbitrary client-supplied path here, since it's written unescaped into
+    // a TOML file that Warp executes commands from (see lib/warp-launch.ts).
+    const isKnownRepoPath = listLocalRepos(db).some((repo) => repo.path === body.workingDir);
+    if (!isKnownRepoPath) {
+      return NextResponse.json(
+        { error: 'workingDir must match a configured local repo.' },
+        { status: 400 }
+      );
+    }
+    workingDir = body.workingDir;
+  } else {
+    workingDir = resolveWorkingDir(db, item);
+  }
 
   if (!workingDir) {
     return NextResponse.json(

--- a/app/api/items/[id]/open-claude/route.ts
+++ b/app/api/items/[id]/open-claude/route.ts
@@ -4,8 +4,9 @@ import { getItemById } from '@/lib/items-repo';
 import { resolveWorkingDir, listLocalRepos } from '@/lib/warp';
 import { writeLaunchConfig, WARP_LAUNCH_URL } from '@/lib/warp-launch';
 
-export async function POST(request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   const item = getItemById(db, id);
 
   if (!item) {

--- a/app/api/items/[id]/park/route.test.ts
+++ b/app/api/items/[id]/park/route.test.ts
@@ -28,7 +28,7 @@ describe('POST /api/items/:id/park', () => {
     setStatus(testDb, item.id, 'in_progress');
     startTimer(testDb, item.id);
 
-    await POST(new Request('http://localhost', { method: 'POST' }), { params: { id: String(item.id) } });
+    await POST(new Request('http://localhost', { method: 'POST' }), { params: Promise.resolve({ id: String(item.id) }) });
 
     const logs = listLogsByItem(testDb, item.id);
     expect(logs).toHaveLength(1);

--- a/app/api/items/[id]/park/route.ts
+++ b/app/api/items/[id]/park/route.ts
@@ -3,8 +3,9 @@ import { db } from '@/lib/db-instance';
 import { setParked, getItemById } from '@/lib/items-repo';
 import { stopTimer } from '@/lib/time-logs-repo';
 
-export async function POST(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   stopTimer(db, id);
   setParked(db, id, true);
   return NextResponse.json(getItemById(db, id));

--- a/app/api/items/[id]/requeue/route.ts
+++ b/app/api/items/[id]/requeue/route.ts
@@ -3,8 +3,9 @@ import { db } from '@/lib/db-instance';
 import { setStatus, getItemById } from '@/lib/items-repo';
 import { completeTimer, elapsedHoursSinceStart } from '@/lib/time-logs-repo';
 
-export async function POST(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   completeTimer(db, id, { durationHours: elapsedHoursSinceStart(db, id) });
   setStatus(db, id, 'inbox');
   return NextResponse.json(getItemById(db, id));

--- a/app/api/items/[id]/route.test.ts
+++ b/app/api/items/[id]/route.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 describe('DELETE /api/items/[id]', () => {
   it('deletes the item', async () => {
     const res = await deleteRoute(new Request('http://localhost', { method: 'DELETE' }), {
-      params: { id: String(itemId) },
+      params: Promise.resolve({ id: String(itemId) }),
     });
     expect(res.status).toBe(200);
     expect(getItemById(testDb, itemId)).toBeUndefined();

--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { deleteItem } from '@/lib/items-repo';
 
-export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   deleteItem(db, id);
   return NextResponse.json({ ok: true });
 }

--- a/app/api/items/[id]/snooze/route.test.ts
+++ b/app/api/items/[id]/snooze/route.test.ts
@@ -16,7 +16,7 @@ describe('POST /api/items/:id/snooze', () => {
     const item = createAdhocItem(testDb, { title: 'Snooze me' });
     const res = await POST(
       new Request('http://localhost/api/items/1/snooze', { method: 'POST', body: JSON.stringify({ option: 'tomorrow' }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
     const body = await res.json();
     expect(body.snoozedUntil).not.toBeNull();
@@ -28,10 +28,10 @@ describe('DELETE /api/items/:id/snooze', () => {
     const item = createAdhocItem(testDb, { title: 'Unsnooze me' });
     await POST(
       new Request('http://localhost/api/items/1/snooze', { method: 'POST', body: JSON.stringify({ option: 'tomorrow' }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
     const res = await DELETE(new Request('http://localhost/api/items/1/snooze', { method: 'DELETE' }), {
-      params: { id: String(item.id) },
+      params: Promise.resolve({ id: String(item.id) }),
     });
     const body = await res.json();
     expect(body.snoozedUntil).toBeNull();

--- a/app/api/items/[id]/snooze/route.ts
+++ b/app/api/items/[id]/snooze/route.ts
@@ -3,15 +3,17 @@ import { db } from '@/lib/db-instance';
 import { setSnoozedUntil, getItemById } from '@/lib/items-repo';
 import { computeSnoozeUntil, type SnoozeOption } from '@/lib/snooze';
 
-export async function POST(request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   const { option } = (await request.json()) as { option: SnoozeOption };
   setSnoozedUntil(db, id, computeSnoozeUntil(option, new Date()));
   return NextResponse.json(getItemById(db, id));
 }
 
-export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   setSnoozedUntil(db, id, null);
   return NextResponse.json(getItemById(db, id));
 }

--- a/app/api/items/[id]/star/route.test.ts
+++ b/app/api/items/[id]/star/route.test.ts
@@ -16,7 +16,7 @@ describe('POST /api/items/:id/star', () => {
     const item = createAdhocItem(testDb, { title: 'Star me' });
     const res = await POST(
       new Request('http://localhost/api/items/1/star', { method: 'POST', body: JSON.stringify({ starred: true }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
     const body = await res.json();
     expect(body.starred).toBe(true);
@@ -26,11 +26,11 @@ describe('POST /api/items/:id/star', () => {
     const item = createAdhocItem(testDb, { title: 'Unstar me' });
     await POST(
       new Request('http://localhost/api/items/1/star', { method: 'POST', body: JSON.stringify({ starred: true }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
     const res = await POST(
       new Request('http://localhost/api/items/1/star', { method: 'POST', body: JSON.stringify({ starred: false }) }),
-      { params: { id: String(item.id) } }
+      { params: Promise.resolve({ id: String(item.id) }) }
     );
     const body = await res.json();
     expect(body.starred).toBe(false);

--- a/app/api/items/[id]/star/route.ts
+++ b/app/api/items/[id]/star/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { setStarred, getItemById } from '@/lib/items-repo';
 
-export async function POST(request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   const { starred } = await request.json();
   setStarred(db, id, Boolean(starred));
   return NextResponse.json(getItemById(db, id));

--- a/app/api/items/[id]/start/route.ts
+++ b/app/api/items/[id]/start/route.ts
@@ -3,8 +3,9 @@ import { db } from '@/lib/db-instance';
 import { setStatus, getItemById } from '@/lib/items-repo';
 import { startTimer } from '@/lib/time-logs-repo';
 
-export async function POST(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   setStatus(db, id, 'in_progress');
   startTimer(db, id);
   return NextResponse.json(getItemById(db, id));

--- a/app/api/items/[id]/stop-timer/route.test.ts
+++ b/app/api/items/[id]/stop-timer/route.test.ts
@@ -18,7 +18,7 @@ describe('POST /api/items/:id/stop-timer', () => {
     setStatus(testDb, item.id, 'in_progress');
     startTimer(testDb, item.id);
 
-    const res = await POST(new Request('http://localhost', { method: 'POST' }), { params: { id: String(item.id) } });
+    const res = await POST(new Request('http://localhost', { method: 'POST' }), { params: Promise.resolve({ id: String(item.id) }) });
     const body = await res.json();
     expect(body.status).toBe('in_progress');
     expect(listLogsByItem(testDb, item.id)[0].endedAt).not.toBeNull();

--- a/app/api/items/[id]/stop-timer/route.ts
+++ b/app/api/items/[id]/stop-timer/route.ts
@@ -3,8 +3,9 @@ import { db } from '@/lib/db-instance';
 import { getItemById } from '@/lib/items-repo';
 import { stopTimer } from '@/lib/time-logs-repo';
 
-export async function POST(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   stopTimer(db, id);
   return NextResponse.json(getItemById(db, id));
 }

--- a/app/api/items/[id]/today/route.test.ts
+++ b/app/api/items/[id]/today/route.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 describe('POST /api/items/[id]/today', () => {
   it('defaults to today when no date is given', async () => {
     const res = await pinToday(new Request('http://localhost', { method: 'POST', body: '{}' }), {
-      params: { id: String(itemId) },
+      params: Promise.resolve({ id: String(itemId) }),
     });
     expect(res.status).toBe(200);
     expect((await res.json()).todayDate).toBe(localDateString(new Date()));
@@ -29,7 +29,7 @@ describe('POST /api/items/[id]/today', () => {
     const tomorrow = addDays(localDateString(new Date()), 1);
     const res = await pinToday(
       new Request('http://localhost', { method: 'POST', body: JSON.stringify({ date: tomorrow }) }),
-      { params: { id: String(itemId) } }
+      { params: Promise.resolve({ id: String(itemId) }) }
     );
     expect((await res.json()).todayDate).toBe(tomorrow);
   });
@@ -37,9 +37,9 @@ describe('POST /api/items/[id]/today', () => {
 
 describe('DELETE /api/items/[id]/today', () => {
   it('clears today_date', async () => {
-    await pinToday(new Request('http://localhost', { method: 'POST', body: '{}' }), { params: { id: String(itemId) } });
+    await pinToday(new Request('http://localhost', { method: 'POST', body: '{}' }), { params: Promise.resolve({ id: String(itemId) }) });
     const res = await unpinToday(new Request('http://localhost', { method: 'DELETE' }), {
-      params: { id: String(itemId) },
+      params: Promise.resolve({ id: String(itemId) }),
     });
     expect((await res.json()).todayDate).toBeNull();
     expect(getItemById(testDb, itemId)?.todayDate).toBeNull();
@@ -50,7 +50,7 @@ describe('POST /api/items/[id]/today plan integration', () => {
   it('adds the item to the plan for the pinned date', async () => {
     await pinToday(
       new Request('http://localhost', { method: 'POST', body: JSON.stringify({ date: '2026-08-20' }) }),
-      { params: { id: String(itemId) } }
+      { params: Promise.resolve({ id: String(itemId) }) }
     );
     const items = getPlanItems(testDb, '2026-08-20');
     expect(items.map((i) => i.itemId)).toEqual([itemId]);
@@ -59,9 +59,9 @@ describe('POST /api/items/[id]/today plan integration', () => {
 
 describe('DELETE /api/items/[id]/today plan integration', () => {
   it('removes the item from its plan when unpinned', async () => {
-    await pinToday(new Request('http://localhost', { method: 'POST', body: '{}' }), { params: { id: String(itemId) } });
+    await pinToday(new Request('http://localhost', { method: 'POST', body: '{}' }), { params: Promise.resolve({ id: String(itemId) }) });
     const today = localDateString(new Date());
-    await unpinToday(new Request('http://localhost', { method: 'DELETE' }), { params: { id: String(itemId) } });
+    await unpinToday(new Request('http://localhost', { method: 'DELETE' }), { params: Promise.resolve({ id: String(itemId) }) });
     expect(getPlanItems(testDb, today)).toEqual([]);
   });
 });

--- a/app/api/items/[id]/today/route.ts
+++ b/app/api/items/[id]/today/route.ts
@@ -4,8 +4,9 @@ import { setTodayDate, getItemById } from '@/lib/items-repo';
 import { localDateString } from '@/lib/date';
 import { addPlanItem, removePlanItem } from '@/lib/plans-repo';
 
-export async function POST(request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   const body = (await request.json().catch(() => ({}))) as { date?: string };
   const date = body.date ?? localDateString(new Date());
   setTodayDate(db, id, date);
@@ -13,8 +14,9 @@ export async function POST(request: Request, { params }: { params: { id: string 
   return NextResponse.json(getItemById(db, id));
 }
 
-export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   const item = getItemById(db, id);
   if (item?.todayDate) removePlanItem(db, item.todayDate, id);
   setTodayDate(db, id, null);

--- a/app/api/items/[id]/undo/route.ts
+++ b/app/api/items/[id]/undo/route.ts
@@ -3,8 +3,9 @@ import { db } from '@/lib/db-instance';
 import { setStatus, getItemById } from '@/lib/items-repo';
 import { undoLastCompletion } from '@/lib/time-logs-repo';
 
-export async function POST(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   undoLastCompletion(db, id);
   setStatus(db, id, 'in_progress', null);
   return NextResponse.json(getItemById(db, id));

--- a/app/api/items/[id]/unpark/route.ts
+++ b/app/api/items/[id]/unpark/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { setParked, getItemById } from '@/lib/items-repo';
 
-export async function POST(_request: Request, { params }: { params: { id: string } }) {
-  const id = Number(params.id);
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
   setParked(db, id, false);
   return NextResponse.json(getItemById(db, id));
 }

--- a/app/api/settings/route.test.ts
+++ b/app/api/settings/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { openDb } from '@/lib/db';
+import { getSetting } from '@/lib/settings-repo';
 import { SETTINGS_KEYS } from '@/lib/config';
 
 const testDb = openDb(':memory:');
@@ -8,17 +9,45 @@ vi.mock('@/lib/db-instance', () => ({ db: testDb }));
 const { GET, POST } = await import('./route');
 
 describe('/api/settings', () => {
-  it('saves and returns settings', async () => {
+  it('saves settings and returns them, redacting PAT values', async () => {
     const postRes = await POST(
       new Request('http://localhost/api/settings', {
         method: 'POST',
-        body: JSON.stringify({ [SETTINGS_KEYS.githubPat]: 'abc123' }),
+        body: JSON.stringify({ [SETTINGS_KEYS.githubPat]: 'abc123', [SETTINGS_KEYS.adoOrg]: 'myorg' }),
       })
     );
     expect(postRes.status).toBe(200);
 
+    // The PAT never comes back in the response body...
+    const postBody = await postRes.json();
+    expect(postBody[SETTINGS_KEYS.githubPat]).toBe('');
+    expect(postBody[`${SETTINGS_KEYS.githubPat}.isSet`]).toBe('true');
+    expect(postBody[SETTINGS_KEYS.adoOrg]).toBe('myorg');
+
     const getRes = await GET();
-    const body = await getRes.json();
-    expect(body[SETTINGS_KEYS.githubPat]).toBe('abc123');
+    const getBody = await getRes.json();
+    expect(getBody[SETTINGS_KEYS.githubPat]).toBe('');
+    expect(getBody[`${SETTINGS_KEYS.githubPat}.isSet`]).toBe('true');
+
+    // ...but it's still stored and retrievable server-side for actual API calls.
+    expect(getSetting(testDb, SETTINGS_KEYS.githubPat)).toBe('abc123');
+  });
+
+  it('does not overwrite a saved PAT when the field is omitted from the request body', async () => {
+    await POST(
+      new Request('http://localhost/api/settings', {
+        method: 'POST',
+        body: JSON.stringify({ [SETTINGS_KEYS.githubPat]: 'keep-me' }),
+      })
+    );
+
+    await POST(
+      new Request('http://localhost/api/settings', {
+        method: 'POST',
+        body: JSON.stringify({ [SETTINGS_KEYS.adoOrg]: 'myorg' }),
+      })
+    );
+
+    expect(getSetting(testDb, SETTINGS_KEYS.githubPat)).toBe('keep-me');
   });
 });

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
-import { getAllSettings, setSetting } from '@/lib/settings-repo';
+import { getRedactedSettings, setSetting } from '@/lib/settings-repo';
 
 export async function GET() {
-  return NextResponse.json(getAllSettings(db));
+  return NextResponse.json(getRedactedSettings(db));
 }
 
 export async function POST(request: Request) {
@@ -11,5 +11,5 @@ export async function POST(request: Request) {
   for (const [key, value] of Object.entries(body)) {
     setSetting(db, key, value);
   }
-  return NextResponse.json(getAllSettings(db));
+  return NextResponse.json(getRedactedSettings(db));
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import SettingsForm from '@/components/SettingsForm';
 import SettingsScoringLink from '@/components/SettingsScoringLink';
 import { db } from '@/lib/db-instance';
-import { getAllSettings } from '@/lib/settings-repo';
+import { getRedactedSettings } from '@/lib/settings-repo';
 
 // GET has no dynamic API usage, so Next.js would statically bake this at
 // build time otherwise — same class of bug already fixed for `/` and
@@ -10,7 +10,7 @@ import { getAllSettings } from '@/lib/settings-repo';
 export const dynamic = 'force-dynamic';
 
 export default function SettingsPage() {
-  const settings = getAllSettings(db);
+  const settings = getRedactedSettings(db);
   return (
     <main className="mx-auto max-w-lg space-y-6 p-6">
       <Link href="/" className="text-sm text-muted-foreground hover:underline">

--- a/components/SettingsForm.tsx
+++ b/components/SettingsForm.tsx
@@ -36,6 +36,8 @@ interface Props {
 
 export default function SettingsForm({ initialSettings }: Props) {
   const [saved, setSaved] = useState(false);
+  const githubPatIsSet = initialSettings[`${SETTINGS_KEYS.githubPat}.isSet`] === 'true';
+  const adoPatIsSet = initialSettings[`${SETTINGS_KEYS.adoPat}.isSet`] === 'true';
   const form = useForm<SettingsValues>({
     resolver: zodResolver(settingsSchema),
     defaultValues: {
@@ -52,20 +54,22 @@ export default function SettingsForm({ initialSettings }: Props) {
   });
 
   async function handleSubmit(values: SettingsValues) {
-    await fetch('/api/settings', {
-      method: 'POST',
-      body: JSON.stringify({
-        [SETTINGS_KEYS.githubPat]: values.githubPat ?? '',
-        [SETTINGS_KEYS.adoPat]: values.adoPat ?? '',
-        [SETTINGS_KEYS.adoOrg]: values.adoOrg ?? '',
-        [SETTINGS_KEYS.adoProject]: values.adoProject ?? '',
-        [SETTINGS_KEYS.adoTeam]: values.adoTeam ?? '',
-        [SETTINGS_KEYS.staleDays]: values.staleDays ?? String(DEFAULT_STALE_DAYS),
-        [SETTINGS_KEYS.localReposBaseDir]: values.localReposBaseDir ?? '',
-        [SETTINGS_KEYS.repoPathOverrides]: values.repoPathOverrides ?? '',
-        [SETTINGS_KEYS.density]: values.density ?? DEFAULT_DENSITY,
-      }),
-    });
+    const body: Record<string, string> = {
+      [SETTINGS_KEYS.adoOrg]: values.adoOrg ?? '',
+      [SETTINGS_KEYS.adoProject]: values.adoProject ?? '',
+      [SETTINGS_KEYS.adoTeam]: values.adoTeam ?? '',
+      [SETTINGS_KEYS.staleDays]: values.staleDays ?? String(DEFAULT_STALE_DAYS),
+      [SETTINGS_KEYS.localReposBaseDir]: values.localReposBaseDir ?? '',
+      [SETTINGS_KEYS.repoPathOverrides]: values.repoPathOverrides ?? '',
+      [SETTINGS_KEYS.density]: values.density ?? DEFAULT_DENSITY,
+    };
+    // Tokens come back from the server redacted (empty), so an untouched
+    // field must never overwrite the saved value with ''. Only send a PAT
+    // when the user actually typed a new one.
+    if (values.githubPat) body[SETTINGS_KEYS.githubPat] = values.githubPat;
+    if (values.adoPat) body[SETTINGS_KEYS.adoPat] = values.adoPat;
+
+    await fetch('/api/settings', { method: 'POST', body: JSON.stringify(body) });
     setSaved(true);
   }
 
@@ -81,11 +85,12 @@ export default function SettingsForm({ initialSettings }: Props) {
                 <FormItem>
                   <FormLabel>GitHub personal access token</FormLabel>
                   <FormControl>
-                    <Input type="password" {...field} />
+                    <Input type="password" placeholder={githubPatIsSet ? 'Saved — leave blank to keep it' : ''} {...field} />
                   </FormControl>
                   <p className="text-xs text-muted-foreground">
                     Tokens are stored in plaintext in your local database — the same trust model as a{' '}
-                    <code className="font-mono">.env</code> file.
+                    <code className="font-mono">.env</code> file. The saved token is never sent back to the
+                    browser; leave this blank to keep it unchanged.
                   </p>
                   <FormMessage />
                 </FormItem>
@@ -98,11 +103,12 @@ export default function SettingsForm({ initialSettings }: Props) {
                 <FormItem>
                   <FormLabel>Azure DevOps personal access token</FormLabel>
                   <FormControl>
-                    <Input type="password" {...field} />
+                    <Input type="password" placeholder={adoPatIsSet ? 'Saved — leave blank to keep it' : ''} {...field} />
                   </FormControl>
                   <p className="text-xs text-muted-foreground">
                     Tokens are stored in plaintext in your local database — the same trust model as a{' '}
-                    <code className="font-mono">.env</code> file.
+                    <code className="font-mono">.env</code> file. The saved token is never sent back to the
+                    browser; leave this blank to keep it unchanged.
                   </p>
                   <FormMessage />
                 </FormItem>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,15 @@ services:
     build: .
     ports:
       # Loopback-only by default. Change to "3000:3000" to reach Ariadne
-      # from other devices on your network.
+      # from other devices on your network — but Ariadne has no login of its
+      # own, so anyone who can reach the port gets full access, including to
+      # your GitHub/Azure DevOps tokens. Set ARIADNE_AUTH_TOKEN below first.
       - "127.0.0.1:3000:3000"
     volumes:
       - ./data:/data
     environment:
       - ARIADNE_DB_PATH=/data/ariadne.db
+      # Uncomment to require this as a Basic Auth password before exposing
+      # Ariadne beyond loopback (any username is accepted):
+      # - ARIADNE_AUTH_TOKEN=change-me
     restart: unless-stopped

--- a/lib/settings-repo.test.ts
+++ b/lib/settings-repo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { openDb } from './db';
-import { getSetting, setSetting, getAllSettings } from './settings-repo';
+import { getSetting, setSetting, getAllSettings, getRedactedSettings } from './settings-repo';
 
 let db: Database.Database;
 
@@ -29,5 +29,34 @@ describe('settings-repo', () => {
     setSetting(db, 'github.pat', 'abc123');
     setSetting(db, 'ado.org', 'myorg');
     expect(getAllSettings(db)).toEqual({ 'github.pat': 'abc123', 'ado.org': 'myorg' });
+  });
+
+  describe('getRedactedSettings', () => {
+    it('blanks out PAT values and flags them as set', () => {
+      setSetting(db, 'github.pat', 'abc123');
+      setSetting(db, 'ado.pat', 'def456');
+      setSetting(db, 'ado.org', 'myorg');
+
+      expect(getRedactedSettings(db)).toEqual({
+        'github.pat': '',
+        'github.pat.isSet': 'true',
+        'ado.pat': '',
+        'ado.pat.isSet': 'true',
+        'ado.org': 'myorg',
+      });
+    });
+
+    it('flags unset PATs as not set', () => {
+      setSetting(db, 'ado.org', 'myorg');
+      const redacted = getRedactedSettings(db);
+      expect(redacted['github.pat.isSet']).toBe('false');
+      expect(redacted['ado.pat.isSet']).toBe('false');
+    });
+
+    it('does not mutate the underlying stored value', () => {
+      setSetting(db, 'github.pat', 'abc123');
+      getRedactedSettings(db);
+      expect(getSetting(db, 'github.pat')).toBe('abc123');
+    });
   });
 });

--- a/lib/settings-repo.ts
+++ b/lib/settings-repo.ts
@@ -1,4 +1,7 @@
 import type Database from 'better-sqlite3';
+import { SETTINGS_KEYS } from './config';
+
+const SECRET_SETTINGS_KEYS: readonly string[] = [SETTINGS_KEYS.githubPat, SETTINGS_KEYS.adoPat];
 
 export function getSetting(db: Database.Database, key: string): string | null {
   const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
@@ -16,4 +19,18 @@ export function setSetting(db: Database.Database, key: string, value: string): v
 export function getAllSettings(db: Database.Database): Record<string, string> {
   const rows = db.prepare('SELECT key, value FROM settings').all() as { key: string; value: string }[];
   return Object.fromEntries(rows.map((r) => [r.key, r.value]));
+}
+
+// For anything leaving the server (API responses, SSR payloads): PAT values
+// never travel past this boundary in the clear, since either would put them
+// in a page's HTML/RSC output or a plain JSON response any caller can read.
+// `<key>.isSet` lets the UI show "a token is saved" without the value itself.
+export function getRedactedSettings(db: Database.Database): Record<string, string> {
+  const settings = getAllSettings(db);
+  for (const key of SECRET_SETTINGS_KEYS) {
+    const isSet = Boolean(settings[key]);
+    settings[key] = '';
+    settings[`${key}.isSet`] = String(isSet);
+  }
+  return settings;
 }

--- a/lib/warp-launch.test.ts
+++ b/lib/warp-launch.test.ts
@@ -44,6 +44,14 @@ describe('writeLaunchConfig', () => {
     );
   });
 
+  it('rejects a working directory containing a quote or newline', () => {
+    dir = mkdtempSync(join(tmpdir(), 'ariadne-launch-test-'));
+
+    expect(() => writeLaunchConfig('/some/dir"\ncommands = ["evil"]', dir)).toThrow(
+      /must not contain quotes or newlines/
+    );
+  });
+
   it('overwrites an existing file for the same config name', () => {
     dir = mkdtempSync(join(tmpdir(), 'ariadne-launch-test-'));
 

--- a/lib/warp-launch.ts
+++ b/lib/warp-launch.ts
@@ -10,6 +10,13 @@ function defaultTabConfigDir(): string {
 }
 
 export function writeLaunchConfig(cwd: string, tabConfigDir: string = defaultTabConfigDir()): void {
+  if (/["\n\r]/.test(cwd)) {
+    // cwd is interpolated unescaped into a TOML string below — a quote or
+    // newline would let it break out of `directory = "..."` and inject
+    // arbitrary keys (e.g. a `commands` override) into the launch config.
+    throw new Error('Invalid working directory: must not contain quotes or newlines.');
+  }
+
   if (!existsSync(tabConfigDir)) {
     mkdirSync(tabConfigDir, { recursive: true });
   }

--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from './middleware';
+
+const ORIGINAL_TOKEN = process.env.ARIADNE_AUTH_TOKEN;
+
+afterEach(() => {
+  if (ORIGINAL_TOKEN === undefined) delete process.env.ARIADNE_AUTH_TOKEN;
+  else process.env.ARIADNE_AUTH_TOKEN = ORIGINAL_TOKEN;
+});
+
+function basicAuthHeader(user: string, pass: string): string {
+  return `Basic ${btoa(`${user}:${pass}`)}`;
+}
+
+describe('middleware', () => {
+  it('allows every request through when ARIADNE_AUTH_TOKEN is unset', () => {
+    delete process.env.ARIADNE_AUTH_TOKEN;
+    const res = middleware(new NextRequest('http://localhost/settings'));
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a request with no Authorization header once a token is configured', () => {
+    process.env.ARIADNE_AUTH_TOKEN = 'secret';
+    const res = middleware(new NextRequest('http://localhost/settings'));
+    expect(res.status).toBe(401);
+    expect(res.headers.get('WWW-Authenticate')).toContain('Basic');
+  });
+
+  it('rejects a wrong password', () => {
+    process.env.ARIADNE_AUTH_TOKEN = 'secret';
+    const req = new NextRequest('http://localhost/settings', {
+      headers: { authorization: basicAuthHeader('any', 'wrong') },
+    });
+    expect(middleware(req).status).toBe(401);
+  });
+
+  it('rejects a malformed Authorization header', () => {
+    process.env.ARIADNE_AUTH_TOKEN = 'secret';
+    const req = new NextRequest('http://localhost/settings', {
+      headers: { authorization: 'not-basic-auth' },
+    });
+    expect(middleware(req).status).toBe(401);
+  });
+
+  it('allows a correct password regardless of the username portion', () => {
+    process.env.ARIADNE_AUTH_TOKEN = 'secret';
+    const req = new NextRequest('http://localhost/settings', {
+      headers: { authorization: basicAuthHeader('anything', 'secret') },
+    });
+    expect(middleware(req).status).toBe(200);
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// Ariadne has no auth model by design — it's a personal, local-only tool.
+// This is a no-op unless the operator opts in to reaching it beyond
+// localhost (see docker-compose.yml) and sets ARIADNE_AUTH_TOKEN, in which
+// case every request must present it as a Basic Auth password.
+export function middleware(request: NextRequest): NextResponse {
+  const token = process.env.ARIADNE_AUTH_TOKEN;
+  if (!token) return NextResponse.next();
+
+  const authHeader = request.headers.get('authorization');
+  if (authHeader && decodeBasicAuthPassword(authHeader) === token) {
+    return NextResponse.next();
+  }
+
+  return new NextResponse('Authentication required.', {
+    status: 401,
+    headers: { 'WWW-Authenticate': 'Basic realm="Ariadne"' },
+  });
+}
+
+function decodeBasicAuthPassword(authHeader: string): string | null {
+  if (!authHeader.startsWith('Basic ')) return null;
+  let decoded: string;
+  try {
+    decoded = atob(authHeader.slice('Basic '.length));
+  } catch {
+    return null;
+  }
+  const separatorIndex = decoded.indexOf(':');
+  return separatorIndex === -1 ? decoded : decoded.slice(separatorIndex + 1);
+}
+
+export const config = {
+  matcher: '/((?!_next/static|_next/image|favicon.ico).*)',
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "lucide-react": "^0.400.0",
-        "next": "^14.2.0",
+        "next": "^15.5.23",
         "next-themes": "^0.4.6",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
@@ -48,7 +48,7 @@
         "@types/react-dom": "^18.3.0",
         "autoprefixer": "^10.4.0",
         "fast-check": "^4.9.0",
-        "postcss": "^8.4.0",
+        "postcss": "^8.5.26",
         "semantic-release": "^25.0.9",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.5.0",
@@ -157,6 +157,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -573,6 +583,555 @@
         "react-hook-form": "^7.55.0"
       }
     },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -617,17 +1176,19 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.35",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
-      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ=="
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.23.tgz",
+      "integrity": "sha512-Mv3Z9hVbFcPnoLevsZ6rnX1TBtyHb5E17yN7HTPDXSXxeNsGBjUFrdbjRXKKXIOhfth7/cg6Ay7PZ2UFawaWsQ==",
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
-      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.23.tgz",
+      "integrity": "sha512-SrEwOROH/rhA03F59hHtdhgtfZMWGzr5duDBWgRQt2rS3mJhqMKOcnNx6txOd0/i3E3D3uFKYFvyHsEiwQxzag==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -637,12 +1198,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
-      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.23.tgz",
+      "integrity": "sha512-f0FpFbG2EhDCuptBGcfrLcYMDuQAhe6m1QA4VVfXFrIBoFXvXt/olGbBkYkloKlXQtmhuzvtdYyuu/6zf07GIg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -652,12 +1214,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
-      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.23.tgz",
+      "integrity": "sha512-WlNtfepUXKX2u2ZsJZ8c3c8+tJSRZqsYzoMwLOY72A8ucKCCgxgNhiePA3qzFYahVWrwcQd8jOeJmBinc+VFVQ==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -667,12 +1233,16 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
-      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.23.tgz",
+      "integrity": "sha512-W/6qKk7UG93mg14PmQC+2urt69MIdwTBLNQ6MJyeC4wOCIHCjz+VfgssvS1pK7mgYBtLC1g6VKNoHD9xB0WWGg==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -682,12 +1252,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
-      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.23.tgz",
+      "integrity": "sha512-vzefI32mi6VMk96RaTAyxApgfGbiFzQBXVsekEjsDv1fr48mlABTWx0sUYhaYCBHWqCalxmz3DxbxFcbFvzNtw==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -697,12 +1271,16 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
-      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.23.tgz",
+      "integrity": "sha512-qppK/3dTGOTI+aoWWBZc3DshFIhrzgL8guATlaN9V6M1QJxbkP/rhEZ22tdICsQ/2WWXopMZ2Jokzj2u3uKY3Q==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -712,27 +1290,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
-      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.23.tgz",
+      "integrity": "sha512-Wc29KFOdT7XBcII3Vtmw7aoU8Uk3Mes/FNJfhFeSHdYBFJWMcR/DsI8U9BCPUhq/uycsUVuqSKGthW15tLsigA==",
       "cpu": [
         "arm64"
       ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
-      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
-      "cpu": [
-        "ia32"
-      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -742,12 +1306,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.33",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
-      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.23.tgz",
+      "integrity": "sha512-/C7wRW4fa9s/PKA18zGPPpVmx8ycgVpP8yOxro4gzGTzjPJdscbAP3ODeFvgiIovxD176Z2J/SXO9t8PJKHLeQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3795,18 +4360,13 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
-    },
     "node_modules/@swc/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@types/better-sqlite3": {
@@ -4330,17 +4890,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4640,7 +5189,8 @@
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "9.0.1",
@@ -5735,7 +6285,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -6557,15 +7108,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6593,40 +7145,40 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.35",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
-      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "version": "15.5.23",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.23.tgz",
+      "integrity": "sha512-Gvd2WKgvxIXCGotxcI1im/Uf3rS3J3oZGw0g/uskg6AVBZhyE3aAbujkYWzS3xLmEPEtTLfkaVQUKK0KMTSIkA==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.35",
-        "@swc/helpers": "0.5.5",
-        "busboy": "1.6.0",
+        "@next/env": "15.5.23",
+        "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
-        "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
-        "styled-jsx": "5.1.1"
+        "styled-jsx": "5.1.6"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=18.17.0"
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.33",
-        "@next/swc-darwin-x64": "14.2.33",
-        "@next/swc-linux-arm64-gnu": "14.2.33",
-        "@next/swc-linux-arm64-musl": "14.2.33",
-        "@next/swc-linux-x64-gnu": "14.2.33",
-        "@next/swc-linux-x64-musl": "14.2.33",
-        "@next/swc-win32-arm64-msvc": "14.2.33",
-        "@next/swc-win32-ia32-msvc": "14.2.33",
-        "@next/swc-win32-x64-msvc": "14.2.33"
+        "@next/swc-darwin-arm64": "15.5.23",
+        "@next/swc-darwin-x64": "15.5.23",
+        "@next/swc-linux-arm64-gnu": "15.5.23",
+        "@next/swc-linux-arm64-musl": "15.5.23",
+        "@next/swc-linux-x64-gnu": "15.5.23",
+        "@next/swc-linux-x64-musl": "15.5.23",
+        "@next/swc-win32-arm64-msvc": "15.5.23",
+        "@next/swc-win32-x64-msvc": "15.5.23",
+        "sharp": "^0.34.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.41.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -6634,6 +7186,9 @@
           "optional": true
         },
         "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
           "optional": true
         },
         "sass": {
@@ -6649,33 +7204,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-abi": {
@@ -9085,9 +9613,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -9102,8 +9630,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10111,6 +10640,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -10449,14 +11028,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -10552,9 +11123,10 @@
       "dev": true
     },
     "node_modules/styled-jsx": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -10562,7 +11134,7 @@
         "node": ">= 12.0.0"
       },
       "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
       },
       "peerDependenciesMeta": {
         "@babel/core": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^0.400.0",
-    "next": "^14.2.0",
+    "next": "^15.5.23",
     "next-themes": "^0.4.6",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
@@ -50,10 +50,14 @@
     "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.0",
     "fast-check": "^4.9.0",
-    "postcss": "^8.4.0",
+    "postcss": "^8.5.26",
     "semantic-release": "^25.0.9",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.5.0",
     "vitest": "^1.6.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.26",
+    "sharp": "^0.35.3"
   }
 }


### PR DESCRIPTION
## Summary

Addresses the security review requested in #34, plus a dependency audit gate for CI.

- **TOML injection in `open-claude`**: `workingDir` from the request body must now match a server-known local repo path; anything else is rejected (400). Added a defense-in-depth guard in `writeLaunchConfig` against quotes/newlines.
- **PAT exposure via `/api/settings`**: `GET`/`POST` and the SSR `/settings` page no longer return raw `github.pat`/`ado.pat` values — a `<key>.isSet` flag lets the UI show "already saved" instead. Blank PAT fields no longer wipe the saved token on submit.
- **Unauthenticated LAN exposure**: added an opt-in `middleware.ts` gated by `ARIADNE_AUTH_TOKEN` (no-op unless set, so default localhost behavior is unchanged). Documented in `docker-compose.yml` and the README.
- **CI dependency audit**: `npm audit --omit=dev --audit-level=high` now blocks CI and the release workflow.
- **Next.js upgrade**: 14.2.35 → 15.5.23 (plus `overrides` pinning its bundled `postcss`/`sharp` to patched versions) to actually clear the audit — required updating every dynamic `[id]` route handler for Next 15's async `params`.

Cleared during the review, no code changes needed: XSS/CSRF surface (no `dangerouslySetInnerHTML`, no markdown rendering) and SQL injection (all queries parameterized).

Not in scope here: 11 remaining `npm audit` findings are all dev-only toolchain (semantic-release, vite, vitest) — not shipped in the app or Docker image.

## Test plan

- [x] `npm test` — 380/380 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds on Next 15
- [x] `npm run test:e2e` — 7/7 Playwright tests passing
- [x] `npm audit --omit=dev --audit-level=high` — 0 findings
- [x] Manual smoke test: settings redaction and middleware no-op-by-default confirmed against a running instance