### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for this repository.
+# These owners are requested for review automatically on every pull request.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo.
+* @chriskievit


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file so every pull request automatically requests a review from @chriskievit.

The single `* @chriskievit` rule covers the whole repo — more specific paths can be layered on later if the project picks up more maintainers.