### PR TITLE
Group Settings into sections and fix save/status feedback

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import SettingsForm from '@/components/SettingsForm';
-import SettingsScoringLink from '@/components/SettingsScoringLink';
 import { db } from '@/lib/db-instance';
 import { getRedactedSettings } from '@/lib/settings-repo';
 
@@ -18,7 +17,6 @@ export default function SettingsPage() {
       </Link>
       <h1 className="text-lg font-semibold">Settings</h1>
       <SettingsForm initialSettings={settings} />
-      <SettingsScoringLink />
     </main>
   );
 }

--- a/components/SettingsForm.tsx
+++ b/components/SettingsForm.tsx
@@ -4,12 +4,20 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { SETTINGS_KEYS, DEFAULT_STALE_DAYS, DEFAULT_DENSITY } from '@/lib/config';
+import SettingsScoringLink from './SettingsScoringLink';
+
+// "Token saved", not "Connected" — this only reflects that a PAT is stored,
+// never that it's valid against GitHub/ADO, so the label shouldn't claim more.
+function ConnectionBadge({ connected }: { connected: boolean }) {
+  return <Badge variant={connected ? 'success' : 'outline'}>{connected ? 'Token saved' : 'No token saved'}</Badge>;
+}
 
 // react-hook-form treats dots in a field `name` as a nested-path separator
 // (e.g. "ado.org" is stored as { ado: { org } }), so SETTINGS_KEYS' dotted
