### PR TITLE
Keep Today items visible through status changes; add Park/Resume in Today

### DIFF
--- a/app/api/items/[id]/start/route.test.ts
+++ b/app/api/items/[id]/start/route.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { openDb } from '@/lib/db';
-import { upsertSyncedItem, getItemById } from '@/lib/items-repo';
+import { upsertSyncedItem, getItemById, setTodayDate } from '@/lib/items-repo';
 import { getRunningTimer } from '@/lib/time-logs-repo';
+import { addPlanItem, getPlanItems } from '@/lib/plans-repo';
+import { localDateString } from '@/lib/date';
 
 const testDb = openDb(':memory:');
 vi.mock('@/lib/db-instance', () => ({ db: testDb }));
@@ -9,7 +11,7 @@ vi.mock('@/lib/db-instance', () => ({ db: testDb }));
 const { POST } = await import('./route');
 
 beforeEach(() => {
-  testDb.exec('DELETE FROM time_logs; DELETE FROM items;');
+  testDb.exec('DELETE FROM time_logs; DELETE FROM plan_items; DELETE FROM items;');
 });
 
 function createItem(title: string) {
@@ -56,5 +58,27 @@ describe('POST /api/items/:id/start', () => {
     await POST(new Request('http://localhost', { method: 'POST' }), { params: Promise.resolve({ id: String(second.id) }) });
 
     expect(getRunningTimer(testDb)?.itemId).toBe(second.id);
+  });
+
+  it("moves a today-pinned item to the top of today's plan order when started", async () => {
+    const first = createItem('First');
+    const second = createItem('Second');
+    const today = localDateString(new Date());
+    setTodayDate(testDb, first.id, today);
+    setTodayDate(testDb, second.id, today);
+    addPlanItem(testDb, today, first.id);
+    addPlanItem(testDb, today, second.id);
+
+    await POST(new Request('http://localhost', { method: 'POST' }), { params: Promise.resolve({ id: String(second.id) }) });
+
+    expect(getPlanItems(testDb, today).map((pi) => pi.itemId)).toEqual([second.id, first.id]);
+  });
+
+  it("leaves today's plan order untouched when starting an item that isn't on today's plan", async () => {
+    const item = createItem('Not pinned');
+
+    await POST(new Request('http://localhost', { method: 'POST' }), { params: Promise.resolve({ id: String(item.id) }) });
+
+    expect(getPlanItems(testDb, localDateString(new Date()))).toEqual([]);
   });
 });

--- a/app/api/items/[id]/start/route.ts
+++ b/app/api/items/[id]/start/route.ts
@@ -2,12 +2,23 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { setStatus, getItemById } from '@/lib/items-repo';
 import { startTimer } from '@/lib/time-logs-repo';
+import { getPlanItems, reorderPlanItems } from '@/lib/plans-repo';
+import { localDateString } from '@/lib/date';
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = await params;
   const id = Number(idParam);
   const body = (await request.json().catch(() => ({}))) as { withTimer?: boolean };
   setStatus(db, id, 'in_progress');
+  // If this item is on today's plan, starting it is also the moment it
+  // becomes "what I'm doing" -- move it to the top of Today's hand-picked
+  // order, persistently, so that's still true if it's later paused.
+  const today = localDateString(new Date());
+  const todayPlanItems = getPlanItems(db, today);
+  if (todayPlanItems.some((pi) => pi.itemId === id)) {
+    const orderedIds = [id, ...todayPlanItems.filter((pi) => pi.itemId !== id).map((pi) => pi.itemId)];
+    reorderPlanItems(db, today, orderedIds);
+  }
   // withTimer: false is used when a linked-item cascade also advances this
   // item's status -- the timer should stay on whichever item the user
   // actually clicked Start on, not silently move to the last linked item.

