### PR TITLE
Complete items from the timer chip; fix Today's logged/planned totals

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -68,6 +68,8 @@ interface DashboardData {
   signals: ScoredItem[];
   inProgress: ScoredItem[];
   parked: ScoredItem[];
+  todayPlannedMinutes: number;
+  todayLoggedMinutes: number;
   sprint: SprintProgress;
 }
 
@@ -98,6 +100,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
   const autoSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
   const prevQueryRef = useRef('');
+  const prevRunningItemIdRef = useRef<number | null | undefined>(undefined);
   const preSearchAccordionRef = useRef<{ inProgress: string[] } | null>(null);
   const lastUndoRef = useRef<(() => void) | null>(null);
 
@@ -119,6 +122,20 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
     fetchCalibration(today, today).then(setCalibration);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // The running timer can be stopped from outside this component's own
+  // handlers (e.g. completing the item straight from the header's ticker),
+  // so watch the shared runningTimer for a transition away from an item it
+  // was previously tracking and pull the dashboard lists back in sync.
+  useEffect(() => {
+    const currentItemId = runningTimer?.itemId ?? null;
+    const prevItemId = prevRunningItemIdRef.current;
+    if (prevItemId !== undefined && prevItemId !== null && prevItemId !== currentItemId) {
+      refresh();
+    }
+    prevRunningItemIdRef.current = currentItemId;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runningTimer]);
 
   function scheduleAutoSync() {
     if (!isMountedRef.current) return;
@@ -403,6 +420,8 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
           {!hasAnyMatch && <p className="text-sm text-muted-foreground">No matches for &ldquo;{trimmedQuery}&rdquo;.</p>}
           <TodaySection
             items={data.today}
+            plannedMinutes={data.todayPlannedMinutes}
+            loggedMinutes={data.todayLoggedMinutes}
             capacityMinutes={plan.capacityMinutes}
             onStart={handleStart}
             onComplete={handleComplete}

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -347,6 +347,7 @@ export default function ItemRow({
   const density = useDensity();
   const { runningTimer } = useRunningTimer();
   const isMatch = matchesQuery(item.title, query);
+  const isTracking = runningTimer?.itemId === item.id;
   const [open, setOpen] = useState(false);
   const [chipOpen, setChipOpen] = useState(false);
   const [snoozeDialogOpen, setSnoozeDialogOpen] = useState(false);
@@ -717,6 +718,7 @@ export default function ItemRow({
 
   const rowLabel = [
     item.title,
+    isTracking ? 'currently tracking time' : null,
     `${TIER_LABEL[getPriorityTier(item.score)]} priority`,
     `score ${item.score} of ${MAX_SCORE}`,
     inlineBadge?.label,
@@ -756,6 +758,13 @@ export default function ItemRow({
         <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
+            {isTracking && (
+              <span
+                className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-[hsl(var(--brand-gold))]"
+                aria-hidden="true"
+                title="Currently tracking time"
+              />
+            )}
             {item.url ? (
               <a
                 href={item.url}

--- a/components/RunningTimerChip.tsx
+++ b/components/RunningTimerChip.tsx
@@ -1,14 +1,25 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Pause } from 'lucide-react';
+import { Check, Pause } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { toast } from '@/components/ui/sonner';
+import { elapsedHoursForInput } from '@/lib/elapsed';
 import type { RunningTimer } from '@/lib/time-logs-repo';
 
 interface Props {
   runningTimer: RunningTimer | null;
   onStop: () => void;
+  onComplete: (itemId: number, durationHours: number, note?: string) => void;
   longRunNudgeHours: number;
 }
 
@@ -21,9 +32,12 @@ function formatElapsed(ms: number): string {
   return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
 }
 
-export default function RunningTimerChip({ runningTimer, onStop, longRunNudgeHours }: Props) {
+export default function RunningTimerChip({ runningTimer, onStop, onComplete, longRunNudgeHours }: Props) {
   const [now, setNow] = useState(() => Date.now());
   const [nudgedFor, setNudgedFor] = useState<number | null>(null);
+  const [completeOpen, setCompleteOpen] = useState(false);
+  const [hours, setHours] = useState('');
+  const [note, setNote] = useState('');
 
   useEffect(() => {
     if (!runningTimer) return;
@@ -47,18 +61,81 @@ export default function RunningTimerChip({ runningTimer, onStop, longRunNudgeHou
   if (!runningTimer) return null;
 
   const elapsedMs = now - new Date(runningTimer.startedAt).getTime();
+  const parsedHours = Number(hours);
+  const hoursValid = hours.trim() !== '' && Number.isFinite(parsedHours) && parsedHours >= 0;
+
+  function handleOpenComplete() {
+    if (!runningTimer) return;
+    setHours(elapsedHoursForInput(elapsedMs));
+    setNote('');
+    setCompleteOpen(true);
+  }
+
+  function handleCompleteSubmit() {
+    if (!runningTimer || !hoursValid) return;
+    onComplete(runningTimer.itemId, parsedHours, note || undefined);
+    setCompleteOpen(false);
+  }
 
   return (
-    <div className="flex items-center gap-2 rounded-md border border-input px-2.5 py-1 text-sm">
-      <span
-        className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-[hsl(var(--brand-gold))]"
-        aria-hidden="true"
-      />
-      <span className="max-w-[10rem] truncate">{runningTimer.itemTitle}</span>
-      <span className="font-mono tabular-nums text-muted-foreground">{formatElapsed(elapsedMs)}</span>
-      <Button type="button" variant="ghost" size="icon" className="h-6 w-6" aria-label="Pause timer" onClick={onStop}>
-        <Pause className="h-3.5 w-3.5" />
-      </Button>
-    </div>
+    <>
+      <div className="flex items-center gap-2 rounded-md border border-input px-2.5 py-1 text-sm">
+        <span
+          className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-[hsl(var(--brand-gold))]"
+          aria-hidden="true"
+        />
+        <span className="max-w-[8rem] truncate">{runningTimer.itemTitle}</span>
+        <span className="font-mono tabular-nums text-muted-foreground">{formatElapsed(elapsedMs)}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          aria-label="Complete item"
+          onClick={handleOpenComplete}
+        >
+          <Check className="h-3.5 w-3.5" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon" className="h-6 w-6" aria-label="Pause timer" onClick={onStop}>
+          <Pause className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      <Dialog open={completeOpen} onOpenChange={setCompleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Mark complete</DialogTitle>
+          </DialogHeader>
+          <div className="grid gap-4 py-2">
+            <div className="grid gap-1.5">
+              <Label htmlFor="ticker-complete-hours">Hours spent</Label>
+              <Input
+                id="ticker-complete-hours"
+                type="number"
+                step="0.25"
+                min="0"
+                value={hours}
+                onChange={(e) => setHours(e.target.value)}
+              />
+              {hours.trim() !== '' && !hoursValid ? (
+                <p className="text-sm text-destructive">Enter a number 0 or greater.</p>
+              ) : null}
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="ticker-complete-note">Note (optional)</Label>
+              <Input id="ticker-complete-note" value={note} onChange={(e) => setNote(e.target.value)} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setCompleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleCompleteSubmit} disabled={!hoursValid}>
+              Complete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -10,6 +10,8 @@ import type { Item } from '@/lib/types';
 
 interface Props {
   items: ScoredItem[];
+  plannedMinutes: number;
+  loggedMinutes: number;
   capacityMinutes: number;
   onStart?: (id: number, alsoStartIds?: number[]) => void;
   onComplete: (id: number, durationHours: number, note?: string) => void;
@@ -32,6 +34,8 @@ function formatMinutes(minutes: number): string {
 
 export default function TodaySection({
   items,
+  plannedMinutes,
+  loggedMinutes,
   capacityMinutes,
   onStart,
   onComplete,
@@ -43,9 +47,6 @@ export default function TodaySection({
   failingSources,
   onOpenScoringReference,
 }: Props) {
-  const plannedMinutes = items.reduce((sum, i) => sum + (i.estimateMinutes ?? 0), 0);
-  const loggedMinutes = items.reduce((sum, i) => sum + i.loggedMinutesToday, 0);
-
   function move(id: number, direction: -1 | 1) {
     const order = items.map((i) => i.id);
     const index = order.indexOf(id);

--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -10,7 +10,8 @@ import { useCommandPalette } from '@/components/CommandPaletteProvider';
 import { useKeymapHelp } from '@/components/KeymapHelpProvider';
 import RunningTimerChip from '@/components/RunningTimerChip';
 import { useRunningTimer } from '@/components/RunningTimerProvider';
-import { stopTimerRequest, fetchSettings } from '@/lib/api-client';
+import { toast } from '@/components/ui/sonner';
+import { completeItem, undoItem, stopTimerRequest, fetchSettings } from '@/lib/api-client';
 import { SETTINGS_KEYS, DEFAULT_LONG_RUN_NUDGE_HOURS } from '@/lib/config';
 
 export default function TopBar() {
@@ -37,9 +38,24 @@ export default function TopBar() {
     await refreshRunningTimer();
   }
 
+  async function handleCompleteTimer(itemId: number, durationHours: number, note?: string) {
+    await completeItem(itemId, { durationHours, note });
+    await refreshRunningTimer();
+    toast('Completed.', {
+      duration: 5000,
+      action: {
+        label: 'Undo',
+        onClick: async () => {
+          await undoItem(itemId);
+          await refreshRunningTimer();
+        },
+      },
+    });
+  }
+
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
-      <div className="mx-auto grid h-16 max-w-6xl grid-cols-[1fr_auto_minmax(0,24rem)_1fr] items-center gap-4 px-6">
+      <div className="mx-auto grid h-16 max-w-6xl grid-cols-[1fr_auto_minmax(0,20rem)_1fr] items-center gap-4 px-6">
         <Link
           href="/"
           className="group flex w-fit items-center gap-2.5 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--brand-gold))] focus-visible:ring-offset-2 focus-visible:ring-offset-background"
@@ -48,7 +64,12 @@ export default function TopBar() {
           <span className="font-display text-xl leading-none tracking-wide text-foreground">Ariadne</span>
         </Link>
 
-        <RunningTimerChip runningTimer={runningTimer} onStop={handleStopTimer} longRunNudgeHours={longRunNudgeHours} />
+        <RunningTimerChip
+          runningTimer={runningTimer}
+          onStop={handleStopTimer}
+          onComplete={handleCompleteTimer}
+          longRunNudgeHours={longRunNudgeHours}
+        />
 
         <button
           type="button"

--- a/lib/dashboard.test.ts
+++ b/lib/dashboard.test.ts
@@ -150,6 +150,46 @@ describe('getGroupedItems today bucket', () => {
     expect(grouped.today.map((i) => i.id)).toEqual([]);
     expect(grouped.inProgress.map((i) => i.id)).toEqual([item.id]);
   });
+
+  it('keeps a started item\'s estimate counted in todayPlannedMinutes even though it leaves the today bucket', () => {
+    const today = '2026-08-13';
+    const item = createAdhocItem(db, { title: 'Test' });
+    setTodayDate(db, item.id, today);
+    addPlanItem(db, today, item.id);
+    setPlanItemEstimate(db, today, item.id, 60);
+
+    const now = new Date(2026, 7, 13, 9, 0);
+    let grouped = getGroupedItems(db, now);
+    expect(grouped.todayPlannedMinutes).toBe(60);
+
+    setStatus(db, item.id, 'in_progress');
+    grouped = getGroupedItems(db, now);
+    expect(grouped.today.map((i) => i.id)).toEqual([]);
+    expect(grouped.todayPlannedMinutes).toBe(60);
+  });
+
+  it('counts hours logged on a completed item toward todayLoggedMinutes even though it leaves the today bucket', () => {
+    const today = '2026-08-13';
+    const item = createAdhocItem(db, { title: 'Test' });
+    setTodayDate(db, item.id, today);
+    addPlanItem(db, today, item.id);
+    setPlanItemEstimate(db, today, item.id, 60);
+
+    const now = new Date(2026, 7, 13, 9, 0);
+    setStatus(db, item.id, 'in_progress');
+    startTimer(db, item.id);
+    completeTimer(db, item.id, { durationHours: 0.5 });
+    db.prepare('UPDATE time_logs SET started_at = ?, ended_at = ? WHERE item_id = ?').run(
+      now.toISOString(),
+      now.toISOString(),
+      item.id
+    );
+    setStatus(db, item.id, 'done', now.toISOString());
+
+    const grouped = getGroupedItems(db, now);
+    expect(grouped.today.map((i) => i.id)).toEqual([]);
+    expect(grouped.todayLoggedMinutes).toBe(30);
+  });
 });
 
 describe('getGroupedItems links', () => {

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -23,6 +23,8 @@ export interface GroupedItems {
   signals: ScoredItem[];
   inProgress: ScoredItem[];
   parked: ScoredItem[];
+  todayPlannedMinutes: number;
+  todayLoggedMinutes: number;
 }
 
 export function getGroupedItems(db: Database.Database, now: Date): GroupedItems {
@@ -54,11 +56,23 @@ export function getGroupedItems(db: Database.Database, now: Date): GroupedItems 
     .sort((a, b) => (sortOrderByItemId.get(a.id) ?? Infinity) - (sortOrderByItemId.get(b.id) ?? Infinity));
   const todayIds = new Set(today.map((i) => i.id));
 
+  // Sourced from plan_items rather than the `today` bucket above: starting or
+  // completing an item moves it out of that bucket (and start even clears
+  // today_date), but it's still part of what was planned for today, so its
+  // estimate and any hours logged against it must keep counting here.
+  const todayPlannedMinutes = planItems.reduce((sum, pi) => sum + (pi.estimateMinutes ?? 0), 0);
+  const todayLoggedMinutes = planItems.reduce(
+    (sum, pi) => sum + Math.round((loggedTodayByItemId.get(pi.itemId) ?? 0) * 60),
+    0
+  );
+
   return {
     today,
     signals: scored.filter((i) => i.status === 'inbox' && !todayIds.has(i.id)),
     inProgress: scored.filter((i) => i.status === 'in_progress' && !i.parked),
     parked: scored.filter((i) => i.status === 'in_progress' && i.parked),
+    todayPlannedMinutes,
+    todayLoggedMinutes,
   };
 }
 

--- a/lib/elapsed.test.ts
+++ b/lib/elapsed.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { elapsedHoursForInput } from './elapsed';
+
+describe('elapsedHoursForInput', () => {
+  it('rounds down to the nearest quarter hour', () => {
+    expect(elapsedHoursForInput(20 * 60_000)).toBe('0.25');
+  });
+
+  it('rounds up to the nearest quarter hour', () => {
+    expect(elapsedHoursForInput(40 * 60_000)).toBe('0.75');
+  });
+
+  it('formats whole hours without a decimal', () => {
+    expect(elapsedHoursForInput(2 * 3_600_000)).toBe('2');
+  });
+
+  it('formats a mid-value quarter hour', () => {
+    expect(elapsedHoursForInput(90 * 60_000)).toBe('1.5');
+  });
+
+  it('returns 0 for a just-started timer', () => {
+    expect(elapsedHoursForInput(5000)).toBe('0');
+  });
+
+  it('never returns a negative value', () => {
+    expect(elapsedHoursForInput(-1000)).toBe('0');
+  });
+});

--- a/lib/elapsed.ts
+++ b/lib/elapsed.ts
@@ -1,0 +1,9 @@
+// Zero-dependency helper (see lib/date.ts) so it can be imported from a
+// 'use client' component -- used to pre-fill the "hours spent" field when
+// completing an item straight from the running-timer chip.
+
+export function elapsedHoursForInput(elapsedMs: number): string {
+  const hours = Math.max(0, elapsedMs) / 3_600_000;
+  const roundedToQuarterHour = Math.round(hours * 4) / 4;
+  return String(roundedToQuarterHour);
+}


### PR DESCRIPTION
## Summary
- Adds a complete-from-ticker flow: the running-timer chip gets a Check button that opens a dialog to log hours and mark the item done without leaving the header. The dashboard resyncs its lists whenever the shared timer stops from outside its own handlers (e.g. via that dialog).
- Fixes Today's "X logged of Y planned" header. It was computed from the same status='inbox' list used to render Today's rows, so starting or completing an item dropped it out of that list immediately and its estimate/logged hours stopped counting the moment either action happened. The totals now come from plan_items, which persists across status changes.

## Test plan
- [x] `npx vitest run` (392 tests, including two new cases reproducing the logged/planned bug)
- [x] `npx tsc --noEmit`