@@ -36,8 +44,11 @@ interface Props {
 
 export default function SettingsForm({ initialSettings }: Props) {
   const [saved, setSaved] = useState(false);
-  const githubPatIsSet = initialSettings[`${SETTINGS_KEYS.githubPat}.isSet`] === 'true';
-  const adoPatIsSet = initialSettings[`${SETTINGS_KEYS.adoPat}.isSet`] === 'true';
+  const [saveError, setSaveError] = useState(false);
+  const [githubPatIsSet, setGithubPatIsSet] = useState(
+    initialSettings[`${SETTINGS_KEYS.githubPat}.isSet`] === 'true'
+  );
+  const [adoPatIsSet, setAdoPatIsSet] = useState(initialSettings[`${SETTINGS_KEYS.adoPat}.isSet`] === 'true');
   const form = useForm<SettingsValues>({
     resolver: zodResolver(settingsSchema),
     defaultValues: {
@@ -69,151 +80,198 @@ export default function SettingsForm({ initialSettings }: Props) {
     if (values.githubPat) body[SETTINGS_KEYS.githubPat] = values.githubPat;
     if (values.adoPat) body[SETTINGS_KEYS.adoPat] = values.adoPat;
 
-    await fetch('/api/settings', { method: 'POST', body: JSON.stringify(body) });
-    setSaved(true);
+    setSaved(false);
+    setSaveError(false);
+    try {
+      const response = await fetch('/api/settings', { method: 'POST', body: JSON.stringify(body) });
+      if (!response.ok) throw new Error(`Settings save failed with status ${response.status}`);
+      // The response carries the same redacted `<key>.isSet` shape as
+      // initialSettings, so the badges can reflect what was actually
+      // persisted instead of going stale until the next page load.
+      const updated = (await response.json()) as Record<string, string>;
+      setGithubPatIsSet(updated[`${SETTINGS_KEYS.githubPat}.isSet`] === 'true');
+      setAdoPatIsSet(updated[`${SETTINGS_KEYS.adoPat}.isSet`] === 'true');
+      setSaved(true);
+    } catch {
+      setSaveError(true);
+    }
   }
 
   return (
     <Card>
       <CardContent className="pt-6">
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
-            <FormField
-              control={form.control}
-              name="githubPat"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>GitHub personal access token</FormLabel>
-                  <FormControl>
-                    <Input type="password" placeholder={githubPatIsSet ? 'Saved — leave blank to keep it' : ''} {...field} />
-                  </FormControl>
-                  <p className="text-xs text-muted-foreground">
-                    Tokens are stored in plaintext in your local database — the same trust model as a{' '}
-                    <code className="font-mono">.env</code> file. The saved token is never sent back to the
-                    browser; leave this blank to keep it unchanged.
-                  </p>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="adoPat"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Azure DevOps personal access token</FormLabel>
-                  <FormControl>
-                    <Input type="password" placeholder={adoPatIsSet ? 'Saved — leave blank to keep it' : ''} {...field} />
-                  </FormControl>
-                  <p className="text-xs text-muted-foreground">
-                    Tokens are stored in plaintext in your local database — the same trust model as a{' '}
-                    <code className="font-mono">.env</code> file. The saved token is never sent back to the
-                    browser; leave this blank to keep it unchanged.
-                  </p>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="adoOrg"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Azure DevOps organization</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="adoProject"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Azure DevOps project</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="adoTeam"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Azure DevOps team (optional)</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="Defaults to the project name if left blank" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="staleDays"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Stale PR threshold (days)</FormLabel>
-                  <FormControl>
-                    <Input type="number" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="localReposBaseDir"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Local repos base directory</FormLabel>
-                  <FormControl>
-                    <Input placeholder="/Users/you/dev/github" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="repoPathOverrides"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Repo path overrides (optional)</FormLabel>
-                  <FormControl>
-                    <Textarea placeholder="repo-name=/absolute/path (one per line)" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="density"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Row density</FormLabel>
-                  <FormControl>
-                    <select
-                      className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                      {...field}
-                    >
-                      <option value="comfortable">Comfortable — 44px rows (default)</option>
-                      <option value="compact">Compact — 36px rows</option>
-                    </select>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+            <div className="space-y-4 border-b pb-6">
+              <h2 className="text-base font-semibold">Integrations</h2>
+
+              <div className="space-y-4">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium">GitHub</h3>
+                  <ConnectionBadge connected={githubPatIsSet} />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="githubPat"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>GitHub personal access token</FormLabel>
+                      <FormControl>
+                        <Input type="password" placeholder={githubPatIsSet ? 'Saved — leave blank to keep it' : ''} {...field} />
+                      </FormControl>
+                      <p className="text-xs text-muted-foreground">
+                        Tokens are stored in plaintext in your local database — the same trust model as a{' '}
+                        <code className="font-mono">.env</code> file. The saved token is never sent back to the
+                        browser; leave this blank to keep it unchanged.
+                      </p>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium">Azure DevOps</h3>
+                  <ConnectionBadge connected={adoPatIsSet} />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="adoPat"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Azure DevOps personal access token</FormLabel>
+                      <FormControl>
+                        <Input type="password" placeholder={adoPatIsSet ? 'Saved — leave blank to keep it' : ''} {...field} />
+                      </FormControl>
+                      <p className="text-xs text-muted-foreground">
+                        Tokens are stored in plaintext in your local database — the same trust model as a{' '}
+                        <code className="font-mono">.env</code> file. The saved token is never sent back to the
+                        browser; leave this blank to keep it unchanged.
+                      </p>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="adoOrg"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Azure DevOps organization</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="adoProject"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Azure DevOps project</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="adoTeam"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Azure DevOps team (optional)</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="Defaults to the project name if left blank" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-4 border-b pb-6">
+              <h2 className="text-base font-semibold">Sync &amp; scoring</h2>
+              <FormField
+                control={form.control}
+                name="staleDays"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Stale PR threshold (days)</FormLabel>
+                    <FormControl>
+                      <Input type="number" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <SettingsScoringLink />
+            </div>
+
+            <div className="space-y-4 border-b pb-6">
+              <h2 className="text-base font-semibold">Local repos</h2>
+              <FormField
+                control={form.control}
+                name="localReposBaseDir"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Local repos base directory</FormLabel>
+                    <FormControl>
+                      <Input placeholder="/Users/you/dev/github" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="repoPathOverrides"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Repo path overrides (optional)</FormLabel>
+                    <FormControl>
+                      <Textarea placeholder="repo-name=/absolute/path (one per line)" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="space-y-4">
+              <h2 className="text-base font-semibold">Appearance</h2>
+              <FormField
+                control={form.control}
+                name="density"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Row density</FormLabel>
+                    <FormControl>
+                      <select
+                        className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        {...field}
+                      >
+                        <option value="comfortable">Comfortable — 44px rows (default)</option>
+                        <option value="compact">Compact — 36px rows</option>
+                      </select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
             <div className="flex items-center gap-3">
               <Button type="submit">Save</Button>
-              {saved && <span className="text-sm text-muted-foreground">Saved.</span>}
+              <span role="status" aria-live="polite" className="text-sm">
+                {saved && <span className="text-muted-foreground">Saved.</span>}
+                {saveError && <span className="text-destructive">Save failed. Try again.</span>}
+              </span>
             </div>
           </form>
         </Form>

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test('settings page groups fields into sections with per-source connection badges', async ({ page }) => {
+  await page.goto('/settings');
+
+  await expect(page.getByRole('heading', { name: 'Integrations' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Sync & scoring' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Local repos' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
+
+  await expect(page.getByRole('heading', { name: 'GitHub' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Azure DevOps' })).toBeVisible();
+
+  // The e2e database starts empty each run, so neither PAT is saved yet.
+  await expect(page.getByText('No token saved')).toHaveCount(2);
+
+  await expect(page.getByRole('button', { name: 'How urgency is scored' })).toBeVisible();
+});
+
+test('saving a field round-trips after reload', async ({ page }) => {
+  await page.goto('/settings');
+
+  const staleDaysInput = page.getByLabel('Stale PR threshold (days)');
+  await staleDaysInput.fill('7');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByRole('status')).toHaveText('Saved.');
+
+  await page.reload();
+  await expect(page.getByLabel('Stale PR threshold (days)')).toHaveValue('7');
+});


### PR DESCRIPTION
## Summary
- Restructures the flat settings form (`components/SettingsForm.tsx`) into four labeled sections: **Integrations** (GitHub / Azure DevOps sub-blocks, each with a per-source "Token saved" badge), **Sync & scoring** (stale-day threshold + "how urgency is scored" link, moved in from the page), **Local repos**, **Appearance**. Presentation only, no `settings-repo` schema/storage changes.
- Structures Integrations as one block per source so a Jira block (#32) is a drop-in later, and gives future scoring-weight config (#35) a named home in Sync & scoring.
- Fixes three issues found in an impeccable-skill design critique of the restructure: a failed save was silently reported as "Saved.", the token badge didn't refresh after a successful save, and the badge label overclaimed connectivity ("Connected") when it only reflects that a token string is stored.

## Test plan
- [x] `npm test` — 384 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx playwright test` — 9/9 pass, including a new `e2e/settings.spec.ts` covering section headings, badges, and a save round-trip
- [x] Manually verified against a live dev server

Closes #33.