--- a/app/api/today/summary/route.test.ts
+++ b/app/api/today/summary/route.test.ts
@@ -17,7 +17,7 @@ describe('GET /api/today/summary', () => {
   it("returns today's plan with each done item carrying hoursLoggedToday", async () => {
     const item = createAdhocItem(testDb, { title: 'Test item' });
     testDb.prepare('UPDATE items SET today_date = ? WHERE id = ?').run(localDateString(new Date()), item.id);
-    setStatus(testDb, item.id, 'in_progress'); // clears today_date
+    setStatus(testDb, item.id, 'in_progress'); // today_date persists; excluded from `planned` via status !== 'done' instead
     setStatus(testDb, item.id, 'done', new Date().toISOString());
     testDb
       .prepare('INSERT INTO time_logs (item_id, started_at, ended_at, duration_hours) VALUES (?, ?, ?, ?)')

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -427,6 +427,8 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
             onComplete={handleComplete}
             onOpenClaude={handleOpenClaude}
             onDelete={handleDelete}
+            onPark={handlePark}
+            onUnpark={handleUnpark}
             onUnpinToday={handleUnpinToday}
             onPlanDay={() => setPlanDayOpen(true)}
             onReorder={handleReorderToday}

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -10,6 +10,7 @@ import {
   Undo2,
   Link2,
   Pause,
+  Play,
   MoreHorizontal,
   Pin,
   Star,
@@ -137,6 +138,11 @@ interface Props {
   onDone?: (id: number, done: boolean) => void;
   sourceIsStale?: boolean;
   onOpenScoringReference: () => void;
+  // Today shows a parked item at full detail (score chip, Complete button,
+  // overflow menu) instead of the stripped-down title-plus-Resume treatment
+  // In-progress's Paused sub-list uses -- it's the one place you're actively
+  // deciding what to resume next, not an ambient list to skim past.
+  fullDetailWhenParked?: boolean;
 }
 
 function actionableLinks(links: LinkedRef[] | undefined, targetStatus: Status): LinkedRef[] {
@@ -190,15 +196,17 @@ function HoverExtras({ item, keptVisible }: { item: Item & { links?: LinkedRef[]
 }
 
 // The quiet `⋯` overflow menu — contents depend on status, matching what
-// used to be always-visible buttons. Only ever mounted for non-parked rows;
-// parked rows get their own minimal "Resume" treatment instead (see the
-// `item.parked` branch in ItemRow), so this never needs an
-// in-progress-and-parked case. Pin/unpin lives here too, keeping the row's
-// action cluster to exactly one primary action plus this one menu.
+// used to be always-visible buttons. Normally only mounted for non-parked
+// rows; parked rows get their own minimal "Resume" treatment instead (see
+// the `item.parked` branch in ItemRow) -- except in Today, which shows the
+// full row (and this menu) even while parked, so the Park/Resume pair below
+// does need to branch on `item.parked`. Pin/unpin lives here too, keeping
+// the row's action cluster to exactly one primary action plus this one menu.
 function OverflowMenu({
   item,
   onRequeue,
   onPark,
+  onUnpark,
   onOpenClaude,
   onDelete,
   onPinToday,
@@ -213,6 +221,7 @@ function OverflowMenu({
   item: Item;
   onRequeue?: (id: number) => void;
   onPark?: (id: number) => void;
+  onUnpark?: (id: number) => void;
   onOpenClaude: () => void;
   onDelete?: () => void;
   onPinToday?: (id: number) => void;
@@ -282,9 +291,14 @@ function OverflowMenu({
             <Undo2 aria-hidden="true" /> Back to queue
           </DropdownMenuItem>
         )}
-        {item.status === 'in_progress' && onPark && (
+        {item.status === 'in_progress' && !item.parked && onPark && (
           <DropdownMenuItem onSelect={() => onPark(item.id)}>
             <Pause aria-hidden="true" /> Park
+          </DropdownMenuItem>
+        )}
+        {item.status === 'in_progress' && item.parked && onUnpark && (
+          <DropdownMenuItem onSelect={() => onUnpark(item.id)}>
+            <Play aria-hidden="true" /> Resume
           </DropdownMenuItem>
         )}
         <DropdownMenuItem onSelect={onOpenClaude}>
@@ -341,6 +355,7 @@ export default function ItemRow({
   onDone,
   sourceIsStale,
   onOpenScoringReference,
+  fullDetailWhenParked = false,
 }: Props) {
   const Icon = SOURCE_ICON[item.source];
   const { query } = useSearch();
@@ -671,8 +686,10 @@ export default function ItemRow({
 
   // Parked rows deliberately cost as little visual attention as possible: no
   // icon, no badge, no priority dot, no primary action, no overflow menu —
-  // just the title and a one-click way back in.
-  if (item.parked) {
+  // just the title and a one-click way back in. Today opts out via
+  // fullDetailWhenParked since it's the one place you're actively deciding
+  // what to resume, not an ambient list to skim past.
+  if (item.parked && !fullDetailWhenParked) {
     return (
       <div
         className={cn(
@@ -719,6 +736,8 @@ export default function ItemRow({
   const rowLabel = [
     item.title,
     isTracking ? 'currently tracking time' : null,
+    item.parked ? 'paused' : null,
+    item.status === 'done' ? 'done' : null,
     `${TIER_LABEL[getPriorityTier(item.score)]} priority`,
     `score ${item.score} of ${MAX_SCORE}`,
     inlineBadge?.label,
@@ -740,7 +759,7 @@ export default function ItemRow({
         'border-l-2 border-l-transparent focus:border-l-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
         SM_ROW_HEIGHT_CLASS[density],
         'motion-safe:transition-opacity motion-safe:duration-200 motion-safe:ease-out',
-        !isMatch && 'opacity-40'
+        !isMatch ? 'opacity-40' : item.status === 'done' && 'opacity-60'
       )}
     >
       <div className="flex w-full min-w-0 items-center gap-3 sm:w-auto">
@@ -765,18 +784,29 @@ export default function ItemRow({
                 title="Currently tracking time"
               />
             )}
+            {item.parked && (
+              <span title="Paused">
+                <Pause className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+              </span>
+            )}
             {item.url ? (
               <a
                 href={item.url}
                 target="_blank"
                 rel="noreferrer"
-                className="min-w-0 truncate font-medium hover:underline"
+                className={cn(
+                  'min-w-0 truncate font-medium hover:underline',
+                  item.status === 'done' && 'line-through'
+                )}
                 title={item.title}
               >
                 {renderTitle(item.title, query)}
               </a>
             ) : (
-              <span className="min-w-0 truncate font-medium" title={item.title}>
+              <span
+                className={cn('min-w-0 truncate font-medium', item.status === 'done' && 'line-through')}
+                title={item.title}
+              >
                 {renderTitle(item.title, query)}
               </span>
             )}
@@ -836,6 +866,7 @@ export default function ItemRow({
           item={item}
           onRequeue={onRequeue}
           onPark={onPark}
+          onUnpark={onUnpark}
           onOpenClaude={handleOpenClaudeClick}
           onDelete={canDelete ? () => setDeleteOpen(true) : undefined}
           onPinToday={onPinToday}

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -17,6 +17,8 @@ interface Props {
   onComplete: (id: number, durationHours: number, note?: string) => void;
   onOpenClaude: (id: number, workingDir?: string) => void;
   onDelete?: (id: number) => void;
+  onPark?: (id: number) => void;
+  onUnpark?: (id: number) => void;
   onUnpinToday?: (id: number) => void;
   onPlanDay: () => void;
   onReorder: (orderedItemIds: number[]) => void;
@@ -41,6 +43,8 @@ export default function TodaySection({
   onComplete,
   onOpenClaude,
   onDelete,
+  onPark,
+  onUnpark,
   onUnpinToday,
   onPlanDay,
   onReorder,
@@ -112,9 +116,12 @@ export default function TodaySection({
                     onComplete={onComplete}
                     onOpenClaude={onOpenClaude}
                     onDelete={onDelete}
+                    onPark={onPark}
+                    onUnpark={onUnpark}
                     onUnpinToday={onUnpinToday}
                     sourceIsStale={failingSources?.has(item.source)}
                     onOpenScoringReference={onOpenScoringReference}
+                    fullDetailWhenParked
                   />
                 </div>
                 {item.estimateMinutes !== null && (

--- a/lib/dashboard.test.ts
+++ b/lib/dashboard.test.ts
@@ -138,12 +138,20 @@ describe('getGroupedItems today bucket', () => {
     expect(grouped.signals.map((i) => i.id)).toEqual([item.id]);
   });
 
-  it('never puts an in-progress item in the today bucket even if today_date is still set', () => {
+  it('shows a started, today-pinned item in both Today and In-progress at once', () => {
     const item = createAdhocItem(db, { title: 'Test' });
     setTodayDate(db, item.id, '2026-08-13');
-    // Bypass setStatus's own auto-clear to simulate a stale write reaching
-    // this state some other way -- belt-and-suspenders on top of Task 4.
-    db.prepare("UPDATE items SET status = 'in_progress' WHERE id = ?").run(item.id);
+    setStatus(db, item.id, 'in_progress');
+
+    const now = new Date(2026, 7, 13, 9, 0);
+    const grouped = getGroupedItems(db, now);
+    expect(grouped.today.map((i) => i.id)).toEqual([item.id]);
+    expect(grouped.inProgress.map((i) => i.id)).toEqual([item.id]);
+  });
+
+  it('never puts an in-progress item that was not pinned to today in the today bucket', () => {
+    const item = createAdhocItem(db, { title: 'Test' });
+    setStatus(db, item.id, 'in_progress');
 
     const now = new Date(2026, 7, 13, 9, 0);
     const grouped = getGroupedItems(db, now);
@@ -151,7 +159,7 @@ describe('getGroupedItems today bucket', () => {
     expect(grouped.inProgress.map((i) => i.id)).toEqual([item.id]);
   });
 
-  it('keeps a started item\'s estimate counted in todayPlannedMinutes even though it leaves the today bucket', () => {
+  it('keeps a started item\'s estimate counted in todayPlannedMinutes, and the item itself in the today bucket', () => {
     const today = '2026-08-13';
     const item = createAdhocItem(db, { title: 'Test' });
     setTodayDate(db, item.id, today);
@@ -164,11 +172,11 @@ describe('getGroupedItems today bucket', () => {
 
     setStatus(db, item.id, 'in_progress');
     grouped = getGroupedItems(db, now);
-    expect(grouped.today.map((i) => i.id)).toEqual([]);
+    expect(grouped.today.map((i) => i.id)).toEqual([item.id]);
     expect(grouped.todayPlannedMinutes).toBe(60);
   });
 
-  it('counts hours logged on a completed item toward todayLoggedMinutes even though it leaves the today bucket', () => {
+  it('counts hours logged on a completed item toward todayLoggedMinutes, and keeps it visible (done) in the today bucket', () => {
     const today = '2026-08-13';
     const item = createAdhocItem(db, { title: 'Test' });
     setTodayDate(db, item.id, today);
@@ -187,7 +195,8 @@ describe('getGroupedItems today bucket', () => {
     setStatus(db, item.id, 'done', now.toISOString());
 
     const grouped = getGroupedItems(db, now);
-    expect(grouped.today.map((i) => i.id)).toEqual([]);
+    expect(grouped.today.map((i) => i.id)).toEqual([item.id]);
+    expect(grouped.today[0].status).toBe('done');
     expect(grouped.todayLoggedMinutes).toBe(30);
   });
 });
@@ -255,7 +264,7 @@ describe('getTodaySummary', () => {
       repo: null,
     });
     setTodayDate(db, finishedViaToday.id, '2026-08-13');
-    setStatus(db, finishedViaToday.id, 'in_progress'); // clears today_date, as expected
+    setStatus(db, finishedViaToday.id, 'in_progress'); // today_date persists; excluded from `planned` via status !== 'done' instead
     setStatus(db, finishedViaToday.id, 'done', '2026-08-13T15:00:00.000Z');
 
     const finishedWithoutEverBeingPinned = upsertSyncedItem(db, {

--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -44,15 +44,16 @@ export function getGroupedItems(db: Database.Database, now: Date): GroupedItems 
     loggedMinutesToday: Math.round((loggedTodayByItemId.get(item.id) ?? 0) * 60),
   }));
 
-  // Today is checked before Signals so pinning an item is a move out of its
-  // score bucket, not a copy -- an item never appears in two sections at
-  // once. Requiring status === 'inbox' here is belt-and-suspenders on top of
-  // setStatus's own auto-clear: an in-progress item never shows up in Today
-  // even if today_date somehow survived. Today is ordered by plan_items'
-  // sort_order rather than score -- it's a hand-ordered list once chosen,
-  // not a re-derivation of the ranking that put it there.
+  // Today tracks plan membership (today_date), not status -- a planned item
+  // stays visible here through Start/Pause/Complete instead of disappearing
+  // into In-progress with no trace, so it can now legitimately appear in
+  // both Today and In-progress at once. Signals stays exclusive of Today:
+  // an item pinned to today's plan is a move out of Signals, not a copy.
+  // Today is ordered by plan_items' sort_order rather than score -- it's a
+  // hand-ordered list once chosen, not a re-derivation of the ranking that
+  // put it there.
   const today = scored
-    .filter((i) => i.status === 'inbox' && i.todayDate === todayStr)
+    .filter((i) => i.todayDate === todayStr)
     .sort((a, b) => (sortOrderByItemId.get(a.id) ?? Infinity) - (sortOrderByItemId.get(b.id) ?? Infinity));
   const todayIds = new Set(today.map((i) => i.id));
 

--- a/lib/items-repo.test.ts
+++ b/lib/items-repo.test.ts
@@ -528,11 +528,11 @@ describe('setTriageState', () => {
 });
 
 describe('setStatus today_date interaction', () => {
-  it('clears an existing today_date when starting an item', () => {
+  it('leaves today_date untouched when starting an item pinned to today', () => {
     const item = createAdhocItem(db, { title: 'Test' });
     setTodayDate(db, item.id, '2026-08-13');
     setStatus(db, item.id, 'in_progress');
-    expect(getItemById(db, item.id)?.todayDate).toBeNull();
+    expect(getItemById(db, item.id)?.todayDate).toBe('2026-08-13');
   });
 
   it('leaves today_date untouched when completing an item directly (never started)', () => {
@@ -556,7 +556,7 @@ describe('setStatus today_date interaction', () => {
     setTodayDate(db, item.id, '2026-08-13');
     setStatus(db, item.id, 'in_progress');
     expect(getItemById(db, item.id)?.parked).toBe(false);
-    expect(getItemById(db, item.id)?.todayDate).toBeNull();
+    expect(getItemById(db, item.id)?.todayDate).toBe('2026-08-13');
   });
 });
 

--- a/lib/items-repo.ts
+++ b/lib/items-repo.ts
@@ -105,17 +105,10 @@ export function getItemById(db: Database.Database, id: number): Item | undefined
 }
 
 export function setStatus(db: Database.Database, id: number, status: Status, completedAt: string | null = null): void {
-  if (status === 'in_progress') {
-    // "In progress" already means "this is what I'm doing right now" -- Today
-    // doesn't need to keep saying the same thing once an item gets here, and
-    // without this an item could show up in both sections at once.
-    db.prepare('UPDATE items SET status = ?, completed_at = ?, parked = 0, today_date = NULL WHERE id = ?').run(
-      status,
-      completedAt,
-      id
-    );
-    return;
-  }
+  // today_date is deliberately untouched here -- Today now tracks plan_items
+  // membership across a status change instead of dropping it, so a planned
+  // item stays visible in Today through Start/Pause/Complete (see
+  // getGroupedItems in lib/dashboard.ts).
   db.prepare('UPDATE items SET status = ?, completed_at = ?, parked = 0 WHERE id = ?').run(status, completedAt, id);
 }
 


### PR DESCRIPTION
## Summary
- Today now tracks plan membership (`today_date`) instead of excluding by status, so a planned item stays visible through Start, Pause, and Complete instead of vanishing into In-progress with no trace.
- Starting a today-pinned item moves it to the top of Today's hand-ordered list.
- Today shows parked items at full detail (score, actions, overflow menu with Resume) instead of the minimal title-only treatment used elsewhere.

## Test plan
- [x] `npx vitest run` — 395 passed
- [x] `npx tsc --noEmit` — clean