### PR TITLE
docs: add MIT license, contribution guidelines, and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+this project a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our standards
+
+Behaviour that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Taking responsibility for our mistakes and learning from them
+- Focusing on what is best for the project and its users
+
+Behaviour that is unacceptable:
+
+- Sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+The maintainer is responsible for clarifying and enforcing these standards, and
+will take appropriate and fair corrective action in response to any behaviour
+deemed inappropriate, threatening, offensive, or harmful. This includes the
+right to remove, edit, or reject comments, commits, code, issues, and pull
+requests that are not aligned with this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — issues, pull requests,
+discussions, and commit history — and also when an individual is officially
+representing the project in public spaces.
+
+## Reporting
+
+Report abusive, harassing, or otherwise unacceptable behaviour privately to
+**chris@chriskievit.dev**.
+
+All complaints will be reviewed and investigated promptly and fairly. The
+maintainer will respect the privacy and security of the reporter of any
+incident. Consequences for violations range from a private warning to a
+permanent ban from interaction with the project, in proportion to the severity
+and to any pattern of repeated behaviour.
+
+If the maintainer is the subject of the report, you can escalate to GitHub at
+[github.com/contact/report-abuse](https://github.com/contact/report-abuse).
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html, and
+condensed for a single-maintainer project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing to Ariadne
+
+Ariadne is a single-maintainer personal tool that other people are welcome to
+fork, self-host, and improve. Contributions are genuinely welcome — the
+expectations below are here so you don't waste effort, not to gatekeep.
+
+## Before you start
+
+**Open an issue before a large PR.** Ariadne has a deliberately small surface:
+a dashboard route, a time report, and Settings. That's a real design constraint,
+not an accident, so a well-built feature can still be declined for being outside
+it. A short issue first saves you from building something that gets turned down.
+
+Small, obvious fixes — a bug, a typo, a broken link — can go straight to a PR.
+
+## Running locally
+
+Node 22 (see `.nvmrc`).
+
+```bash
+npm install
+npm run dev
+```
+
+The app runs at `http://127.0.0.1:3000`. On first run, open **Settings** to add
+GitHub and Azure DevOps personal access tokens with read-only scopes. They're
+stored in the local SQLite database, so nothing you configure while developing
+leaves your machine.
+
+Docker is also supported — see the self-hosting section of the README.
+
+## Testing
+
+**A PR is expected to arrive end-to-end tested.** Cover new or changed behaviour
+with tests in the framework that already exists here — please don't introduce
+another one:
+
+- **Logic, repositories, API routes** → a Vitest `*.test.ts` alongside the file
+  it covers, following the existing pattern in `lib/` and `app/api/`.
+- **Anything a user can see or click** → a Playwright spec in `e2e/`, reusing
+  the helpers in `e2e/helpers.ts` and seeding its own state.
+
+If you're changing code whose tests are missing, add them as part of the PR
+rather than leaving the gap where you found it.
+
+The e2e suite runs single-worker with no retries, so a test that only passes
+sometimes counts as failing. Tests must be self-contained and not depend on
+each other's leftovers.
+
+```bash
+npm test          # Vitest
+npm run test:e2e  # Playwright
+```
+
+## What CI enforces
+
+CI runs on every pull request and mirrors these commands exactly. Run them
+locally first — it's faster than waiting for a red build:
+
+```bash
+npm test                              # unit and route tests
+npx tsc --noEmit                      # type check
+npm run build                         # production build
+npm run test:e2e                      # end-to-end tests
+npm audit --omit=dev --audit-level=high   # production dependency audit
+```
+
+CI also greps `lib/github-client.ts` and `lib/ado-client.ts` for non-GET request
+methods. See below.
+
+## Project invariants
+
+These aren't style preferences. A PR that breaks one won't be merged.
+
+**Read-only, always.** Ariadne never writes back to GitHub or Azure DevOps.
+Actions like Start and Complete only ever touch Ariadne's own local `items`
+table. This is enforced in CI: any `POST`/`PUT`/`PATCH`/`DELETE` method string
+in the provider clients fails the build unless it's an explicitly marked
+`READ-ONLY-QUERY` (GitHub GraphQL and Azure DevOps WIQL both require POST to
+carry a query body).
+
+**Local-only and single-user.** No account system, no cloud sync, no
+multi-tenant backend. Just a SQLite file on the user's machine.
+
+**Transparent scoring.** Urgency is a deterministic, readable point formula in
+`lib/scoring.ts`, and every score chip opens to show which rules fired. New
+scoring rules go in that table and stay explainable. No opaque ranking.
+
+**Honest tradeoffs.** Where a limitation exists — tokens stored in plaintext
+locally, for instance — it's documented rather than hidden. Keep it that way.
+
+## Commits
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/) with
+the Angular preset, and releases are fully automated by semantic-release on
+merge to `main`. Your commit type decides the version bump:
+
+| Prefix | Effect |
+| --- | --- |
+| `feat:` | minor release |
+| `fix:` | patch release |
+| `BREAKING CHANGE:` in the body | major release |
+| `docs:`, `chore:`, `ci:`, `refactor:`, `test:` | no release |
+
+**Don't hand-edit `CHANGELOG.md`, the `version` field in `package.json`, or
+`package-lock.json` versions.** semantic-release owns all three and will
+overwrite your changes.
+
+## Pull requests
+
+- One focused change per PR. Unrelated refactoring makes review harder and
+  usually gets asked out again.
+- Say what you changed and why. If there's a tradeoff, name it — that's more
+  useful than a clean-looking diff.
+- Link the issue it addresses, if there is one.
+- Expect review comments. This is a personal tool with opinions baked in;
+  questions about an approach aren't a rejection of it.
+
+## Working with AI agents
+
+Agents are welcome here. Ariadne is largely built with them, so it would be odd
+to ask contributors not to use them. There's no disclosure requirement.
+
+**But the person who opens the PR owns the diff.** That means:
+
+- You understand every line you're submitting and can explain why it's there.
+- You can answer review questions about it without going back to re-derive the
+  reasoning.
+- You ran `npm test` and `npm run test:e2e` locally and they passed.
+- The tests are real tests, not assertions shaped to match whatever the code
+  currently does.
+
+A PR that reads as unreviewed agent output — tests that don't test anything,
+invented APIs, changes to files the task never needed to touch, a description
+that doesn't match the diff — will be closed rather than reviewed line by line.
+Review time is the scarce resource on a single-maintainer project, and that's
+the whole reason for the rule.
+
+## Code of conduct
+
+Participation is covered by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE) that covers this project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Kievit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ariadne",
       "version": "1.0.7",
