### PR TITLE
Dashboard critique fixes: keyboard-first coverage, row a11y, cascade dialog preview, type ramp

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import { SearchProvider } from '@/components/SearchProvider';
 import { CommandPaletteProvider } from '@/components/CommandPaletteProvider';
+import { KeymapHelpProvider } from '@/components/KeymapHelpProvider';
 import { DensityProvider } from '@/components/DensityProvider';
 import { RunningTimerProvider } from '@/components/RunningTimerProvider';
 import TopBar from '@/components/TopBar';
@@ -37,10 +38,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <DensityProvider density={density}>
             <SearchProvider>
               <CommandPaletteProvider>
-                <RunningTimerProvider>
-                  <TopBar />
-                  {children}
-                </RunningTimerProvider>
+                <KeymapHelpProvider>
+                  <RunningTimerProvider>
+                    <TopBar />
+                    {children}
+                  </RunningTimerProvider>
+                </KeymapHelpProvider>
               </CommandPaletteProvider>
             </SearchProvider>
           </DensityProvider>

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -7,6 +7,7 @@ import { Accordion } from '@/components/ui/accordion';
 import { Card, CardContent } from '@/components/ui/card';
 import { useSearch } from './SearchProvider';
 import { useCommandPalette } from './CommandPaletteProvider';
+import { useKeymapHelp } from './KeymapHelpProvider';
 import { useRunningTimer } from './RunningTimerProvider';
 import { matchesQuery } from '@/lib/search';
 import SprintProgressHeader from './SprintProgressHeader';
@@ -18,7 +19,6 @@ import ShutdownDialog from './ShutdownDialog';
 import PlanDayDialog from './PlanDayDialog';
 import SwitchTimerDialog from './SwitchTimerDialog';
 import GlobalKeymapProvider from './GlobalKeymapProvider';
-import KeymapHelpDialog from './KeymapHelpDialog';
 import CommandPalette from './CommandPalette';
 import ScoringReferenceDialog from './ScoringReferenceDialog';
 import FirstRunCard from './FirstRunCard';
@@ -77,7 +77,6 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
   const [reviewDayOpen, setReviewDayOpen] = useState(false);
   const [quickAddOpen, setQuickAddOpen] = useState(false);
   const [inProgressAccordion, setInProgressAccordion] = useState<string[]>(['in-progress']);
-  const [helpOpen, setHelpOpen] = useState(false);
   const [signalsQuery, setSignalsQuery] = useState('');
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
   const [sourceStatuses, setSourceStatuses] = useState<SourceStatus[]>([]);
@@ -104,6 +103,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
 
   const { query, setQuery } = useSearch();
   const { open: paletteOpen, setOpen: setPaletteOpen } = useCommandPalette();
