### PR TITLE
feat(today): drag to reorder Today and step 3 of Plan the day

### DIFF
--- a/components/PlanDayDialog.tsx
+++ b/components/PlanDayDialog.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import ScoreChip from './ScoreChip';
+import SortableRows from './SortableRows';
 import { GROUP_ORDER, GROUP_LABEL, groupOf } from '@/lib/grouping';
 import { formatCalibrationSentence, type CalibrationEntry } from '@/lib/calibration';
 import type { ScoredItem } from '@/lib/dashboard';
@@ -27,7 +28,7 @@ interface Props {
   onDrop: (id: number) => void;
   onAdd: (id: number) => void;
   onSetEstimate: (id: number, minutes: number | null) => void;
-  onReorder: (orderedIds: number[]) => void;
+  onReorder: (orderedIds: number[]) => void | Promise<void>;
   onSetCapacity: (minutes: number) => void;
   calibration: CalibrationEntry[];
   onOpenScoringReference: () => void;
@@ -178,21 +179,27 @@ export default function PlanDayDialog({
 
         {step === 3 && (
           <div className="flex min-h-0 flex-1 flex-col gap-3">
-            <p className="shrink-0 text-sm text-muted-foreground">
-              Optional. Drag to reorder, or use the arrows in Today.
-            </p>
+            <p className="shrink-0 text-sm text-muted-foreground">Optional. Drag to reorder.</p>
             <div className="min-h-0 flex-1 space-y-2 overflow-y-auto">
-              {today.map((item) => (
-                <div key={item.id} className="flex items-center justify-between gap-2 border-b pb-2 text-sm">
-                  <span className="min-w-0 truncate">{item.title}</span>
-                  <Input
-                    defaultValue={item.estimateMinutes ? formatMinutes(item.estimateMinutes) : ''}
-                    placeholder="e.g. 1h 30m"
-                    className="h-8 w-28 text-right font-mono text-sm"
-                    onBlur={(e) => onSetEstimate(item.id, parseDurationInput(e.target.value))}
-                  />
-                </div>
-              ))}
+              <SortableRows
+                items={today}
+                labelOf={(item) => item.title}
+                onReorder={onReorder}
+                className="space-y-2"
+                rowClassName="flex items-center gap-2 border-b pb-2 text-sm"
+              >
+                {(item) => (
+                  <>
+                    <span className="min-w-0 flex-1 truncate">{item.title}</span>
+                    <Input
+                      defaultValue={item.estimateMinutes ? formatMinutes(item.estimateMinutes) : ''}
+                      placeholder="e.g. 1h 30m"
+                      className="h-8 w-28 shrink-0 text-right font-mono text-sm"
+                      onBlur={(e) => onSetEstimate(item.id, parseDurationInput(e.target.value))}
+                    />
+                  </>
+                )}
+              </SortableRows>
               {calibration.map((entry) => {
                 const sentence = formatCalibrationSentence(entry);
                 return sentence ? (

--- a/components/SortableRows.tsx
+++ b/components/SortableRows.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type Announcements,
+  type DragEndEvent,
+  type UniqueIdentifier,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Props<T extends { id: number }> {
+  items: T[];
+  // Used for the grip's accessible name and the screen-reader announcements,
+  // so a keyboard drag says "Picked up Fix the auth loop" rather than an id.
+  labelOf: (item: T) => string;
+  onReorder: (orderedIds: number[]) => void | Promise<void>;
+  className?: string;
+  rowClassName?: string;
+  children: (item: T) => ReactNode;
+}
+
+function sameSet(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(b);
+  return a.every((id) => set.has(id));
+}
+
+export default function SortableRows<T extends { id: number }>({
+  items,
+  labelOf,
+  onReorder,
+  className,
+  rowClassName,
+  children,
+}: Props<T>) {
+  // The order the caller is about to persist. Reordering round-trips through
+  // the API and a full refresh, so without this the dropped row snaps back to
+  // where it came from for as long as that takes. Cleared once the caller's
+  // handler resolves, by which point props carry the new order.
+  const [pendingOrder, setPendingOrder] = useState<number[] | null>(null);
+
+  const ids = items.map((item) => item.id);
+  // A pending order that no longer covers the same items is stale -- something
+  // was pinned or unpinned while the reorder was in flight. Props win.
+  const order = pendingOrder && sameSet(pendingOrder, ids) ? pendingOrder : ids;
+  const byId = new Map(items.map((item) => [item.id, item]));
+  const ordered = order.map((id) => byId.get(id)).filter((item): item is T => item !== undefined);
+
+  const sensors = useSensors(
+    // A few pixels of travel before a drag starts, so clicking the grip (or a
+    // control next to it) never registers as a reorder.
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function describe(id: UniqueIdentifier): string {
+    const item = byId.get(Number(id));
+    return item ? labelOf(item) : 'item';
+  }
+
+  function positionOf(id: UniqueIdentifier): string {
+    return `position ${order.indexOf(Number(id)) + 1} of ${order.length}`;
+  }
+
+  const announcements: Announcements = {
+    onDragStart: ({ active }) => `Picked up ${describe(active.id)}, ${positionOf(active.id)}.`,
+    // dnd-kit fires a drag-over against the lifted row itself the moment it is
+    // picked up. Announcing that would talk over "Picked up ..." with a
+    // position that has not changed, so only real moves are announced.
+    onDragOver: ({ active, over }) =>
+      over && over.id !== active.id ? `${describe(active.id)} moved to ${positionOf(over.id)}.` : undefined,
+    onDragEnd: ({ active, over }) =>
+      over
+        ? `${describe(active.id)} dropped at ${positionOf(over.id)}.`
+        : `${describe(active.id)} dropped.`,
+    onDragCancel: ({ active }) =>
+      `Reordering cancelled. ${describe(active.id)} returned to ${positionOf(active.id)}.`,
+  };
+
+  async function handleDragEnd({ active, over }: DragEndEvent) {
+    if (!over || active.id === over.id) return;
+    const from = order.indexOf(Number(active.id));
+    const to = order.indexOf(Number(over.id));
+    if (from === -1 || to === -1) return;
+    const next = arrayMove(order, from, to);
+    setPendingOrder(next);
+    try {
+      await onReorder(next);
+    } finally {
+      setPendingOrder(null);
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+      accessibility={{ announcements }}
+    >
+      <SortableContext items={order} strategy={verticalListSortingStrategy}>
+        <div className={className}>
+          {ordered.map((item) => (
+            <SortableRow key={item.id} id={item.id} label={labelOf(item)} className={rowClassName}>
+              {children(item)}
+            </SortableRow>
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+interface RowProps {
+  id: number;
+  label: string;
+  className?: string;
+  children: ReactNode;
+}
+
+function SortableRow({ id, label, className, children }: RowProps) {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } =
+    useSortable({ id });
+
+  const style = {
+    // Vertical only -- zeroing x is cheaper than pulling in @dnd-kit/modifiers
+    // for a single axis restriction.
+    transform: transform ? CSS.Translate.toString({ ...transform, x: 0 }) : undefined,
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(className, isDragging && 'relative z-10 rounded-md bg-background shadow-lg')}
+    >
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        aria-label={`Reorder ${label}`}
+        className={cn(
+          'shrink-0 cursor-grab touch-none rounded text-muted-foreground',
+          'hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+          isDragging && 'cursor-grabbing text-foreground',
+        )}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      {children}
+    </div>
+  );
+}

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useState } from 'react';
-import { ChevronUp, ChevronDown } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import ItemRow from './ItemRow';
+import SortableRows from './SortableRows';
 import type { ScoredItem } from '@/lib/dashboard';
 import type { Item } from '@/lib/types';
 
@@ -21,7 +20,7 @@ interface Props {
   onUnpark?: (id: number) => void;
   onUnpinToday?: (id: number) => void;
   onPlanDay: () => void;
-  onReorder: (orderedItemIds: number[]) => void;
+  onReorder: (orderedItemIds: number[]) => void | Promise<void>;
   failingSources?: Set<Item['source']>;
   onOpenScoringReference: () => void;
 }
@@ -51,15 +50,6 @@ export default function TodaySection({
   failingSources,
   onOpenScoringReference,
 }: Props) {
-  function move(id: number, direction: -1 | 1) {
-    const order = items.map((i) => i.id);
-    const index = order.indexOf(id);
-    const swapWith = index + direction;
-    if (swapWith < 0 || swapWith >= order.length) return;
-    [order[index], order[swapWith]] = [order[swapWith], order[index]];
-    onReorder(order);
-  }
-
   return (
     <Card className="border-l-2 border-l-[hsl(var(--brand-gold))]">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 p-4">
@@ -86,29 +76,14 @@ export default function TodaySection({
             </p>
           </div>
         ) : (
-          <div>
-            {items.map((item, index) => (
-              <div key={item.id} className="flex items-center gap-1">
-                <div className="flex shrink-0 flex-col">
-                  <button
-                    type="button"
-                    aria-label={`Move ${item.title} up`}
-                    disabled={index === 0}
-                    onClick={() => move(item.id, -1)}
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-30"
-                  >
-                    <ChevronUp className="h-3 w-3" />
-                  </button>
-                  <button
-                    type="button"
-                    aria-label={`Move ${item.title} down`}
-                    disabled={index === items.length - 1}
-                    onClick={() => move(item.id, 1)}
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-30"
-                  >
-                    <ChevronDown className="h-3 w-3" />
-                  </button>
-                </div>
+          <SortableRows
+            items={items}
+            labelOf={(item) => item.title}
+            onReorder={onReorder}
+            rowClassName="flex items-center gap-1"
+          >
+            {(item) => (
+              <>
                 <div className="min-w-0 flex-1">
                   <ItemRow
                     item={item}
@@ -131,9 +106,9 @@ export default function TodaySection({
                       : formatMinutes(item.estimateMinutes)}
                   </span>
                 )}
-              </div>
-            ))}
-          </div>
+              </>
+            )}
+          </SortableRows>
         )}
       </CardContent>
     </Card>

--- a/e2e/today-reorder.spec.ts
+++ b/e2e/today-reorder.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import { createItem } from './helpers';
+
+// The grip's accessible name is "Reorder <title>", so the handles alone give
+// us Today's order without depending on row internals. Other specs may leave
+// their own items pinned, so keep only the ones this test created.
+async function gripOrder(scope: Page | Locator, titles: string[]): Promise<string[]> {
+  const labels = await scope
+    .locator('button[aria-label^="Reorder "]')
+    .evaluateAll((els) => els.map((el) => el.getAttribute('aria-label') ?? ''));
+  return labels.map((label) => label.replace('Reorder ', '')).filter((title) => titles.includes(title));
+}
+
+async function pinTwoItems(request: Parameters<typeof createItem>[0], stamp: number) {
+  const titles = [`Reorder first ${stamp}`, `Reorder second ${stamp}`];
+  for (const title of titles) {
+    const itemId = await createItem(request, title);
+    // The same path the 't' pin uses: sets today_date and adds the plan item.
+    await request.post(`/api/items/${itemId}/today`, { data: {} });
+  }
+  return titles;
+}
+
+// Positions are asserted by shape, not value: every test in this file leaves
+// its items pinned, so Today's length depends on what ran before.
+function pickedUp(title: string): RegExp {
+  return new RegExp(`Picked up ${title}, position \\d+ of \\d+\\.`);
+}
+
+function movedTo(title: string): RegExp {
+  return new RegExp(`${title} moved to position \\d+ of \\d+\\.`);
+}
+
+function reorderResponse(page: Page) {
+  return page.waitForResponse(
+    (res) => res.url().includes('/api/plan/items/reorder') && res.request().method() === 'PUT'
+  );
+}
+
+test('a Today row can be reordered by keyboard and the new order persists', async ({ page, request }) => {
+  const [first, second] = await pinTwoItems(request, Date.now());
+
+  await page.goto('/');
+  await expect.poll(() => gripOrder(page, [first, second])).toEqual([first, second]);
+
+  // Focus the grip, lift, move down one, drop. Each step waits for the drag
+  // state to settle -- keys sent back-to-back outrun the sensor -- which also
+  // asserts the announcements a screen reader would hear.
+  const live = page.locator('[role="status"][aria-live]');
+  const grip = page.getByRole('button', { name: `Reorder ${first}` });
+  const persisted = reorderResponse(page);
+  await grip.focus();
+  await page.keyboard.press('Space');
+  await expect(grip).toHaveAttribute('aria-pressed', 'true');
+  await expect(live).toContainText(pickedUp(first));
+  await page.keyboard.press('ArrowDown');
+  await expect(live).toContainText(movedTo(first));
+  await page.keyboard.press('Space');
+  expect((await persisted).status()).toBe(200);
+
+  await expect.poll(() => gripOrder(page, [first, second])).toEqual([second, first]);
+
+  // The order is server state, not just local component state.
+  await page.reload();
+  await expect.poll(() => gripOrder(page, [first, second])).toEqual([second, first]);
+
+  // Escape abandons a drag without reordering.
+  await page.getByRole('button', { name: `Reorder ${second}` }).focus();
+  await page.keyboard.press('Space');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Escape');
+  await expect.poll(() => gripOrder(page, [first, second])).toEqual([second, first]);
+});
+
+test('a Today row can be dragged with the mouse', async ({ page, request }) => {
+  const [first, second] = await pinTwoItems(request, Date.now() + 1);
+
+  await page.goto('/');
+  await expect.poll(() => gripOrder(page, [first, second])).toEqual([first, second]);
+
+  const from = await page.getByRole('button', { name: `Reorder ${first}` }).boundingBox();
+  const to = await page.getByRole('button', { name: `Reorder ${second}` }).boundingBox();
+  if (!from || !to) throw new Error('grip handles are not visible');
+
+  const persisted = reorderResponse(page);
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+  await page.mouse.down();
+  // Clear the 4px activation distance first, then travel past the next row's
+  // midpoint so closestCenter picks it as the drop target.
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2 + 10, { steps: 5 });
+  await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2 + 5, { steps: 10 });
+  await page.mouse.up();
+  expect((await persisted).status()).toBe(200);
+
+  await expect.poll(() => gripOrder(page, [first, second])).toEqual([second, first]);
+});
+
+test('step 3 of Plan the day reorders the same list Today shows', async ({ page, request }) => {
+  const [first, second] = await pinTwoItems(request, Date.now() + 2);
+
+  await page.goto('/');
+  await expect.poll(() => gripOrder(page, [first, second])).toEqual([first, second]);
+
+  await page.keyboard.press('p');
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toContainText('step 1 of 4');
+  await dialog.getByRole('button', { name: 'Next' }).click();
+  await dialog.getByRole('button', { name: 'Next' }).click();
+  await expect(dialog).toContainText('step 3 of 4');
+  await expect.poll(() => gripOrder(dialog, [first, second])).toEqual([first, second]);
+
+  const live = dialog.locator('[role="status"][aria-live]');
+  const grip = dialog.getByRole('button', { name: `Reorder ${first}` });
+  const persisted = reorderResponse(page);
+  await grip.focus();
+  await page.keyboard.press('Space');
+  await expect(grip).toHaveAttribute('aria-pressed', 'true');
+  await expect(live).toContainText(pickedUp(first));
+  await page.keyboard.press('ArrowDown');
+  await expect(live).toContainText(movedTo(first));
+  await page.keyboard.press('Space');
+  expect((await persisted).status()).toBe(200);
+
+  await expect.poll(() => gripOrder(dialog, [first, second])).toEqual([second, first]);
+
+  // Closing the dialog, Today shows the order chosen in the ritual -- one list,
+  // not two.
+  await page.keyboard.press('Escape');
+  await expect(dialog).toHaveCount(0);
+  await expect.poll(() => gripOrder(page, [first, second])).toEqual([second, first]);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.4.0",
         "@radix-ui/react-accordion": "^1.2.15",
         "@radix-ui/react-dialog": "^1.1.18",
@@ -158,6 +161,59 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.4.0",
     "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-dialog": "^1.1.18",


### PR DESCRIPTION
## What

Step 3 of Plan the day already told you to "drag to reorder" and nothing happened. The only real way to change the order was the pair of chevrons in Today. Both lists are now sortable, through one shared `SortableRows` component, so reordering works the same way wherever the plan is shown.

## The grip replaces Today's chevrons

dnd-kit's keyboard sensor covers what the arrows were there for — focus the grip, `Space` to lift, `↑`/`↓` to move, `Space` to drop, `Escape` to cancel — and the announcements name the item ("Picked up Fix the auth redirect loop, position 1 of 3"), so the row loses two controls without losing a keyboard path.

## Notes

- **Optimistic order.** A reorder round-trips through `PUT /api/plan/items/reorder` and a full dashboard refresh. Without rendering the new order immediately, the dropped row visibly snaps back to where it came from until the refresh lands.
- **Vertical only**, by zeroing `transform.x` rather than pulling in `@dnd-kit/modifiers` for a single-axis restriction.
- **4px activation distance**, so clicking the grip — or the controls beside it — never registers as a reorder.
- **New dependency:** `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`. `npm audit --omit=dev` is clean.
- No backend changes. The reorder endpoint and `handleReorderToday` already existed.

## Testing

New `e2e/today-reorder.spec.ts` covers three paths: keyboard drag with persistence across a reload, mouse drag, and reordering in step 3 of the dialog then confirming Today shows the same order after the dialog closes. The `Escape`-cancels case is asserted too.

Full suite locally on Node 22: 395 unit tests, 12 e2e, `tsc --noEmit`, and `next build` all pass.