### PR TITLE
fix(timer): enforce a single running timer across all start paths

### DIFF
--- a/app/api/items/[id]/start/route.test.ts
+++ b/app/api/items/[id]/start/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { upsertSyncedItem, getItemById } from '@/lib/items-repo';
+import { getRunningTimer } from '@/lib/time-logs-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM time_logs; DELETE FROM items;');
+});
+
+function createItem(title: string) {
+  return upsertSyncedItem(testDb, {
+    source: 'ado_workitem',
+    externalId: title,
+    title,
+    url: null,
+    reason: 'assigned',
+    dueDate: null,
+    sprintIteration: null,
+    rawUpdatedAt: null,
+    repo: null,
+  });
+}
+
+describe('POST /api/items/:id/start', () => {
+  it('sets the item in_progress and starts its timer by default', async () => {
+    const item = createItem('Started normally');
+
+    await POST(new Request('http://localhost', { method: 'POST' }), { params: Promise.resolve({ id: String(item.id) }) });
+
+    expect(getItemById(testDb, item.id)?.status).toBe('in_progress');
+    expect(getRunningTimer(testDb)?.itemId).toBe(item.id);
+  });
+
+  it('sets the item in_progress without starting a timer when withTimer is false', async () => {
+    const item = createItem('Started via link cascade');
+
+    await POST(
+      new Request('http://localhost', { method: 'POST', body: JSON.stringify({ withTimer: false }) }),
+      { params: Promise.resolve({ id: String(item.id) }) }
+    );
+
+    expect(getItemById(testDb, item.id)?.status).toBe('in_progress');
+    expect(getRunningTimer(testDb)).toBeNull();
+  });
+
+  it('never leaves two items with an open timer, even across two start calls', async () => {
+    const first = createItem('First');
+    const second = createItem('Second');
+
+    await POST(new Request('http://localhost', { method: 'POST' }), { params: Promise.resolve({ id: String(first.id) }) });
+    await POST(new Request('http://localhost', { method: 'POST' }), { params: Promise.resolve({ id: String(second.id) }) });
+
+    expect(getRunningTimer(testDb)?.itemId).toBe(second.id);
+  });
+});

--- a/app/api/items/[id]/start/route.ts
+++ b/app/api/items/[id]/start/route.ts
@@ -3,10 +3,14 @@ import { db } from '@/lib/db-instance';
 import { setStatus, getItemById } from '@/lib/items-repo';
 import { startTimer } from '@/lib/time-logs-repo';
 
-export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = await params;
   const id = Number(idParam);
+  const body = (await request.json().catch(() => ({}))) as { withTimer?: boolean };
   setStatus(db, id, 'in_progress');
-  startTimer(db, id);
+  // withTimer: false is used when a linked-item cascade also advances this
+  // item's status -- the timer should stay on whichever item the user
+  // actually clicked Start on, not silently move to the last linked item.
+  if (body.withTimer !== false) startTimer(db, id);
   return NextResponse.json(getItemById(db, id));
 }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -166,8 +166,11 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
       return;
     }
     await startItem(id);
+    // Linked items only advance to in_progress -- the timer stays on the
+    // item the user actually clicked Start on, not the last one in this
+    // loop (see the withTimer contract in lib/api-client.ts).
     for (const linkId of alsoStartIds) {
-      await startItem(linkId);
+      await startItem(linkId, { withTimer: false });
     }
     await refresh();
   }
@@ -185,7 +188,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
     if (pendingStartId !== null) {
       await startItem(pendingStartId);
       for (const linkId of pendingStartAlsoIds) {
-        await startItem(linkId);
+        await startItem(linkId, { withTimer: false });
       }
     }
     setSwitchTimerOpen(false);