+  const { setOpen: setHelpOpen } = useKeymapHelp();
   const router = useRouter();
 
   useEffect(() => {
@@ -487,7 +487,6 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
         onJustStop={handleJustStopTimer}
         onSwitch={handleSwitchTimer}
       />
-      <KeymapHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
       <ScoringReferenceDialog open={scoringReferenceOpen} onOpenChange={setScoringReferenceOpen} />
       <CommandPalette
         open={paletteOpen}

--- a/components/GlobalKeymapProvider.tsx
+++ b/components/GlobalKeymapProvider.tsx
@@ -48,6 +48,20 @@ export default function GlobalKeymapProvider({
 
       if (isTypingTarget(e.target)) return;
 
+      if (e.key === 'j' || e.key === 'k') {
+        // Don't steal focus out from under an open dialog or the score-chip
+        // popover -- both render with role="dialog" (see ScoreChip.tsx and
+        // components/ui/dialog.tsx) -- so this only ever moves row focus on
+        // the plain dashboard surface, not out of an active overlay.
+        if (document.querySelector('[role="dialog"]')) return;
+        e.preventDefault();
+        const rows = Array.from(document.querySelectorAll<HTMLElement>('[data-row-id]'));
+        const currentIndex = rows.findIndex((el) => el === document.activeElement);
+        const nextIndex = e.key === 'j' ? Math.min(rows.length - 1, currentIndex + 1) : Math.max(0, currentIndex - 1);
+        rows[nextIndex === -1 ? 0 : nextIndex]?.focus();
+        return;
+      }
+
       if (pendingG) {
         pendingG = false;
         if (pendingGTimeout) clearTimeout(pendingGTimeout);

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -38,7 +38,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn, formatRelativeTime } from '@/lib/utils';
-import { REASON_LABEL, type ScoreBreakdownEntry } from '@/lib/scoring';
+import { REASON_LABEL, MAX_SCORE, TIER_LABEL, getPriorityTier, type ScoreBreakdownEntry } from '@/lib/scoring';
 import { getStatusPill, type BadgeVariant } from '@/lib/status-pill';
 import { isKeptVisible } from '@/lib/grouping';
 import { matchesQuery } from '@/lib/search';
@@ -46,6 +46,7 @@ import type { Item, Status } from '@/lib/types';
 import type { LinkedRef } from '@/lib/links-repo';
 import { useSearch } from '@/components/SearchProvider';
 import { useDensity } from '@/components/DensityProvider';
+import { useRunningTimer } from '@/components/RunningTimerProvider';
 import type { Density } from '@/lib/config';
 import ScoreChip from './ScoreChip';
 import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
@@ -344,6 +345,7 @@ export default function ItemRow({
   const Icon = SOURCE_ICON[item.source];
   const { query } = useSearch();
   const density = useDensity();
+  const { runningTimer } = useRunningTimer();
   const isMatch = matchesQuery(item.title, query);
   const [open, setOpen] = useState(false);
   const [chipOpen, setChipOpen] = useState(false);
@@ -363,6 +365,11 @@ export default function ItemRow({
   const hoursValid = hours.trim() !== '' && Number.isFinite(parsedHours) && parsedHours >= 0;
   const pendingStartLinks = (item.links ?? []).filter((link) => link.itemId !== null && link.status === 'inbox');
   const pendingCompleteLinks = actionableLinks(item.links, 'done');
+  // Starting this item will also pop Dashboard's SwitchTimerDialog right
+  // after this one closes, if a different item's timer is running. Named
+  // here so the cascade dialog can preview that second question instead of
+  // letting it land as a surprise second modal.
+  const willSwitchTimer = Boolean(runningTimer && runningTimer.itemId !== item.id);
 
   function handleStartClick() {
     if (pendingStartLinks.length > 0) {
@@ -564,11 +571,16 @@ export default function ItemRow({
     <Dialog open={startCascadeOpen} onOpenChange={setStartCascadeOpen}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Start linked item{pendingStartLinks.length > 1 ? 's' : ''} too?</DialogTitle>
+          <DialogTitle>
+            Start linked item{pendingStartLinks.length > 1 ? 's' : ''} too?
+            {willSwitchTimer && <span className="text-muted-foreground"> (1 of 2)</span>}
+          </DialogTitle>
           <DialogDescription>
             {pendingStartLinks.length === 1
               ? `"${pendingStartLinks[0].title}" is linked to this item.`
               : `${pendingStartLinks.length} linked items aren't in progress yet.`}
+            {willSwitchTimer &&
+              ` You'll also be asked whether to stop or switch the timer running on "${runningTimer?.itemTitle}".`}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -690,9 +702,34 @@ export default function ItemRow({
   const keptVisible = isKeptVisible(item, item.score);
   const inlineBadge = getInlineBadge(item, keptVisible);
 
+  // Row-scoped shortcuts (see handleRowKeyDown) only fire while this exact
+  // wrapper has focus, so both the accessible name and the discoverability
+  // hint below are keyed off the same list rather than a static one -- a
+  // row without, say, onStar never claims 's' works on it.
+  const rowShortcuts = [
+    item.url ? 'o' : null,
+    onStar ? 's' : null,
+    onSnooze || onUnsnooze ? 'e' : null,
+    onDone ? 'd' : null,
+    onPinToday || onUnpinToday ? 't' : null,
+    'x',
+  ].filter((key): key is string => key !== null);
+
+  const rowLabel = [
+    item.title,
+    `${TIER_LABEL[getPriorityTier(item.score)]} priority`,
+    `score ${item.score} of ${MAX_SCORE}`,
+    inlineBadge?.label,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
   return (
     <div
       tabIndex={0}
+      role="group"
+      aria-label={rowLabel}
+      aria-keyshortcuts={rowShortcuts.join(' ')}
       data-row-id={item.id}
       onKeyDown={handleRowKeyDown}
       className={cn(
@@ -754,6 +791,16 @@ export default function ItemRow({
         </div>
       </div>
       <div className="flex w-full shrink-0 items-center justify-end gap-1 opacity-100 motion-safe:transition-opacity sm:w-auto sm:opacity-60 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
+        {rowShortcuts.length > 0 && (
+          <span
+            aria-hidden="true"
+            className="hidden shrink-0 items-center gap-1 rounded border border-border bg-background px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground sm:group-focus-visible:inline-flex"
+          >
+            {rowShortcuts.map((key) => (
+              <kbd key={key}>{key}</kbd>
+            ))}
+          </span>
+        )}
         {item.status === 'inbox' && onStart && (
           <Button
             type="button"

--- a/components/KeymapHelpProvider.tsx
+++ b/components/KeymapHelpProvider.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { createContext, useContext, useState, type ReactNode } from 'react';
+import KeymapHelpDialog from './KeymapHelpDialog';
+
+interface KeymapHelpContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+const KeymapHelpContext = createContext<KeymapHelpContextValue | undefined>(undefined);
+
+// Lives at the layout level, alongside CommandPaletteProvider, so TopBar's
+// "?" button -- rendered above every page, not just the dashboard -- can
+// open the shortcuts reference without Dashboard needing to hand it a prop.
+// Unlike CommandPalette, this dialog has no page-specific data to thread
+// through (it just reads the static KEYMAP table), so the provider renders
+// it directly instead of leaving that to whichever page happens to be
+// mounted.
+export function KeymapHelpProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <KeymapHelpContext.Provider value={{ open, setOpen }}>
+      {children}
+      <KeymapHelpDialog open={open} onOpenChange={setOpen} />
+    </KeymapHelpContext.Provider>
+  );
+}
+
+export function useKeymapHelp(): KeymapHelpContextValue {
+  const ctx = useContext(KeymapHelpContext);
+  if (!ctx) throw new Error('useKeymapHelp must be used within a KeymapHelpProvider');
+  return ctx;
+}

--- a/components/QueryBar.tsx
+++ b/components/QueryBar.tsx
@@ -141,7 +141,7 @@ export default function QueryBar({
           >
             <Star className="h-3 w-3" aria-hidden="true" />
             {view.label}
-            {view.shortcut && <kbd className="ml-1 font-mono text-[10px] text-muted-foreground">{view.shortcut}</kbd>}
+            {view.shortcut && <kbd className="ml-1 font-mono text-[11px] text-muted-foreground">{view.shortcut}</kbd>}
             <span
               role="button"
               tabIndex={0}

--- a/components/ScoreChip.tsx
+++ b/components/ScoreChip.tsx
@@ -3,7 +3,7 @@
 import { useId } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
-import { getPriorityTier, MAX_SCORE, type PriorityTier, type ScoreBreakdownEntry } from '@/lib/scoring';
+import { getPriorityTier, MAX_SCORE, TIER_LABEL, type PriorityTier, type ScoreBreakdownEntry } from '@/lib/scoring';
 
 // Urgency bands per docs/wireframes/phase-0-foundation.html: only the top two
 // bands are filled, medium is an outline, low has no border at all -- visual
@@ -15,13 +15,6 @@ const TIER_CHIP_CLASS: Record<PriorityTier, string> = {
   medium: 'border-2 border-urgency-medium bg-transparent text-foreground',
   high: 'border-transparent bg-urgency-high text-urgency-high-foreground',
   critical: 'border-transparent bg-urgency-critical text-urgency-critical-foreground',
-};
-
-const TIER_LABEL: Record<PriorityTier, string> = {
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  critical: 'Critical',
 };
 
 interface Props {

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -9,7 +9,6 @@ import QueryBar from './QueryBar';
 import { groupOf, isKeptVisible, GROUP_ORDER, GROUP_LABEL, type ObligationGroup } from '@/lib/grouping';
 import { parseQuery, applyQuery, withoutFilter } from '@/lib/query';
 import { isSnoozed, type SnoozeOption } from '@/lib/snooze';
-import { isTypingTarget } from '@/lib/keymap';
 import { createSavedView, deleteSavedView } from '@/lib/api-client';
 import type { SavedView } from '@/lib/saved-views';
 import type { Source } from '@/lib/types';
@@ -166,18 +165,9 @@ export default function SignalsBoard({
   }, [filtered]);
 
   return (
-    <div
-      aria-labelledby="signals-heading"
-      onKeyDown={(e) => {
-        if (isTypingTarget(document.activeElement)) return;
-        if (e.key !== 'j' && e.key !== 'k') return;
-        e.preventDefault();
-        const rows = Array.from(e.currentTarget.querySelectorAll<HTMLElement>('[data-row-id]'));
-        const currentIndex = rows.findIndex((el) => el === document.activeElement);
-        const nextIndex = e.key === 'j' ? Math.min(rows.length - 1, currentIndex + 1) : Math.max(0, currentIndex - 1);
-        rows[nextIndex === -1 ? 0 : nextIndex]?.focus();
-      }}
-    >
+    // j/k row navigation is handled globally (GlobalKeymapProvider), across
+    // Today, In-progress, and Signals alike -- not scoped to this section.
+    <div aria-labelledby="signals-heading">
       <div className="mb-3 flex items-center justify-between gap-2">
         <h2 id="signals-heading" className="flex items-center gap-2 text-base font-semibold">
           Signals

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { BarChart3, Search, Settings } from 'lucide-react';
+import { BarChart3, HelpCircle, Search, Settings } from 'lucide-react';
 import { AriadneMark } from '@/components/icons/ariadne-mark';
 import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { useCommandPalette } from '@/components/CommandPaletteProvider';
+import { useKeymapHelp } from '@/components/KeymapHelpProvider';
 import RunningTimerChip from '@/components/RunningTimerChip';
 import { useRunningTimer } from '@/components/RunningTimerProvider';
 import { stopTimerRequest, fetchSettings } from '@/lib/api-client';
@@ -14,6 +15,7 @@ import { SETTINGS_KEYS, DEFAULT_LONG_RUN_NUDGE_HOURS } from '@/lib/config';
 
 export default function TopBar() {
   const { setOpen } = useCommandPalette();
+  const { setOpen: setHelpOpen } = useKeymapHelp();
   const { runningTimer, refreshRunningTimer } = useRunningTimer();
   const [longRunNudgeHours, setLongRunNudgeHours] = useState(DEFAULT_LONG_RUN_NUDGE_HOURS);
 
@@ -68,6 +70,16 @@ export default function TopBar() {
             <Link href="/settings">
               <Settings className="h-4 w-4" />
             </Link>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Keyboard shortcuts"
+            title="Keyboard shortcuts (?)"
+            onClick={() => setHelpOpen(true)}
+          >
+            <HelpCircle className="h-4 w-4" />
           </Button>
           <ThemeToggle />
         </div>

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -135,7 +135,7 @@ const FormDescription = React.forwardRef<
     <p
       ref={ref}
       id={formDescriptionId}
-      className={cn("text-[0.8rem] text-muted-foreground", className)}
+      className={cn("text-xs text-muted-foreground", className)}
       {...props}
     />
   )
@@ -157,7 +157,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      className={cn("text-[0.8rem] font-medium text-destructive", className)}
+      className={cn("text-xs font-medium text-destructive", className)}
       {...props}
     >
       {body}

--- a/lib/keymap.ts
+++ b/lib/keymap.ts
@@ -7,19 +7,23 @@ export interface KeyBinding {
 // The single place a binding may be declared -- the `?` cheat sheet
 // (KeymapHelpDialog) and the command palette's shortcut hints both render
 // straight from this array, so neither can drift from what's actually wired
-// up. Row-scoped bindings fire from each row's own onKeyDown (naturally
-// inert while typing, since focus never reaches a row while an input has
-// it); global bindings go through the document-level listener in
-// GlobalKeymapProvider, which checks isTypingTarget before acting on any of
-// them.
+// up. `scope: 'row'` bindings act on whichever row currently has focus.
+// Most of them (enter/o, x, s, e, d, t) fire from that row's own bubbled
+// onKeyDown; j/k are the exception -- they navigate *between* rows, so they
+// fire from GlobalKeymapProvider's document-level listener instead, which
+// scans every `[data-row-id]` on the page (Today, In-progress, and Signals
+// alike) rather than one section's own container. `scope: 'global'`
+// bindings are page-level and always fire from GlobalKeymapProvider, which
+// checks isTypingTarget before acting on any binding (naturally inert while
+// typing, since focus never reaches a row while an input has it).
 //
 // Deliberately NOT included yet: `space` (start/stop timer) and `P` (plan
 // the day) -- both trigger Phase 3 features that don't exist in this
 // codebase yet. Declaring a binding for a nonexistent action would ship a
 // dead shortcut; they're added here once Phase 3 builds what they call.
 export const KEYMAP: KeyBinding[] = [
-  { keys: 'j', description: 'Move focus to the next signal', scope: 'row' },
-  { keys: 'k', description: 'Move focus to the previous signal', scope: 'row' },
+  { keys: 'j', description: 'Move focus to the next item', scope: 'row' },
+  { keys: 'k', description: 'Move focus to the previous item', scope: 'row' },
   { keys: '↵ / o', description: 'Open upstream in a new tab', scope: 'row' },
   { keys: 'x', description: 'Show the score breakdown', scope: 'row' },
   { keys: 's', description: 'Star (local only)', scope: 'row' },

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -129,6 +129,13 @@ export function getPriorityTier(score: number): PriorityTier {
   return 'low';
 }
 
+export const TIER_LABEL: Record<PriorityTier, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  critical: 'Critical',
+};
+
 export interface ScoringReferenceRow {
   label: string;
   points: number;


### PR DESCRIPTION
## Summary

Addresses all 5 priority issues from `/impeccable critique`'s dashboard review (35/40, Good):

- j/k row navigation now works across Today, In-progress, and Signals (was scoped to Signals only), via GlobalKeymapProvider's document-level listener.
- ItemRow's focusable wrapper gets `role="group"`, a computed `aria-label`, and `aria-keyshortcuts` so assistive tech gets a coherent row announcement.
- A focus-visible-only shortcut hint now surfaces directly on the row instead of being hidden inside the overflow menu.
- The start-linked-items cascade dialog previews the follow-up switch-timer question ("(1 of 2)") instead of surprising the user with a second modal.
- Three font sizes drifted off DESIGN.md's documented type ramp (QueryBar.tsx, ui/form.tsx) — moved onto the documented 11px/12px steps, and centralized `TIER_LABEL` into `lib/scoring.ts` instead of duplicating it.
- Added a visible `?` help icon in the TopBar (new `KeymapHelpProvider`, mirroring `CommandPaletteProvider`'s pattern) — the keyboard shortcuts dialog previously had no discoverable entry point anywhere on the page.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm test` — 380/380 passing
- [x] `detect.mjs` design-system scan — clean (was 3 findings)
- [x] Manual verification via isolated worktree + throwaway DB copy: confirmed row aria-label/aria-keyshortcuts render correctly per section, j navigation crosses section boundaries, focus-visible shortcut hint appears, and the new help button opens the dialog from both `/` and `/settings`