+      "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.4.0",
         "@radix-ui/react-accordion": "^1.2.15",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ariadne",
   "version": "1.0.7",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev -H 127.0.0.1",
     "build": "next build",


### PR DESCRIPTION
Closes #31.

The repo has been public for a while with a README, screenshots, and open issues, but no `LICENSE`, no contribution guidance, and no `license` field in `package.json`. That left reuse rights legally ambiguous right as #13 landed and started pointing self-hosters here. This fills the gap.

**`LICENSE`** — MIT. Fits a personal tool people are encouraged to fork and self-host, and it's the norm in the homelab space #4 is courting. `package.json` gets `"license": "MIT"` alongside `"private": true` — the two do different jobs, `private` keeps it off npm and `license` is what GitHub and tooling read. The lockfile's root entry mirrors that field, so it's updated by hand to match; running `npm install --package-lock-only` here would also have stripped `libc` from 20 optional platform packages, which is npm-version drift I didn't want to smuggle in.

**`CONTRIBUTING.md`** — deliberately light, since this is a single-maintainer project. Issue first for anything large, because the small surface is a real filter. Beyond that it documents things a contributor currently has no way to know:

- The exact five commands CI runs, so a red build isn't a surprise
- Conventional commits and what each prefix does to the version, plus a warning not to hand-edit `CHANGELOG.md` or version fields — semantic-release owns those and will overwrite them
- The project invariants, including the fact that read-only isn't a guideline but a CI grep over the provider clients that fails the build

**Testing expectations** — PRs are expected to arrive end-to-end tested, using the frameworks already here: Vitest `*.test.ts` beside the file for logic and routes, a Playwright spec in `e2e/` for anything visible. If you're touching code whose tests are missing, they get added as part of the PR. Scoped to behaviour that actually changed, so a typo fix doesn't need an e2e spec.

**Agent-assisted contributions** — welcome and undisclosed, because the project is built that way and a disclosure rule nobody follows is worse than none. The line drawn instead is accountability: the person opening the PR owns the diff, can explain every line, and ran the tests. Unreviewed agent output gets closed rather than reviewed line by line.

**`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, condensed for a solo project, reports to a personal address with GitHub's abuse form as the escalation path for when the maintainer is the problem.

Skipped deliberately: `SECURITY.md`, a README license section, and issue/PR templates. Easy to add later if inbound traffic ever justifies them.

Docs only, plus two metadata lines. I couldn't run the suite locally — no `node_modules` in the working copy, and installing under this machine's Node 24 is what caused the lockfile drift above — so CI is the verification here.