--- a/e2e/linked-item-start.spec.ts
+++ b/e2e/linked-item-start.spec.ts
@@ -14,7 +14,7 @@ test('starting a linked item with "Start both" moves both to In Progress even wh
 }) => {
   await ensureNoRunningTimer(request);
   const suffix = String(Date.now());
-  const { prItemId, adoItemId, adoTitle } = seedLinkedPair(suffix);
+  const { prItemId, adoItemId, prTitle } = seedLinkedPair(suffix);
   const otherTitle = `Already running ${suffix}`;
   const otherItemId = await createItem(request, otherTitle);
 
@@ -37,9 +37,10 @@ test('starting a linked item with "Start both" moves both to In Progress even wh
   await expect(page.getByRole('dialog', { name: 'A timer is already running' })).toBeVisible();
   await page.getByRole('button', { name: 'Switch' }).click();
 
-  // The link's timer starts second (after the item that was clicked), so it
-  // ends up as the one live-running -- both still land in In Progress below.
-  await expect(page.locator('header')).toContainText(adoTitle);
+  // The timer stays on the item the user actually clicked Start on -- the
+  // linked item only advances to In Progress, it never takes over the
+  // timer (see the withTimer: false contract in lib/api-client.ts).
+  await expect(page.locator('header')).toContainText(prTitle);
 
   const ids = await inProgressIds(request);
   expect(ids).toContain(prItemId);

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -18,8 +18,11 @@ export async function triggerSync() {
   return res.json();
 }
 
-export async function startItem(id: number) {
-  await fetch(`/api/items/${id}/start`, { method: 'POST' });
+export async function startItem(id: number, options?: { withTimer?: boolean }) {
+  await fetch(`/api/items/${id}/start`, {
+    method: 'POST',
+    body: JSON.stringify({ withTimer: options?.withTimer ?? true }),
+  });
 }
 
 export async function completeItem(id: number, body: { durationHours: number; note?: string }) {

--- a/lib/time-logs-repo.test.ts
+++ b/lib/time-logs-repo.test.ts
@@ -58,6 +58,29 @@ describe('startTimer / completeTimer', () => {
   });
 });
 
+describe('startTimer enforces a single running timer', () => {
+  it('closes any other item\'s open timer before opening a new one', () => {
+    const other = createAdhocItem(db, { title: 'Was already running' });
+    startTimer(db, other.id);
+    expect(getRunningTimer(db)?.itemId).toBe(other.id);
+
+    startTimer(db, itemId);
+
+    // Exactly one open timer should exist across the whole table, and it
+    // should be the one just started -- not both.
+    const openCount = db.prepare('SELECT COUNT(*) as n FROM time_logs WHERE ended_at IS NULL').get() as { n: number };
+    expect(openCount.n).toBe(1);
+    expect(getRunningTimer(db)?.itemId).toBe(itemId);
+
+    // The previously-running item's elapsed time should be banked, not
+    // discarded, when it gets closed out this way.
+    const otherLogs = listLogsByItem(db, other.id);
+    expect(otherLogs).toHaveLength(1);
+    expect(otherLogs[0].endedAt).not.toBeNull();
+    expect(otherLogs[0].durationHours).not.toBeNull();
+  });
+});
+
 describe('elapsedHoursSinceStart', () => {
   it('returns the wall-clock hours elapsed since the open timer started', () => {
     const started = startTimer(db, itemId);

--- a/lib/time-logs-repo.ts
+++ b/lib/time-logs-repo.ts
@@ -13,7 +13,18 @@ function rowToLog(row: any): TimeLog {
   };
 }
 
+// Enforces the single-running-timer invariant here, at the source, rather
+// than relying on every caller to stop the previous timer first -- that's
+// exactly the discipline the link-start cascade (Dashboard.tsx) forgot,
+// leaving multiple items with an open timer at once. Closing any other
+// open timer first (banking its elapsed time, same as stopTimer) means
+// that can't happen again regardless of what a future caller does.
 export function startTimer(db: Database.Database, itemId: number): TimeLog {
+  const others = db
+    .prepare('SELECT item_id FROM time_logs WHERE ended_at IS NULL AND item_id != ?')
+    .all(itemId) as { item_id: number }[];
+  for (const other of others) stopTimer(db, other.item_id);
+
   const now = new Date().toISOString();
   const result = db.prepare('INSERT INTO time_logs (item_id, started_at) VALUES (?, ?)').run(itemId, now);
   return rowToLog(db.prepare('SELECT * FROM time_logs WHERE id = ?').get(result.lastInsertRowid));


### PR DESCRIPTION
## Summary

Root cause of "multiple items showed as running on the timer": `startTimer()` never checked for an existing open timer, relying entirely on every caller to stop the previous one first. That held for the normal switch-timer dialog, but the link-start cascade ("Start all"/"Start both" on linked items) looped `startItem()` over each linked item, opening a new timer for each one without closing the one just opened for the previous item in the same batch — leaving multiple items with an open timer at once, invisible in the UI (which only ever shows the most recently started one).

- `startTimer()` now closes any other open timer (banking its elapsed time, same as a normal pause) before opening a new one — enforced at the source, not by caller discipline.
- Linked items started via a cascade now only advance to `in_progress` (new `startItem(id, { withTimer: false })` option) — the timer stays on whichever item you actually clicked Start on, not the last linked item in the loop. This is separate from "in progress" status, which can and should still apply to multiple items at once.

## Test plan

- [x] New test in `lib/time-logs-repo.test.ts` proving the single-timer invariant, confirmed it failed against the old code before the fix
- [x] New `app/api/items/[id]/start/route.test.ts` (route had no test coverage before this)
- [x] `tsc --noEmit` clean
- [x] `npm test` — 384/384 passing
- [x] `detect.mjs` design-system scan — clean