### PR TITLE
fix(ci): use an admin PAT for semantic-release's push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # protect-main requires PRs for the default GITHUB_TOKEN (the
+          # github-actions bot isn't an admin bypass actor), but
+          # @semantic-release/git needs to push the version-bump commit and
+          # tag straight to main. RELEASE_TOKEN is a PAT from an account that
+          # holds the repo's admin bypass role.
+          token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
@@ -47,4 +53,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- The `protect-main` ruleset requires all changes to go through a PR; the default `GITHUB_TOKEN` (github-actions bot) isn't a bypass actor for that rule, so `@semantic-release/git`'s direct push of the version-bump commit + tag to `main` was rejected with `GH013`.
- Switches the release job's checkout token and the `semantic-release` env to `secrets.RELEASE_TOKEN`, a PAT from an admin account (which does hold the bypass role).

Confirmed root cause via the failed run: https://github.com/chriskievit/ariadne/actions/runs/32035024422/job/95403604975

## Test plan
- [ ] Requires the `RELEASE_TOKEN` repo secret to exist before this takes effect (not yet added at PR time)
- [x] Workflow YAML is otherwise unchanged; no app code touched