### PR TITLE
feat(signals): flag items already closed at the source and offer Complete

### DIFF
--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -50,6 +50,7 @@ import { useDensity } from '@/components/DensityProvider';
 import { useRunningTimer } from '@/components/RunningTimerProvider';
 import type { Density } from '@/lib/config';
 import ScoreChip from './ScoreChip';
+import { settledOutcome } from '@/lib/settled';
 import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
 
 // Row height is fixed per mode so content can never reflow it — comfortable
@@ -98,7 +99,13 @@ function getInlineBadge(
 ): { label: string; variant: BadgeVariant | ReasonVariant } | null {
   if (keptVisible) return { label: 'Kept visible', variant: 'outline' };
   const statusPill = getStatusPill(item);
-  if (statusPill) return statusPill;
+  // One green per row. On a settled row the check chip already carries the
+  // affirmative colour, so an ADO "Done" pill next to it would say the same
+  // thing twice in the same hue. The pill keeps the state's actual wording
+  // (which the check can't carry) and gives up the fill.
+  if (statusPill) {
+    return settledOutcome(item) ? { ...statusPill, variant: 'outline' } : statusPill;
+  }
   return getReasonPills(item)[0] ?? null;
 }
 
@@ -204,6 +211,7 @@ function HoverExtras({ item, keptVisible }: { item: Item & { links?: LinkedRef[]
 // the row's action cluster to exactly one primary action plus this one menu.
 function OverflowMenu({
   item,
+  onStart,
   onRequeue,
   onPark,
   onUnpark,
@@ -219,6 +227,7 @@ function OverflowMenu({
   density,
 }: {
   item: Item;
+  onStart?: () => void;
   onRequeue?: (id: number) => void;
   onPark?: (id: number) => void;
   onUnpark?: (id: number) => void;
@@ -248,6 +257,14 @@ function OverflowMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {/* Only mounted for a settled row, whose primary button is Complete.
+            Starting it is still legitimate (a merged PR can need follow-up
+            work), just not the obvious thing, so it moves in here. */}
+        {onStart && (
+          <DropdownMenuItem onSelect={onStart}>
+            <Play aria-hidden="true" /> Start anyway
+          </DropdownMenuItem>
+        )}
         {onStar && (
           <DropdownMenuItem onSelect={() => onStar(item.id, !item.starred)}>
             <Star aria-hidden="true" className={item.starred ? 'fill-current' : undefined} />
@@ -377,6 +394,13 @@ export default function ItemRow({
   const [pendingComplete, setPendingComplete] = useState<{ hours: number; note?: string } | null>(null);
   const canDelete = item.source === 'adhoc' && Boolean(onDelete);
 
+  // The source system has closed this item but Ariadne, being read-only, has
+  // not. A settled row keeps its place and its full-strength text -- the chip
+  // carries the state -- and swaps its primary action from Start to Complete,
+  // because starting work that is already finished is never what you meant.
+  const settled = settledOutcome(item);
+  const canComplete = item.status === 'in_progress' || (item.status === 'inbox' && Boolean(settled));
+
   const parsedHours = Number(hours);
   const hoursValid = hours.trim() !== '' && Number.isFinite(parsedHours) && parsedHours >= 0;
   const pendingStartLinks = (item.links ?? []).filter((link) => link.itemId !== null && link.status === 'inbox');
@@ -458,6 +482,9 @@ export default function ItemRow({
         return;
       case 'x':
         setChipOpen(true);
+        return;
+      case 'c':
+        if (canComplete) setOpen(true);
         return;
       case 's':
         onStar?.(item.id, !item.starred);
@@ -726,6 +753,7 @@ export default function ItemRow({
   // row without, say, onStar never claims 's' works on it.
   const rowShortcuts = [
     item.url ? 'o' : null,
+    canComplete ? 'c' : null,
     onStar ? 's' : null,
     onSnooze || onUnsnooze ? 'e' : null,
     onDone ? 'd' : null,
@@ -738,6 +766,8 @@ export default function ItemRow({
     isTracking ? 'currently tracking time' : null,
     item.parked ? 'paused' : null,
     item.status === 'done' ? 'done' : null,
+    settled === 'finished' ? 'done at the source' : null,
+    settled === 'gone' ? 'gone from the source' : null,
     `${TIER_LABEL[getPriorityTier(item.score)]} priority`,
     `score ${item.score} of ${MAX_SCORE}`,
     inlineBadge?.label,
@@ -768,6 +798,7 @@ export default function ItemRow({
           scoreBreakdown={item.scoreBreakdown ?? []}
           notFired={item.notFired ?? []}
           keptVisible={keptVisible}
+          settled={settled}
           open={chipOpen}
           onOpenChange={setChipOpen}
           onOpenScoringReference={onOpenScoringReference}
@@ -840,7 +871,7 @@ export default function ItemRow({
             ))}
           </span>
         )}
-        {item.status === 'inbox' && onStart && (
+        {item.status === 'inbox' && !settled && onStart && (
           <Button
             type="button"
             variant="outline"
@@ -851,7 +882,7 @@ export default function ItemRow({
             Start
           </Button>
         )}
-        {item.status === 'in_progress' && (
+        {canComplete && (
           <Button
             type="button"
             variant="outline"
@@ -864,6 +895,7 @@ export default function ItemRow({
         )}
         <OverflowMenu
           item={item}
+          onStart={item.status === 'inbox' && settled ? handleStartClick : undefined}
           onRequeue={onRequeue}
           onPark={onPark}
           onUnpark={onUnpark}

--- a/components/ScoreChip.tsx
+++ b/components/ScoreChip.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { useId } from 'react';
+import { Check, Minus } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { getPriorityTier, MAX_SCORE, TIER_LABEL, type PriorityTier, type ScoreBreakdownEntry } from '@/lib/scoring';
+import type { SettledOutcome } from '@/lib/settled';
 
 // Urgency bands per docs/wireframes/phase-0-foundation.html: only the top two
 // bands are filled, medium is an outline, low has no border at all -- visual
@@ -17,11 +19,41 @@ const TIER_CHIP_CLASS: Record<PriorityTier, string> = {
   critical: 'border-transparent bg-urgency-critical text-urgency-critical-foreground',
 };
 
+// A settled item's urgency band is history: the source system already closed
+// it, so the chip stops reporting a live reading and reports the outcome
+// instead. 'finished' is the one case the design system reserves Success Green
+// for -- "done, needs no action". 'gone' left your plate unfinished, so it gets
+// the neutral treatment rather than an affirmative green tick.
+const SETTLED_CHIP_CLASS: Record<SettledOutcome, string> = {
+  finished: 'border-transparent bg-success text-success-foreground',
+  gone: 'border border-urgency-low/40 bg-transparent text-muted-foreground',
+};
+
+const SETTLED_ICON: Record<SettledOutcome, typeof Check> = {
+  finished: Check,
+  gone: Minus,
+};
+
+const SETTLED_CHIP_LABEL: Record<SettledOutcome, string> = {
+  finished: 'Done at the source',
+  gone: 'Gone from the source',
+};
+
+// Leads the popover so the number underneath reads as history rather than a
+// live reading. The score stays fully inspectable either way -- a score that
+// exists must be explainable (PRODUCT.md), and this one still drives the row's
+// position in its group.
+const SETTLED_EXPLANATION: Record<SettledOutcome, string> = {
+  finished: 'Finished where it lives. Ariadne is read-only, so it still needs completing here.',
+  gone: 'No longer yours where it lives. Ariadne is read-only, so it still needs clearing here.',
+};
+
 interface Props {
   score: number;
   scoreBreakdown: ScoreBreakdownEntry[];
   notFired: string[];
   keptVisible: boolean;
+  settled?: SettledOutcome | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenScoringReference: () => void;
@@ -33,6 +65,7 @@ export default function ScoreChip({
   scoreBreakdown,
   notFired,
   keptVisible,
+  settled,
   open,
   onOpenChange,
   onOpenScoringReference,
@@ -40,6 +73,7 @@ export default function ScoreChip({
 }: Props) {
   const tier = getPriorityTier(score);
   const titleId = useId();
+  const SettledIcon = settled ? SETTLED_ICON[settled] : null;
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
@@ -49,9 +83,13 @@ export default function ScoreChip({
           className={cn(
             'inline-flex h-5 min-w-[1.5rem] shrink-0 items-center justify-center rounded px-1 font-mono text-[11px] font-semibold tabular-nums',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-            TIER_CHIP_CLASS[tier]
+            settled ? SETTLED_CHIP_CLASS[settled] : TIER_CHIP_CLASS[tier]
           )}
-          aria-label={`Urgency ${score} of ${MAX_SCORE}, show breakdown`}
+          aria-label={
+            settled
+              ? `${SETTLED_CHIP_LABEL[settled]}, urgency ${score} of ${MAX_SCORE}, show breakdown`
+              : `Urgency ${score} of ${MAX_SCORE}, show breakdown`
+          }
           onKeyDown={(e) => {
             if (e.key.toLowerCase() === 'x') {
               e.preventDefault();
@@ -59,15 +97,17 @@ export default function ScoreChip({
             }
           }}
         >
-          {score}
+          {SettledIcon ? <SettledIcon className="h-3 w-3" aria-hidden="true" /> : score}
         </button>
       </PopoverTrigger>
       <PopoverContent role="dialog" aria-labelledby={titleId} className="w-72">
         <div className="space-y-2 text-sm">
           <h2 id={titleId} className="font-medium">
-            Why {score}?
+            {settled ? SETTLED_CHIP_LABEL[settled] : `Why ${score}?`}
           </h2>
-          <div className="space-y-1 border-t pt-2">
+          {settled && <p className="text-xs text-muted-foreground">{SETTLED_EXPLANATION[settled]}</p>}
+          {settled && <p className="border-t pt-2 text-xs text-muted-foreground">It still scores {score}:</p>}
+          <div className={cn('space-y-1 pt-2', !settled && 'border-t')}>
             {scoreBreakdown.map((entry, i) => (
               <div key={i} className="flex items-center justify-between gap-3">
                 <span>{entry.label}</span>

--- a/e2e/seed-settled.ts
+++ b/e2e/seed-settled.ts
@@ -1,0 +1,76 @@
+import { openDb } from '../lib/db';
+import { upsertSyncedItem } from '../lib/items-repo';
+import { E2E_DB_PATH } from './db-path';
+
+// A merged PR and a Done work item only ever reach this state through a real
+// sync against GitHub/ADO, which e2e tests can't do. Seed them straight into
+// the sqlite file the dev server under test points at, the same way
+// seed-links.ts does.
+export function seedSettledPair(suffix: string): {
+  mergedPrId: number;
+  doneAdoId: number;
+  openPrId: number;
+  mergedPrTitle: string;
+  doneAdoTitle: string;
+  openPrTitle: string;
+} {
+  const db = openDb(E2E_DB_PATH);
+  try {
+    const base = `${Date.now()}${suffix}`;
+    const mergedPrTitle = `Merged PR ${suffix}`;
+    const doneAdoTitle = `Done work item ${suffix}`;
+    const openPrTitle = `Open PR ${suffix}`;
+
+    const mergedPr = upsertSyncedItem(db, {
+      source: 'github_pr',
+      externalId: `${base}@merged-pr`,
+      title: mergedPrTitle,
+      url: 'https://example.test/pr/merged',
+      reason: 'authored',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: new Date().toISOString(),
+      prStatus: 'merged',
+      repo: null,
+    });
+
+    const doneAdo = upsertSyncedItem(db, {
+      source: 'ado_workitem',
+      externalId: `${base}@done-ado`,
+      title: doneAdoTitle,
+      url: 'https://example.test/ado/done',
+      reason: 'assigned',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: new Date().toISOString(),
+      adoStatus: 'Done',
+      repo: null,
+    });
+
+    // The control: same shape, still open upstream, so the test can tell the
+    // settled treatment apart from "every row looks like this now".
+    const openPr = upsertSyncedItem(db, {
+      source: 'github_pr',
+      externalId: `${base}@open-pr`,
+      title: openPrTitle,
+      url: 'https://example.test/pr/open',
+      reason: 'authored',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: new Date().toISOString(),
+      prStatus: 'ready_for_review',
+      repo: null,
+    });
+
+    return {
+      mergedPrId: mergedPr.id,
+      doneAdoId: doneAdo.id,
+      openPrId: openPr.id,
+      mergedPrTitle,
+      doneAdoTitle,
+      openPrTitle,
+    };
+  } finally {
+    db.close();
+  }
+}

--- a/e2e/settled-upstream.spec.ts
+++ b/e2e/settled-upstream.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { ensureNoRunningTimer } from './helpers';
+import { seedSettledPair } from './seed-settled';
+
+test('items already closed at the source offer Complete instead of Start', async ({ page, request }) => {
+  await ensureNoRunningTimer(request);
+  const { mergedPrId, doneAdoId, openPrId } = seedSettledPair(String(Date.now()));
+
+  await page.goto('/');
+
+  const mergedRow = page.locator(`[data-row-id="${mergedPrId}"]`);
+  const doneRow = page.locator(`[data-row-id="${doneAdoId}"]`);
+  const openRow = page.locator(`[data-row-id="${openPrId}"]`);
+
+  // Both settled rows lead with Complete and hide Start behind the overflow
+  // menu; the still-open PR keeps the ordinary Start affordance.
+  await expect(mergedRow.getByRole('button', { name: 'Complete' })).toBeVisible();
+  await expect(mergedRow.getByRole('button', { name: 'Start', exact: true })).toHaveCount(0);
+  await expect(doneRow.getByRole('button', { name: 'Complete' })).toBeVisible();
+  await expect(openRow.getByRole('button', { name: 'Start', exact: true })).toBeVisible();
+  await expect(openRow.getByRole('button', { name: 'Complete' })).toHaveCount(0);
+
+  // The settled state is announced on the row itself, not just drawn.
+  await expect(mergedRow).toHaveAttribute('aria-label', /done at the source/);
+  await expect(openRow).not.toHaveAttribute('aria-label', /done at the source/);
+
+  // The chip still opens the breakdown, so the score stays inspectable.
+  await mergedRow.getByRole('button', { name: /done at the source/i }).click();
+  await expect(page.getByRole('dialog').getByText('Done at the source')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  // Completing from a settled row runs the ordinary Complete dialog and moves
+  // the item out of Signals.
+  await mergedRow.getByRole('button', { name: 'Complete' }).click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByText('Mark complete')).toBeVisible();
+  await dialog.getByLabel(/hours/i).fill('0');
+  await dialog.getByRole('button', { name: 'Complete' }).click();
+
+  await expect(page.locator(`[data-row-id="${mergedPrId}"]`)).toHaveCount(0);
+});

--- a/lib/keymap.test.ts
+++ b/lib/keymap.test.ts
@@ -16,6 +16,11 @@ describe('KEYMAP', () => {
     }
   });
 
+  it('declares the row-scoped complete binding wired up in ItemRow', () => {
+    const complete = KEYMAP.find((binding) => binding.keys === 'c');
+    expect(complete).toEqual({ keys: 'c', description: 'Complete the focused item', scope: 'row' });
+  });
+
   it('declares every binding with a row or global scope', () => {
     for (const binding of KEYMAP) {
       expect(['row', 'global']).toContain(binding.scope);

--- a/lib/keymap.ts
+++ b/lib/keymap.ts
@@ -8,7 +8,7 @@ export interface KeyBinding {
 // (KeymapHelpDialog) and the command palette's shortcut hints both render
 // straight from this array, so neither can drift from what's actually wired
 // up. `scope: 'row'` bindings act on whichever row currently has focus.
-// Most of them (enter/o, x, s, e, d, t) fire from that row's own bubbled
+// Most of them (enter/o, x, c, s, e, d, t) fire from that row's own bubbled
 // onKeyDown; j/k are the exception -- they navigate *between* rows, so they
 // fire from GlobalKeymapProvider's document-level listener instead, which
 // scans every `[data-row-id]` on the page (Today, In-progress, and Signals
@@ -26,6 +26,7 @@ export const KEYMAP: KeyBinding[] = [
   { keys: 'k', description: 'Move focus to the previous item', scope: 'row' },
   { keys: '↵ / o', description: 'Open upstream in a new tab', scope: 'row' },
   { keys: 'x', description: 'Show the score breakdown', scope: 'row' },
+  { keys: 'c', description: 'Complete the focused item', scope: 'row' },
   { keys: 's', description: 'Star (local only)', scope: 'row' },
   { keys: 'e', description: 'Snooze (local only)', scope: 'row' },
   { keys: 'd', description: 'Mark done (local only)', scope: 'row' },

--- a/lib/settled.test.ts
+++ b/lib/settled.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { settledOutcome } from './settled';
+
+describe('settledOutcome', () => {
+  it('returns null for adhoc items, which have no source system to settle in', () => {
+    expect(settledOutcome({ source: 'adhoc', prStatus: null, adoStatus: null })).toBeNull();
+  });
+
+  it('returns null when a github_pr item has no prStatus', () => {
+    expect(settledOutcome({ source: 'github_pr', prStatus: null, adoStatus: null })).toBeNull();
+  });
+
+  it('returns null when an ado_workitem has no adoStatus', () => {
+    expect(settledOutcome({ source: 'ado_workitem', prStatus: null, adoStatus: null })).toBeNull();
+  });
+
+  it('treats a merged pull request as finished', () => {
+    expect(settledOutcome({ source: 'github_pr', prStatus: 'merged', adoStatus: null })).toBe('finished');
+  });
+
+  it.each(['draft', 'ready_for_review', 'changes_requested', 'approved'] as const)(
+    'leaves an open pull request in prStatus %s unsettled',
+    (prStatus) => {
+      expect(settledOutcome({ source: 'github_pr', prStatus, adoStatus: null })).toBeNull();
+    }
+  );
+
+  it.each(['Done', 'Closed', 'Resolved', 'Completed', 'done', 'CLOSED'])(
+    'treats ado state %s as finished',
+    (adoStatus) => {
+      expect(settledOutcome({ source: 'ado_workitem', prStatus: null, adoStatus })).toBe('finished');
+    }
+  );
+
+  it.each(['Removed', 'removed'])('treats ado state %s as gone rather than finished', (adoStatus) => {
+    expect(settledOutcome({ source: 'ado_workitem', prStatus: null, adoStatus })).toBe('gone');
+  });
+
+  it.each(['New', 'Active', 'Committed', 'Blocked', 'In Progress'])(
+    'leaves ado state %s unsettled',
+    (adoStatus) => {
+      expect(settledOutcome({ source: 'ado_workitem', prStatus: null, adoStatus })).toBeNull();
+    }
+  );
+
+  // A work item's state is free text from Azure DevOps, so the match has to be
+  // a substring one -- but 'Ready for done-ness review' is not a done state.
+  // These pin the substring behaviour that lib/status-pill.ts already relies on
+  // so a future tightening of the regex has to break a test on purpose.
+  it('matches a done state embedded in a longer custom state name', () => {
+    expect(settledOutcome({ source: 'ado_workitem', prStatus: null, adoStatus: 'Dev Done' })).toBe('finished');
+  });
+
+  it('prefers gone over finished when a state names both', () => {
+    expect(settledOutcome({ source: 'ado_workitem', prStatus: null, adoStatus: 'Removed (was Done)' })).toBe('gone');
+  });
+
+  it('ignores a stale prStatus on an ado work item', () => {
+    expect(settledOutcome({ source: 'ado_workitem', prStatus: 'merged', adoStatus: 'Active' })).toBeNull();
+  });
+
+  it('ignores a stale adoStatus on a pull request', () => {
+    expect(settledOutcome({ source: 'github_pr', prStatus: 'approved', adoStatus: 'Done' })).toBeNull();
+  });
+});

--- a/lib/settled.ts
+++ b/lib/settled.ts
@@ -1,0 +1,30 @@
+import type { Item } from './types';
+
+// An item is "settled" when its source system says there is nothing left to do
+// on it, but Ariadne's own status still says otherwise. Ariadne is read-only
+// against GitHub and Azure DevOps, so it can never act on that itself -- it can
+// only surface it and let you Complete the item by hand.
+//
+// 'finished' means you got it over the line (merged, Done). 'gone' means it
+// left your plate without being finished (an ADO work item set to Removed), so
+// it must not wear the same affirmative marker.
+export type SettledOutcome = 'finished' | 'gone';
+
+// Azure DevOps work item states are free text per process template, so both
+// checks are substring matches. Shared with lib/status-pill.ts, which colours
+// the pill off the same two patterns -- the green pill and the settled check
+// must never disagree about what a state means.
+export const ADO_FINISHED_PATTERN = /resolv|done|closed|complet/i;
+export const ADO_GONE_PATTERN = /remov/i;
+
+export function settledOutcome(item: Pick<Item, 'source' | 'prStatus' | 'adoStatus'>): SettledOutcome | null {
+  if (item.source === 'github_pr') {
+    return item.prStatus === 'merged' ? 'finished' : null;
+  }
+  if (item.source === 'ado_workitem' && item.adoStatus) {
+    // Gone wins a state that matches both: "Removed (was Done)" is removed.
+    if (ADO_GONE_PATTERN.test(item.adoStatus)) return 'gone';
+    if (ADO_FINISHED_PATTERN.test(item.adoStatus)) return 'finished';
+  }
+  return null;
+}

--- a/lib/status-pill.ts
+++ b/lib/status-pill.ts
@@ -1,3 +1,4 @@
+import { ADO_FINISHED_PATTERN, ADO_GONE_PATTERN } from './settled';
 import type { Item, PrStatus } from './types';
 
 export type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'warning' | 'success' | 'outline' | 'blocked';
@@ -18,11 +19,14 @@ const PR_STATUS_PILL: Record<PrStatus, StatusPill> = {
   merged: { label: 'Merged', variant: 'outline' },
 };
 
+// The done and removed patterns come from lib/settled.ts, which decides
+// whether a row gets the settled check -- the pill's colour and that check are
+// two readings of the same fact and must not drift apart.
 function adoStatusVariant(state: string): BadgeVariant {
   const s = state.toLowerCase();
   if (/block/.test(s)) return 'blocked';
-  if (/resolv|done|closed|complet/.test(s)) return 'success';
-  if (/remov/.test(s)) return 'destructive';
+  if (ADO_GONE_PATTERN.test(s)) return 'destructive';
+  if (ADO_FINISHED_PATTERN.test(s)) return 'success';
   if (/active|committ|doing|progress/.test(s)) return 'secondary';
   return 'outline';
 }


### PR DESCRIPTION
A merged PR or a work item set to Done stays in Signals until you complete it by hand, because Ariadne is read-only and never writes back. Nothing told you which rows those were, and an inbox row only ever offered Start, so the fastest work to clear was the slowest thing on the page.

Settled rows now say so and lead with the action you actually want.

## What changed

**`lib/settled.ts`** decides the outcome once. `finished` covers a merged PR and an ADO done state; `gone` covers a work item set to Removed, which left your plate without being finished. `status-pill.ts` imports the same two patterns instead of repeating them, so the pill and the check cannot disagree. Its gone check moves ahead of its done check to match `settled.ts`, otherwise a `Removed (was Done)` state would render green next to a gone marker.

**The score chip** reports the outcome instead of a number. A merged PR still scores 45, which is history rather than a live reading, so the chip stays a button on the same popover and the breakdown stays inspectable. Only `finished` gets Success Green; `gone` takes the neutral band.

**A settled inbox row** leads with Complete and moves Start into the overflow menu as "Start anyway". Complete is the existing dialog, hours and note and link cascade included. Nothing is applied for you. `c` completes the focused row, declared in `KEYMAP` so the `?` cheat sheet picks it up. The state is in the row's `aria-label`, not only drawn.

Rows keep their place, their ranking and their full-strength text. This marks work as ready to claim, not as clutter to archive.

## Design notes

One green per row: on a settled row the ADO `Done` pill drops to outline, since the check already carries the affirmative colour and the pill still carries the state's wording.

This is Success Green's second use in the system and its first on the dashboard. It is admitted deliberately, not by default: the reserved meaning is "done, needs no action", the chip replaces an urgency band rather than sitting beside one, and a row shows the check or a score, never both. `DESIGN.md` needs its Success Green entry updated to say so, but that file is still untracked, so it is left out of this PR.

## Not in scope

Closed-unmerged PRs. `PrStatus` has no `closed` member and `fetchMergedExternalIds` only answers merged-or-not, so a PR closed without merging keeps its last known status forever. Covering it needs a new status member, a sync change and a pill entry. ADO `Removed` already works.

## Testing

- 25 new unit tests for `settledOutcome`, plus a `KEYMAP` test for the `c` binding
- New e2e spec: both settled kinds offer Complete, the still-open PR keeps Start, the state is announced on the row, the chip still opens the breakdown, and completing from a settled row moves the item out of Signals
- The e2e spec was written after the code, so the feature was disabled to confirm it fails, then restored
- 421 unit tests and 13 e2e pass, `tsc --noEmit` clean, production build succeeds

Note: `better-sqlite3` is compiled for the Node in `.nvmrc` (22). On a newer Node, 39 test files fail before any of this. Run under `nvm use`.
