### PR TITLE
feat(mcp): local stdio MCP server for reading and moving items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ docs/wireframes/
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Local MCP client config -- see the MCP section of the README
+.mcp.json
+mcp/dist

--- a/README.md
+++ b/README.md
@@ -98,6 +98,78 @@ docker run -d -p 127.0.0.1:3000:3000 -v $(pwd)/data:/data \
   -e ARIADNE_DB_PATH=/data/ariadne.db ariadne
 ```
 
+## Controlling Ariadne from an assistant
+
+Ariadne ships an [MCP](https://modelcontextprotocol.io) server, so an
+assistant that speaks MCP can read your dashboard and move items through it.
+Useful when the work happens somewhere other than the dashboard: you finish
+something in a terminal and say so, instead of switching windows to click
+Complete.
+
+It talks to your running Ariadne over `http://127.0.0.1:3000`, so start the
+app first. Transport is stdio, which means no extra port and no extra
+listener: your client spawns the server and it exits with the session.
+
+### Setup
+
+Build it once, then register it. The build is part of `npm run build`, so if
+you have already built the app you can skip the first line.
+
+```bash
+npm run mcp:build
+claude mcp add --scope user ariadne -- node "$(pwd)/mcp/dist/index.js"
+```
+
+For Claude Desktop, add the same command to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "ariadne": {
+      "command": "node",
+      "args": ["/absolute/path/to/ariadne/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+Two optional environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ARIADNE_URL` | `http://127.0.0.1:3000` | Where Ariadne is listening |
+| `ARIADNE_AUTH_TOKEN` | unset | Same value as the app's, if you have exposed Ariadne beyond loopback |
+
+### What it can do
+
+35 tools, each mapping to exactly one thing Ariadne already does:
+
+- **Look around.** List items, today's summary, a day's plan, the running
+  timer, sprint progress, sync status, the time report, estimate calibration.
+- **Move work.** Start, complete, stop the timer, requeue, undo a completion,
+  park, unpark, snooze, unsnooze, star, mark triaged, add to or remove from a
+  day.
+- **Plan.** Set a day's capacity, add and remove plan items, reorder them, set
+  estimates.
+- **Housekeeping.** Create an ad-hoc item, delete an item, sync, manage saved
+  views.
+
+Completing an item needs the hours it took, and the server will not invent
+them, so expect to be asked.
+
+### What it deliberately cannot do
+
+- **Write to GitHub or Azure DevOps.** Same as the rest of Ariadne. Completing
+  an item here does not close the pull request or work item it came from.
+- **Change your settings.** Settings writes accept arbitrary values including
+  your access tokens, so that route is not exposed. Reading settings works and
+  returns them redacted.
+- **Decide anything.** Every tool is one narrow verb. There is no "plan my
+  day" or "close everything stale": the ranking stays yours to read and act
+  on, which is the whole point of the project.
+
+The full list with descriptions lives in `mcp/tools.ts`.
+
 ## Troubleshooting
 
 ### Sync suddenly stopped working
@@ -126,7 +198,8 @@ source, marked stale, rather than hiding it.
 | Command | Description |
 |---|---|
 | `npm run dev` | Start the dev server |
-| `npm run build` | Production build |
+| `npm run build` | Production build, including the MCP server |
+| `npm run mcp:build` | Build just the MCP server |
 | `npm run start` | Run the production build |
 | `npm test` | Run the test suite (Vitest) |
 

--- a/mcp/client.test.ts
+++ b/mcp/client.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { AriadneClient } from './client';
+
+type FetchCall = { url: string; init: RequestInit | undefined };
+
+/**
+ * Records what the client asked for and replies with whatever the test
+ * wants. Injected rather than mocked globally so each test can see the
+ * exact request the tool layer built.
+ */
+function recordingFetch(response: {
+  status?: number;
+  body?: unknown;
+  bodyText?: string;
+}): { calls: FetchCall[]; fetchImpl: typeof fetch } {
+  const calls: FetchCall[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    const text = response.bodyText ?? JSON.stringify(response.body ?? {});
+    return new Response(text, {
+      status: response.status ?? 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+describe('AriadneClient', () => {
+  it('resolves a GET against the configured base URL', async () => {
+    const { calls, fetchImpl } = recordingFetch({ body: { today: [] } });
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl });
+
+    const result = await client.get('/api/today/summary');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://127.0.0.1:3000/api/today/summary');
+    expect(calls[0].init?.method).toBe('GET');
+    expect(result).toEqual({ today: [] });
+  });
+
+  it('sends a JSON body on POST', async () => {
+    const { calls, fetchImpl } = recordingFetch({ body: { id: 1 } });
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl });
+
+    await client.post('/api/items/1/complete', { durationHours: 1.5 });
+
+    expect(calls[0].init?.method).toBe('POST');
+    expect(calls[0].init?.body).toBe(JSON.stringify({ durationHours: 1.5 }));
+    expect(new Headers(calls[0].init?.headers).get('content-type')).toBe('application/json');
+  });
+
+  it('omits the body entirely when a POST has no payload', async () => {
+    const { calls, fetchImpl } = recordingFetch({ body: {} });
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl });
+
+    await client.post('/api/items/1/park');
+
+    expect(calls[0].init?.body).toBeUndefined();
+  });
+
+  it('strips a trailing slash from the base URL rather than doubling it', async () => {
+    const { calls, fetchImpl } = recordingFetch({ body: {} });
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000/', fetchImpl });
+
+    await client.get('/api/items');
+
+    expect(calls[0].url).toBe('http://127.0.0.1:3000/api/items');
+  });
+
+  it('sends Basic auth when an auth token is configured', async () => {
+    const { calls, fetchImpl } = recordingFetch({ body: {} });
+    const client = new AriadneClient({
+      baseUrl: 'http://127.0.0.1:3000',
+      authToken: 'sekrit',
+      fetchImpl,
+    });
+
+    await client.get('/api/items');
+
+    const sent = new Headers(calls[0].init?.headers).get('authorization');
+    expect(sent).toBe(`Basic ${Buffer.from('ariadne:sekrit').toString('base64')}`);
+  });
+
+  it('sends no authorization header when no token is configured', async () => {
+    const { calls, fetchImpl } = recordingFetch({ body: {} });
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl });
+
+    await client.get('/api/items');
+
+    expect(new Headers(calls[0].init?.headers).get('authorization')).toBeNull();
+  });
+
+  it("surfaces the API's own error message on a 4xx", async () => {
+    const { fetchImpl } = recordingFetch({
+      status: 400,
+      body: { error: 'durationHours is required and must be >= 0' },
+    });
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl });
+
+    await expect(client.post('/api/items/1/complete', {})).rejects.toThrow(
+      'durationHours is required and must be >= 0',
+    );
+  });
+
+  it('falls back to status and path when an error response is not JSON', async () => {
+    const { fetchImpl } = recordingFetch({ status: 401, bodyText: 'Authentication required.' });
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl });
+
+    await expect(client.get('/api/items')).rejects.toThrow(
+      'Ariadne returned 401 for GET /api/items: Authentication required.',
+    );
+  });
+
+  it('explains how to start Ariadne when the connection is refused', async () => {
+    const fetchImpl = (async () => {
+      throw new TypeError('fetch failed');
+    }) as unknown as typeof fetch;
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl });
+
+    await expect(client.get('/api/items')).rejects.toThrow(
+      /Cannot reach Ariadne at http:\/\/127\.0\.0\.1:3000/,
+    );
+    await expect(client.get('/api/items')).rejects.toThrow(/npm run dev/);
+  });
+
+  it('treats an empty 200 body as null rather than throwing', async () => {
+    const { fetchImpl } = recordingFetch({ status: 200, bodyText: '' });
+    const client = new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl });
+
+    await expect(client.get('/api/items')).resolves.toBeNull();
+  });
+});

--- a/mcp/client.ts
+++ b/mcp/client.ts
@@ -1,0 +1,91 @@
+/**
+ * The MCP server's only route into Ariadne: HTTP against the running app.
+ *
+ * Deliberately not a direct SQLite reader. The API routes hold orchestration
+ * the tables don't -- Start also floats the item to the top of today's plan,
+ * Complete also closes the running timer -- so talking to the routes keeps a
+ * single source of truth and avoids a second writer on the database file.
+ */
+
+export const DEFAULT_BASE_URL = 'http://127.0.0.1:3000';
+
+export interface AriadneClientConfig {
+  baseUrl: string;
+  /** Only set when the operator has exposed Ariadne beyond loopback. */
+  authToken?: string | null;
+  fetchImpl?: typeof fetch;
+}
+
+type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export class AriadneClient {
+  private readonly baseUrl: string;
+  private readonly authToken: string | null;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: AriadneClientConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '');
+    this.authToken = config.authToken ?? null;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  get<T = unknown>(path: string): Promise<T> {
+    return this.request<T>('GET', path);
+  }
+
+  post<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>('POST', path, body);
+  }
+
+  put<T = unknown>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>('PUT', path, body);
+  }
+
+  del<T = unknown>(path: string): Promise<T> {
+    return this.request<T>('DELETE', path);
+  }
+
+  private async request<T>(method: Method, path: string, body?: unknown): Promise<T> {
+    const headers: Record<string, string> = {};
+    if (body !== undefined) headers['content-type'] = 'application/json';
+    if (this.authToken) {
+      // Ariadne's middleware only reads the password half, so the username is
+      // arbitrary -- see middleware.ts.
+      headers.authorization = `Basic ${Buffer.from(`ariadne:${this.authToken}`).toString('base64')}`;
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+    } catch (cause) {
+      throw new Error(
+        `Cannot reach Ariadne at ${this.baseUrl}. Is it running? Start it with \`npm run dev\`, ` +
+          `or point the server at a different address with ARIADNE_URL.`,
+        { cause },
+      );
+    }
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      throw new Error(apiErrorMessage(method, path, response.status, text));
+    }
+
+    if (text === '') return null as T;
+    return JSON.parse(text) as T;
+  }
+}
+
+function apiErrorMessage(method: Method, path: string, status: number, text: string): string {
+  try {
+    const parsed = JSON.parse(text) as { error?: unknown };
+    if (typeof parsed.error === 'string') return parsed.error;
+  } catch {
+    // Not JSON -- fall through to the generic shape below.
+  }
+  return `Ariadne returned ${status} for ${method} ${path}: ${text}`;
+}

--- a/mcp/config.test.ts
+++ b/mcp/config.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { resolveConfig } from './config';
+import { DEFAULT_BASE_URL } from './client';
+
+describe('resolveConfig', () => {
+  it('defaults to loopback on the port Ariadne serves', () => {
+    expect(resolveConfig({})).toEqual({ baseUrl: DEFAULT_BASE_URL, authToken: null });
+  });
+
+  it('takes the base URL from ARIADNE_URL', () => {
+    expect(resolveConfig({ ARIADNE_URL: 'http://127.0.0.1:4000' }).baseUrl).toBe(
+      'http://127.0.0.1:4000',
+    );
+  });
+
+  it('takes the auth token from ARIADNE_AUTH_TOKEN, matching the app env var', () => {
+    expect(resolveConfig({ ARIADNE_AUTH_TOKEN: 'sekrit' }).authToken).toBe('sekrit');
+  });
+
+  it('treats blank env vars as unset rather than as empty values', () => {
+    expect(resolveConfig({ ARIADNE_URL: '  ', ARIADNE_AUTH_TOKEN: '' })).toEqual({
+      baseUrl: DEFAULT_BASE_URL,
+      authToken: null,
+    });
+  });
+});

--- a/mcp/config.ts
+++ b/mcp/config.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_BASE_URL } from './client';
+
+export interface ResolvedConfig {
+  baseUrl: string;
+  authToken: string | null;
+}
+
+/**
+ * ARIADNE_AUTH_TOKEN is deliberately the same name the app uses, so a setup
+ * that has exposed Ariadne beyond loopback configures both halves with one
+ * value.
+ */
+export function resolveConfig(env: Record<string, string | undefined>): ResolvedConfig {
+  return {
+    baseUrl: trimmed(env.ARIADNE_URL) ?? DEFAULT_BASE_URL,
+    authToken: trimmed(env.ARIADNE_AUTH_TOKEN) ?? null,
+  };
+}
+
+function trimmed(value: string | undefined): string | null {
+  const result = value?.trim();
+  return result ? result : null;
+}

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * stdio entrypoint for the Ariadne MCP server.
+ *
+ * Nothing may be written to stdout here but JSON-RPC: a single stray line
+ * corrupts the stream and the client drops the connection. Diagnostics go to
+ * stderr, which MCP clients surface as server logs.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { AriadneClient } from './client';
+import { resolveConfig } from './config';
+import { createServer } from './server';
+
+/**
+ * Walks up from the compiled file to find the app's package.json, so the
+ * version reported in the MCP handshake tracks the release rather than a
+ * constant someone has to remember to bump.
+ */
+function appVersion(): string {
+  let dir = __dirname;
+  for (let depth = 0; depth < 4; depth += 1) {
+    try {
+      const raw = readFileSync(join(dir, 'package.json'), 'utf8');
+      const parsed = JSON.parse(raw) as { name?: string; version?: string };
+      if (parsed.name === 'ariadne' && parsed.version) return parsed.version;
+    } catch {
+      // Not here, keep walking.
+    }
+    dir = join(dir, '..');
+  }
+  return '0.0.0';
+}
+
+async function main(): Promise<void> {
+  const config = resolveConfig(process.env);
+  const server = createServer(new AriadneClient(config), appVersion());
+  await server.connect(new StdioServerTransport());
+  process.stderr.write(`ariadne-mcp ready, talking to ${config.baseUrl}\n`);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`ariadne-mcp failed to start: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/mcp/server.test.ts
+++ b/mcp/server.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { AriadneClient } from './client';
+import { TOOLS } from './tools';
+import { createServer } from './server';
+
+type FetchCall = { url: string; method: string | undefined; body: string | undefined };
+
+/**
+ * Stands up a real MCP client and server on a linked in-memory transport, so
+ * these tests exercise the actual protocol rather than a stand-in for it. Only
+ * the HTTP hop into Ariadne is faked.
+ */
+async function connected(respond: (call: FetchCall) => Response) {
+  const calls: FetchCall[] = [];
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    const call = {
+      url: String(url),
+      method: init?.method,
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    };
+    calls.push(call);
+    return respond(call);
+  }) as unknown as typeof fetch;
+
+  const server = createServer(
+    new AriadneClient({ baseUrl: 'http://127.0.0.1:3000', fetchImpl }),
+  );
+  const client = new Client({ name: 'test', version: '0.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  return { client, calls };
+}
+
+const jsonOk = (body: unknown) =>
+  new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+
+describe('createServer', () => {
+  it('advertises every tool in the registry', async () => {
+    const { client } = await connected(() => jsonOk({}));
+
+    const { tools } = await client.listTools();
+
+    expect(tools.map((t) => t.name).sort()).toEqual(TOOLS.map((t) => t.name).sort());
+  });
+
+  it('carries titles and annotations through to the client', async () => {
+    const { client } = await connected(() => jsonOk({}));
+
+    const { tools } = await client.listTools();
+    const deleteTool = tools.find((t) => t.name === 'delete_item');
+    const listTool = tools.find((t) => t.name === 'list_items');
+
+    expect(deleteTool?.annotations?.destructiveHint).toBe(true);
+    expect(listTool?.annotations?.readOnlyHint).toBe(true);
+    expect(listTool?.title).toBeTruthy();
+  });
+
+  it('performs the underlying request when a tool is called', async () => {
+    const { client, calls } = await connected(() => jsonOk({ id: 7, status: 'in_progress' }));
+
+    const result = await client.callTool({ name: 'start_item', arguments: { itemId: 7 } });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://127.0.0.1:3000/api/items/7/start');
+    expect(calls[0].method).toBe('POST');
+    expect(result.isError).toBeFalsy();
+    expect((result.content as { type: string; text: string }[])[0].text).toContain('in_progress');
+  });
+
+  it('rejects a call whose arguments fail the input schema', async () => {
+    const { client, calls } = await connected(() => jsonOk({}));
+
+    const result = await client.callTool({
+      name: 'complete_item',
+      arguments: { itemId: 7 },
+    }).catch((error: Error) => error);
+
+    // Either shape is acceptable, so long as Ariadne was never touched.
+    const rejected = result instanceof Error || (result as { isError?: boolean }).isError === true;
+    expect(rejected).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("reports the route's own error message instead of crashing", async () => {
+    const { client } = await connected(
+      () =>
+        new Response(JSON.stringify({ error: 'durationHours is required and must be >= 0' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+
+    const result = await client.callTool({
+      name: 'complete_item',
+      arguments: { itemId: 7, durationHours: 1 },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as { type: string; text: string }[])[0].text).toContain(
+      'durationHours is required',
+    );
+  });
+
+  it('explains how to start Ariadne when it is not running', async () => {
+    const { client } = await connected(() => {
+      throw new TypeError('fetch failed');
+    });
+
+    const result = await client.callTool({ name: 'list_items', arguments: {} });
+
+    expect(result.isError).toBe(true);
+    expect((result.content as { type: string; text: string }[])[0].text).toMatch(
+      /Cannot reach Ariadne/,
+    );
+  });
+
+  it('stays connected and usable after a failed call', async () => {
+    let fail = true;
+    const { client } = await connected(() => {
+      if (fail) throw new TypeError('fetch failed');
+      return jsonOk({ recovered: true });
+    });
+
+    await client.callTool({ name: 'list_items', arguments: {} });
+    fail = false;
+    const result = await client.callTool({ name: 'list_items', arguments: {} });
+
+    expect(result.isError).toBeFalsy();
+    expect((result.content as { type: string; text: string }[])[0].text).toContain('recovered');
+  });
+});

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -1,0 +1,64 @@
+/**
+ * Wires the tool registry onto an MCP server. Kept separate from index.ts so
+ * tests can drive it over an in-memory transport instead of a real stdio pipe.
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AriadneClient } from './client';
+import { TOOLS } from './tools';
+
+export const SERVER_NAME = 'ariadne';
+
+const INSTRUCTIONS = `Ariadne is a personal, local-only work dashboard. Use these tools to see what is
+on the plate and to move items through it: start, complete, park, snooze, plan.
+
+Two things to respect:
+
+- completing an item needs the hours it took. Ask the user, do not estimate for
+  them.
+- Ariadne never writes back to GitHub or Azure DevOps. Closing an item here does
+  not close the pull request or work item it came from.`;
+
+export function createServer(client: AriadneClient, version = '0.0.0'): McpServer {
+  const server = new McpServer(
+    { name: SERVER_NAME, version },
+    { instructions: INSTRUCTIONS },
+  );
+
+  for (const tool of TOOLS) {
+    server.registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        annotations: { title: tool.title, ...tool.annotations },
+      },
+      // The SDK has already validated args against inputSchema by this point.
+      async (args: unknown) => {
+        try {
+          const result = await tool.run(client, args as Record<string, unknown>);
+          return { content: [{ type: 'text' as const, text: format(result) }] };
+        } catch (error) {
+          // Returned rather than thrown: a 400 from Ariadne is a fact the model
+          // should read and act on, not a transport failure that kills the call.
+          return {
+            isError: true,
+            content: [{ type: 'text' as const, text: message(error) }],
+          };
+        }
+      },
+    );
+  }
+
+  return server;
+}
+
+function format(result: unknown): string {
+  if (result === null || result === undefined) return 'Done.';
+  return JSON.stringify(result, null, 2);
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/mcp/tools.test.ts
+++ b/mcp/tools.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { AriadneClient } from './client';
+import { TOOLS, toolByName } from './tools';
+
+type Recorded = { method: string; path: string; body?: unknown };
+
+function stubClient(result: unknown = { ok: true }): {
+  calls: Recorded[];
+  client: AriadneClient;
+} {
+  const calls: Recorded[] = [];
+  const client = {
+    get: async (path: string) => {
+      calls.push({ method: 'GET', path });
+      return result;
+    },
+    post: async (path: string, body?: unknown) => {
+      calls.push({ method: 'POST', path, body });
+      return result;
+    },
+    put: async (path: string, body?: unknown) => {
+      calls.push({ method: 'PUT', path, body });
+      return result;
+    },
+    del: async (path: string) => {
+      calls.push({ method: 'DELETE', path });
+      return result;
+    },
+  } as unknown as AriadneClient;
+  return { calls, client };
+}
+
+async function invoke(name: string, args: Record<string, unknown> = {}): Promise<Recorded> {
+  const tool = toolByName(name);
+  if (!tool) throw new Error(`No such tool: ${name}`);
+  const parsed = z.object(tool.inputSchema).parse(args);
+  const { calls, client } = stubClient();
+  await tool.run(client, parsed);
+  expect(calls).toHaveLength(1);
+  return calls[0];
+}
+
+describe('tool registry hygiene', () => {
+  it('gives every tool a unique snake_case name', () => {
+    const names = TOOLS.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+    for (const name of names) expect(name).toMatch(/^[a-z][a-z0-9_]*$/);
+  });
+
+  it('gives every tool a title and a description', () => {
+    for (const tool of TOOLS) {
+      expect(tool.title, tool.name).toBeTruthy();
+      expect(tool.description.length, tool.name).toBeGreaterThan(20);
+    }
+  });
+
+  it('finds tools by name and returns undefined for unknown ones', () => {
+    expect(toolByName('start_item')?.name).toBe('start_item');
+    expect(toolByName('nope')).toBeUndefined();
+  });
+});
+
+describe('the excluded routes stay excluded', () => {
+  it('exposes no tool that writes settings', async () => {
+    // Settings writes accept arbitrary key/value pairs, which includes the
+    // GitHub and Azure DevOps PATs. Reading is fine, the route redacts.
+    for (const tool of TOOLS) {
+      if (tool.annotations.readOnlyHint) continue;
+      const { calls, client } = stubClient();
+      await tool.run(client, permissiveArgs(tool.inputSchema)).catch(() => undefined);
+      for (const call of calls) expect(call.path).not.toContain('/api/settings');
+    }
+  });
+
+  it('exposes no tool that spawns Claude via open-claude', () => {
+    for (const tool of TOOLS) {
+      expect(tool.name).not.toContain('claude');
+    }
+  });
+});
+
+describe('annotations', () => {
+  it('marks every read tool read-only and every write tool not', async () => {
+    for (const tool of TOOLS) {
+      const { calls, client } = stubClient();
+      await tool.run(client, permissiveArgs(tool.inputSchema)).catch(() => undefined);
+      const usedOnlyGet = calls.every((c) => c.method === 'GET');
+      expect(Boolean(tool.annotations.readOnlyHint), `${tool.name} readOnlyHint`).toBe(usedOnlyGet);
+    }
+  });
+
+  it('flags delete_item as destructive and says so in the description', () => {
+    const tool = toolByName('delete_item');
+    expect(tool?.annotations.destructiveHint).toBe(true);
+    expect(tool?.description.toLowerCase()).toMatch(/cannot be undone|no undo|permanent/);
+  });
+
+  it('does not flag reversible writes as destructive', () => {
+    for (const name of ['park_item', 'snooze_item', 'add_to_today', 'star_item']) {
+      expect(toolByName(name)?.annotations.destructiveHint, name).not.toBe(true);
+    }
+  });
+});
+
+describe('read tools map to their routes', () => {
+  it.each([
+    ['list_items', {}, 'GET', '/api/items'],
+    ['get_today', {}, 'GET', '/api/today/summary'],
+    ['get_today', { date: '2026-08-31' }, 'GET', '/api/today/summary?date=2026-08-31'],
+    ['get_plan', { date: '2026-08-31' }, 'GET', '/api/plan?date=2026-08-31'],
+    ['get_running_timer', {}, 'GET', '/api/timer/running'],
+    ['get_sprint', {}, 'GET', '/api/sprint'],
+    ['get_sync_status', {}, 'GET', '/api/sync-status'],
+    ['get_settings', {}, 'GET', '/api/settings'],
+    ['list_local_repos', {}, 'GET', '/api/local-repos'],
+    ['list_saved_views', {}, 'GET', '/api/saved-views'],
+    [
+      'get_report',
+      { start: '2026-08-01', end: '2026-08-31' },
+      'GET',
+      '/api/report?start=2026-08-01&end=2026-08-31',
+    ],
+    [
+      'get_calibration',
+      { start: '2026-08-01', end: '2026-08-31' },
+      'GET',
+      '/api/calibration?start=2026-08-01&end=2026-08-31',
+    ],
+  ])('%s %o hits %s %s', async (name, args, method, path) => {
+    const call = await invoke(name as string, args as Record<string, unknown>);
+    expect(call.method).toBe(method);
+    expect(call.path).toBe(path);
+  });
+});
+
+describe('item write tools map to their routes', () => {
+  it.each([
+    ['start_item', { itemId: 7 }, 'POST', '/api/items/7/start', {}],
+    ['start_item', { itemId: 7, withTimer: false }, 'POST', '/api/items/7/start', { withTimer: false }],
+    [
+      'complete_item',
+      { itemId: 7, durationHours: 1.5 },
+      'POST',
+      '/api/items/7/complete',
+      { durationHours: 1.5 },
+    ],
+    [
+      'complete_item',
+      { itemId: 7, durationHours: 0, note: 'no work needed' },
+      'POST',
+      '/api/items/7/complete',
+      { durationHours: 0, note: 'no work needed' },
+    ],
+    ['stop_timer', { itemId: 7 }, 'POST', '/api/items/7/stop-timer', undefined],
+    ['requeue_item', { itemId: 7 }, 'POST', '/api/items/7/requeue', undefined],
+    ['undo_completion', { itemId: 7 }, 'POST', '/api/items/7/undo', undefined],
+    ['park_item', { itemId: 7 }, 'POST', '/api/items/7/park', undefined],
+    ['unpark_item', { itemId: 7 }, 'POST', '/api/items/7/unpark', undefined],
+    ['snooze_item', { itemId: 7, option: 'tomorrow' }, 'POST', '/api/items/7/snooze', { option: 'tomorrow' }],
+    ['unsnooze_item', { itemId: 7 }, 'DELETE', '/api/items/7/snooze', undefined],
+    ['star_item', { itemId: 7, starred: true }, 'POST', '/api/items/7/star', { starred: true }],
+    ['set_triage_done', { itemId: 7, done: true }, 'POST', '/api/items/7/done', { done: true }],
+    ['add_to_today', { itemId: 7 }, 'POST', '/api/items/7/today', {}],
+    ['add_to_today', { itemId: 7, date: '2026-09-01' }, 'POST', '/api/items/7/today', { date: '2026-09-01' }],
+    ['remove_from_today', { itemId: 7 }, 'DELETE', '/api/items/7/today', undefined],
+    ['delete_item', { itemId: 7 }, 'DELETE', '/api/items/7', undefined],
+    ['sync_now', {}, 'POST', '/api/sync', undefined],
+    ['create_item', { title: 'Write the thing' }, 'POST', '/api/items', { title: 'Write the thing' }],
+    [
+      'create_item',
+      { title: 'Write the thing', category: 'admin', dueDate: '2026-09-05' },
+      'POST',
+      '/api/items',
+      { title: 'Write the thing', category: 'admin', dueDate: '2026-09-05' },
+    ],
+  ])('%s %o hits %s %s', async (name, args, method, path, body) => {
+    const call = await invoke(name as string, args as Record<string, unknown>);
+    expect(call.method).toBe(method);
+    expect(call.path).toBe(path);
+    expect(call.body).toEqual(body);
+  });
+});
+
+describe('plan and saved-view write tools map to their routes', () => {
+  it.each([
+    [
+      'set_plan',
+      { date: '2026-08-31', capacityMinutes: 300, note: 'light day' },
+      'POST',
+      '/api/plan',
+      { date: '2026-08-31', capacityMinutes: 300, note: 'light day' },
+    ],
+    [
+      'add_plan_item',
+      { date: '2026-08-31', itemId: 7 },
+      'POST',
+      '/api/plan/items',
+      { date: '2026-08-31', itemId: 7 },
+    ],
+    [
+      'remove_plan_item',
+      { date: '2026-08-31', itemId: 7 },
+      'DELETE',
+      '/api/plan/items?date=2026-08-31&itemId=7',
+      undefined,
+    ],
+    [
+      'reorder_plan_items',
+      { date: '2026-08-31', orderedItemIds: [3, 1, 2] },
+      'PUT',
+      '/api/plan/items/reorder',
+      { date: '2026-08-31', orderedItemIds: [3, 1, 2] },
+    ],
+    [
+      'set_plan_item_estimate',
+      { date: '2026-08-31', itemId: 7, minutes: 45 },
+      'POST',
+      '/api/plan/items/estimate',
+      { date: '2026-08-31', itemId: 7, minutes: 45 },
+    ],
+    [
+      'create_saved_view',
+      { label: 'Stale PRs', query: 'is:pr stale' },
+      'POST',
+      '/api/saved-views',
+      { label: 'Stale PRs', query: 'is:pr stale' },
+    ],
+    [
+      'reorder_saved_views',
+      { orderedIds: ['a', 'b'] },
+      'PUT',
+      '/api/saved-views',
+      { orderedIds: ['a', 'b'] },
+    ],
+    ['delete_saved_view', { id: 'abc' }, 'DELETE', '/api/saved-views?id=abc', undefined],
+  ])('%s %o hits %s %s', async (name, args, method, path, body) => {
+    const call = await invoke(name as string, args as Record<string, unknown>);
+    expect(call.method).toBe(method);
+    expect(call.path).toBe(path);
+    expect(call.body).toEqual(body);
+  });
+
+  it('percent-encodes query values rather than pasting them raw', async () => {
+    const call = await invoke('delete_saved_view', { id: 'a b&c' });
+    expect(call.path).toBe('/api/saved-views?id=a%20b%26c');
+  });
+});
+
+describe('input schemas refuse nonsense before it reaches the API', () => {
+  function parse(name: string, args: Record<string, unknown>) {
+    return z.object(toolByName(name)!.inputSchema).safeParse(args);
+  }
+
+  it('requires durationHours on complete_item', () => {
+    expect(parse('complete_item', { itemId: 1 }).success).toBe(false);
+    expect(parse('complete_item', { itemId: 1, durationHours: 2 }).success).toBe(true);
+  });
+
+  it('rejects a negative durationHours, matching the route', () => {
+    expect(parse('complete_item', { itemId: 1, durationHours: -1 }).success).toBe(false);
+    expect(parse('complete_item', { itemId: 1, durationHours: 0 }).success).toBe(true);
+  });
+
+  it('accepts only the four real snooze options', () => {
+    for (const option of ['later_today', 'tomorrow', 'next_week', 'until_activity']) {
+      expect(parse('snooze_item', { itemId: 1, option }).success, option).toBe(true);
+    }
+    expect(parse('snooze_item', { itemId: 1, option: 'next_year' }).success).toBe(false);
+  });
+
+  it('requires an integer itemId', () => {
+    expect(parse('start_item', { itemId: 1.5 }).success).toBe(false);
+    expect(parse('start_item', { itemId: 'seven' }).success).toBe(false);
+    expect(parse('start_item', {}).success).toBe(false);
+  });
+
+  it('requires a non-empty title on create_item', () => {
+    expect(parse('create_item', { title: '' }).success).toBe(false);
+    expect(parse('create_item', {}).success).toBe(false);
+  });
+
+  it('requires ISO dates where the routes compare them as strings', () => {
+    expect(parse('get_report', { start: '01-08-2026', end: '2026-08-31' }).success).toBe(false);
+    expect(parse('get_report', { start: '2026-08-01', end: '2026-08-31' }).success).toBe(true);
+  });
+
+  it('requires both ends of a report range', () => {
+    expect(parse('get_report', { start: '2026-08-01' }).success).toBe(false);
+  });
+});
+
+/**
+ * Builds an argument object good enough to let any tool's run() reach the
+ * client, so the sweep tests above can see which routes it touches.
+ */
+function permissiveArgs(shape: z.ZodRawShape): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  for (const key of Object.keys(shape)) {
+    if (key === 'itemId') args[key] = 1;
+    else if (key === 'orderedItemIds') args[key] = [1];
+    else if (key === 'orderedIds') args[key] = ['a'];
+    else if (key === 'option') args[key] = 'tomorrow';
+    else if (key.endsWith('Hours') || key.endsWith('Minutes') || key === 'minutes') args[key] = 1;
+    else if (key === 'starred' || key === 'done' || key === 'withTimer') args[key] = true;
+    else if (key === 'date' || key === 'start' || key === 'end' || key === 'dueDate') args[key] = '2026-08-31';
+    else args[key] = 'x';
+  }
+  return args;
+}

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -1,0 +1,404 @@
+/**
+ * Every tool the MCP server exposes, as data.
+ *
+ * Two rules hold this list to Ariadne's philosophy that the app never takes
+ * action the user didn't trigger:
+ *
+ * 1. Narrow verbs only. One tool maps to exactly one route. No `triage_my_day`,
+ *    no `auto_complete_stale`, nothing that infers intent from state.
+ * 2. No silent guesses. `complete_item` demands an explicit durationHours, so a
+ *    duration has to be asked for rather than invented.
+ *
+ * Deliberately absent: `POST /api/settings`, which writes arbitrary key/value
+ * pairs including the GitHub and Azure DevOps PATs, and
+ * `POST /api/items/:id/open-claude`, which spawns Claude in a terminal.
+ */
+
+import { z } from 'zod';
+import type { AriadneClient } from './client';
+
+export interface ToolAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+}
+
+export interface ToolDefinition {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: z.ZodRawShape;
+  annotations: ToolAnnotations;
+  run: (client: AriadneClient, args: Record<string, unknown>) => Promise<unknown>;
+}
+
+const itemId = z.number().int().describe("The Ariadne item id, as returned by list_items");
+const isoDate = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be a YYYY-MM-DD date')
+  .describe('A local date as YYYY-MM-DD');
+
+const READ_ONLY: ToolAnnotations = { readOnlyHint: true };
+const WRITES: ToolAnnotations = { readOnlyHint: false };
+
+/** Builds `?a=1&b=2`, or '' when nothing is set. Skips undefined values. */
+function query(params: Record<string, string | number | undefined>): string {
+  const pairs = Object.entries(params)
+    .filter((entry): entry is [string, string | number] => entry[1] !== undefined)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  return pairs.length === 0 ? '' : `?${pairs.join('&')}`;
+}
+
+/** Drops undefined keys so an optional argument doesn't become an explicit null. */
+function body(payload: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(payload).filter(([, value]) => value !== undefined));
+}
+
+// Typed loosely on purpose: each run() re-narrows its own args, and the
+// registry is heterogeneous by nature.
+function define<Shape extends z.ZodRawShape>(tool: {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Shape;
+  annotations: ToolAnnotations;
+  run: (client: AriadneClient, args: z.infer<z.ZodObject<Shape>>) => Promise<unknown>;
+}): ToolDefinition {
+  return tool as unknown as ToolDefinition;
+}
+
+export const TOOLS: readonly ToolDefinition[] = [
+  // ---------------------------------------------------------------- reads
+  define({
+    name: 'list_items',
+    title: 'List all items',
+    description:
+      "Every item Ariadne knows about, grouped into today, signals, in-progress and parked, each scored by urgency. This is the starting point for finding an item's id.",
+    inputSchema: {},
+    annotations: READ_ONLY,
+    run: (client) => client.get('/api/items'),
+  }),
+  define({
+    name: 'get_today',
+    title: "Get today's summary",
+    description:
+      "What is planned, in progress and already done for a given day, with hours logged and estimates. Defaults to today when no date is given.",
+    inputSchema: { date: isoDate.optional() },
+    annotations: READ_ONLY,
+    run: (client, { date }) => client.get(`/api/today/summary${query({ date })}`),
+  }),
+  define({
+    name: 'get_plan',
+    title: 'Get the plan for a day',
+    description: "A day's capacity, note and hand-ordered plan items.",
+    inputSchema: { date: isoDate },
+    annotations: READ_ONLY,
+    run: (client, { date }) => client.get(`/api/plan${query({ date })}`),
+  }),
+  define({
+    name: 'get_running_timer',
+    title: 'Get the running timer',
+    description: 'The item whose timer is currently running, if any, and how long it has been going.',
+    inputSchema: {},
+    annotations: READ_ONLY,
+    run: (client) => client.get('/api/timer/running'),
+  }),
+  define({
+    name: 'get_sprint',
+    title: 'Get sprint progress',
+    description: 'Progress through the configured Azure DevOps sprint iteration.',
+    inputSchema: {},
+    annotations: READ_ONLY,
+    run: (client) => client.get('/api/sprint'),
+  }),
+  define({
+    name: 'get_sync_status',
+    title: 'Get sync status',
+    description: 'When Ariadne last synced with GitHub and Azure DevOps, and whether it failed.',
+    inputSchema: {},
+    annotations: READ_ONLY,
+    run: (client) => client.get('/api/sync-status'),
+  }),
+  define({
+    name: 'get_report',
+    title: 'Get the time report',
+    description: 'Hours logged per item and per category over a date range, inclusive of both ends.',
+    inputSchema: { start: isoDate, end: isoDate },
+    annotations: READ_ONLY,
+    run: (client, { start, end }) => client.get(`/api/report${query({ start, end })}`),
+  }),
+  define({
+    name: 'get_calibration',
+    title: 'Get estimate calibration',
+    description: 'How estimates compared with actual logged time over a date range.',
+    inputSchema: { start: isoDate, end: isoDate },
+    annotations: READ_ONLY,
+    run: (client, { start, end }) => client.get(`/api/calibration${query({ start, end })}`),
+  }),
+  define({
+    name: 'get_settings',
+    title: 'Get settings',
+    description:
+      'Ariadne\'s settings, with secrets redacted. Personal access tokens are never returned in full and cannot be changed through this server.',
+    inputSchema: {},
+    annotations: READ_ONLY,
+    run: (client) => client.get('/api/settings'),
+  }),
+  define({
+    name: 'list_local_repos',
+    title: 'List configured local repos',
+    description: 'The local checkout paths configured in Settings.',
+    inputSchema: {},
+    annotations: READ_ONLY,
+    run: (client) => client.get('/api/local-repos'),
+  }),
+  define({
+    name: 'list_saved_views',
+    title: 'List saved views',
+    description: 'The saved dashboard search queries, in their display order.',
+    inputSchema: {},
+    annotations: READ_ONLY,
+    run: (client) => client.get('/api/saved-views'),
+  }),
+
+  // --------------------------------------------------------- item writes
+  define({
+    name: 'create_item',
+    title: 'Create an ad-hoc item',
+    description:
+      'Adds an item that did not come from GitHub or Azure DevOps. Use this for work that only exists in your head.',
+    inputSchema: {
+      title: z.string().min(1).describe('What the item is'),
+      category: z.string().optional().describe('Optional grouping label'),
+      dueDate: isoDate.optional(),
+    },
+    annotations: WRITES,
+    run: (client, { title, category, dueDate }) =>
+      client.post('/api/items', body({ title, category, dueDate })),
+  }),
+  define({
+    name: 'start_item',
+    title: 'Start an item',
+    description:
+      "Moves the item to in-progress, starts its timer, and floats it to the top of today's plan if it is on it. Pass withTimer false to change status without timing.",
+    inputSchema: {
+      itemId,
+      withTimer: z.boolean().optional().describe('Defaults to true'),
+    },
+    annotations: WRITES,
+    run: (client, { itemId: id, withTimer }) =>
+      client.post(`/api/items/${id}/start`, body({ withTimer })),
+  }),
+  define({
+    name: 'complete_item',
+    title: 'Complete an item',
+    description:
+      'Marks the item done and closes its timer with the hours you give. durationHours is required and is never inferred, so ask the user how long it took rather than guessing.',
+    inputSchema: {
+      itemId,
+      durationHours: z.number().min(0).describe('Hours to log against this item. Ask, do not guess.'),
+      note: z.string().optional().describe('Optional note stored on the time log'),
+    },
+    annotations: WRITES,
+    run: (client, { itemId: id, durationHours, note }) =>
+      client.post(`/api/items/${id}/complete`, body({ durationHours, note })),
+  }),
+  define({
+    name: 'stop_timer',
+    title: 'Stop the timer on an item',
+    description: 'Stops timing without changing the item status. Use this for a pause, not a completion.',
+    inputSchema: { itemId },
+    annotations: WRITES,
+    run: (client, { itemId: id }) => client.post(`/api/items/${id}/stop-timer`),
+  }),
+  define({
+    name: 'requeue_item',
+    title: 'Requeue an item to the inbox',
+    description: 'Closes the running timer with the elapsed time and sends the item back to the inbox.',
+    inputSchema: { itemId },
+    annotations: WRITES,
+    run: (client, { itemId: id }) => client.post(`/api/items/${id}/requeue`),
+  }),
+  define({
+    name: 'undo_completion',
+    title: 'Undo a completion',
+    description: 'Reverses the last completion: drops that time log and puts the item back in progress.',
+    inputSchema: { itemId },
+    annotations: WRITES,
+    run: (client, { itemId: id }) => client.post(`/api/items/${id}/undo`),
+  }),
+  define({
+    name: 'park_item',
+    title: 'Park an item',
+    description: 'Stops any running timer and moves the item to the parked sub-list. Reversible with unpark_item.',
+    inputSchema: { itemId },
+    annotations: WRITES,
+    run: (client, { itemId: id }) => client.post(`/api/items/${id}/park`),
+  }),
+  define({
+    name: 'unpark_item',
+    title: 'Unpark an item',
+    description: 'Brings a parked item back into the normal lists.',
+    inputSchema: { itemId },
+    annotations: WRITES,
+    run: (client, { itemId: id }) => client.post(`/api/items/${id}/unpark`),
+  }),
+  define({
+    name: 'snooze_item',
+    title: 'Snooze an item',
+    description: 'Hides the item until later today, tomorrow, next week, or until there is activity on it.',
+    inputSchema: {
+      itemId,
+      option: z.enum(['later_today', 'tomorrow', 'next_week', 'until_activity']),
+    },
+    annotations: WRITES,
+    run: (client, { itemId: id, option }) => client.post(`/api/items/${id}/snooze`, { option }),
+  }),
+  define({
+    name: 'unsnooze_item',
+    title: 'Unsnooze an item',
+    description: 'Clears a snooze so the item comes back immediately.',
+    inputSchema: { itemId },
+    annotations: WRITES,
+    run: (client, { itemId: id }) => client.del(`/api/items/${id}/snooze`),
+  }),
+  define({
+    name: 'star_item',
+    title: 'Star or unstar an item',
+    description: 'Marks the item as starred, or clears the star when starred is false.',
+    inputSchema: { itemId, starred: z.boolean() },
+    annotations: WRITES,
+    run: (client, { itemId: id, starred }) => client.post(`/api/items/${id}/star`, { starred }),
+  }),
+  define({
+    name: 'set_triage_done',
+    title: 'Mark an item triaged',
+    description:
+      'Sets the triage state, which is about having dealt with a signal rather than having finished the work. Use complete_item to finish work.',
+    inputSchema: { itemId, done: z.boolean() },
+    annotations: WRITES,
+    run: (client, { itemId: id, done }) => client.post(`/api/items/${id}/done`, { done }),
+  }),
+  define({
+    name: 'add_to_today',
+    title: "Add an item to a day's plan",
+    description: "Pins the item to a day's plan. Defaults to today when no date is given.",
+    inputSchema: { itemId, date: isoDate.optional() },
+    annotations: WRITES,
+    run: (client, { itemId: id, date }) => client.post(`/api/items/${id}/today`, body({ date })),
+  }),
+  define({
+    name: 'remove_from_today',
+    title: "Remove an item from today's plan",
+    description: 'Unpins the item from whichever day it is planned for, without changing its status.',
+    inputSchema: { itemId },
+    annotations: WRITES,
+    run: (client, { itemId: id }) => client.del(`/api/items/${id}/today`),
+  }),
+  define({
+    name: 'delete_item',
+    title: 'Delete an item',
+    description:
+      'Permanently deletes the item and its links. This cannot be undone, and a synced item will reappear on the next sync. An item with logged time is refused, since deleting it would rewrite the time report -- park it instead. Prefer park_item or set_triage_done unless the user explicitly asked for a delete.',
+    inputSchema: { itemId },
+    annotations: { readOnlyHint: false, destructiveHint: true },
+    run: (client, { itemId: id }) => client.del(`/api/items/${id}`),
+  }),
+  define({
+    name: 'sync_now',
+    title: 'Sync with GitHub and Azure DevOps',
+    description:
+      'Pulls fresh items from GitHub and Azure DevOps. Read-only against both: Ariadne never writes back to either.',
+    inputSchema: {},
+    annotations: WRITES,
+    run: (client) => client.post('/api/sync'),
+  }),
+
+  // --------------------------------------------------------- plan writes
+  define({
+    name: 'set_plan',
+    title: "Set a day's capacity and note",
+    description: "Creates or updates a day's plan: how many minutes are available, plus an optional note.",
+    inputSchema: {
+      date: isoDate,
+      capacityMinutes: z.number().int().min(0),
+      note: z.string().nullable().optional(),
+    },
+    annotations: WRITES,
+    run: (client, { date, capacityMinutes, note }) =>
+      client.post('/api/plan', body({ date, capacityMinutes, note })),
+  }),
+  define({
+    name: 'add_plan_item',
+    title: "Add an item to a day's plan",
+    description:
+      "Lower-level counterpart to add_to_today: adds plan membership without setting the item's own today date. Prefer add_to_today.",
+    inputSchema: { date: isoDate, itemId },
+    annotations: WRITES,
+    run: (client, { date, itemId: id }) => client.post('/api/plan/items', { date, itemId: id }),
+  }),
+  define({
+    name: 'remove_plan_item',
+    title: "Remove an item from a day's plan",
+    description: "Removes plan membership for one item on one day. Prefer remove_from_today.",
+    inputSchema: { date: isoDate, itemId },
+    annotations: WRITES,
+    run: (client, { date, itemId: id }) =>
+      client.del(`/api/plan/items${query({ date, itemId: id })}`),
+  }),
+  define({
+    name: 'reorder_plan_items',
+    title: "Reorder a day's plan",
+    description:
+      "Sets the hand-picked order of a day's plan. List every item id already on that day: ids you leave out keep their old positions and can end up colliding with the new ones. Call get_plan first to see the current membership.",
+    inputSchema: { date: isoDate, orderedItemIds: z.array(z.number().int()) },
+    annotations: WRITES,
+    run: (client, { date, orderedItemIds }) =>
+      client.put('/api/plan/items/reorder', { date, orderedItemIds }),
+  }),
+  define({
+    name: 'set_plan_item_estimate',
+    title: 'Estimate a planned item',
+    description: 'Sets how many minutes an item on a given day is expected to take.',
+    inputSchema: { date: isoDate, itemId, minutes: z.number().int().min(0) },
+    annotations: WRITES,
+    run: (client, { date, itemId: id, minutes }) =>
+      client.post('/api/plan/items/estimate', { date, itemId: id, minutes }),
+  }),
+
+  // --------------------------------------------------- saved view writes
+  define({
+    name: 'create_saved_view',
+    title: 'Save a dashboard view',
+    description: 'Saves a search query as a named view, optionally bound to a keyboard shortcut.',
+    inputSchema: {
+      label: z.string().min(1),
+      query: z.string().min(1).describe('A dashboard search query'),
+      shortcut: z.string().nullable().optional(),
+    },
+    annotations: WRITES,
+    run: (client, { label, query: q, shortcut }) =>
+      client.post('/api/saved-views', body({ label, query: q, shortcut })),
+  }),
+  define({
+    name: 'reorder_saved_views',
+    title: 'Reorder saved views',
+    description:
+      'Sets the display order of the saved views. This replaces the whole list, so any saved view whose id you leave out is deleted. Call list_saved_views first and pass every id back.',
+    inputSchema: { orderedIds: z.array(z.string()) },
+    annotations: WRITES,
+    run: (client, { orderedIds }) => client.put('/api/saved-views', { orderedIds }),
+  }),
+  define({
+    name: 'delete_saved_view',
+    title: 'Delete a saved view',
+    description: 'Removes a saved view. The items it matched are untouched.',
+    inputSchema: { id: z.string().min(1) },
+    annotations: WRITES,
+    run: (client, { id }) => client.del(`/api/saved-views${query({ id })}`),
+  }),
+];
+
+export function toolByName(name: string): ToolDefinition | undefined {
+  return TOOLS.find((tool) => tool.name === name);
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": ".",
+    "declaration": false,
+    "sourceMap": false,
+    "incremental": false,
+    "lib": ["esnext"],
+    "plugins": [],
+    // node16 rather than the app's bundler resolution: this output is run
+    // straight by node, so it needs real CommonJS emit and exports-map
+    // resolution instead of something a bundler would finish for it.
+    "module": "node16",
+    "moduleResolution": "node16"
+  },
+  "include": ["*.ts"],
+  "exclude": ["dist", "*.test.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.4.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@radix-ui/react-accordion": "^1.2.15",
         "@radix-ui/react-dialog": "^1.1.18",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
@@ -628,6 +629,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@hookform/resolvers": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
@@ -752,9 +765,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -770,9 +780,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -790,9 +797,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -808,9 +812,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -828,9 +829,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -846,9 +844,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -866,9 +861,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -885,9 +877,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -903,9 +892,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -929,9 +915,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -953,9 +936,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -979,9 +959,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1003,9 +980,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1029,9 +1003,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1054,9 +1025,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1078,9 +1046,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1232,6 +1197,55 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.23",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.23.tgz",
@@ -1277,9 +1291,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1295,9 +1306,6 @@
       "integrity": "sha512-W/6qKk7UG93mg14PmQC+2urt69MIdwTBLNQ6MJyeC4wOCIHCjz+VfgssvS1pK7mgYBtLC1g6VKNoHD9xB0WWGg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1315,9 +1323,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1333,9 +1338,6 @@
       "integrity": "sha512-qppK/3dTGOTI+aoWWBZc3DshFIhrzgL8guATlaN9V6M1QJxbkP/rhEZ22tdICsQ/2WWXopMZ2Jokzj2u3uKY3Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4605,6 +4607,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -4654,6 +4669,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -4873,6 +4921,30 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -4947,6 +5019,15 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4954,6 +5035,35 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -5386,11 +5496,23 @@
         "proto-list": "~1.2.1"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/content-type": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
       "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5473,12 +5595,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.2",
@@ -5530,7 +5687,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -5699,7 +5855,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5749,6 +5904,15 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/detect-libc": {
@@ -5818,6 +5982,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -5861,6 +6039,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.384",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
@@ -5880,6 +6064,15 @@
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -5936,10 +6129,31 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -5991,6 +6205,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -6013,10 +6233,40 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -6049,6 +6299,77 @@
         "node": ">=6"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+      "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fast-check": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
@@ -6071,6 +6392,12 @@
       "engines": {
         "node": ">=12.17.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
     },
     "node_modules/fast-equals": {
       "version": "5.4.1",
@@ -6105,6 +6432,22 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -6144,6 +6487,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -6189,6 +6553,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -6200,6 +6573,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -6288,12 +6670,49 @@
         "node": "*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
       "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -6339,6 +6758,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6377,6 +6808,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -6396,6 +6839,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hook-std": {
@@ -6422,6 +6874,26 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -6461,6 +6933,22 @@
       "dev": true,
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -6578,6 +7066,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6670,6 +7176,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -6705,8 +7217,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/issue-parser": {
       "version": "7.0.2",
@@ -6741,6 +7252,15 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6784,6 +7304,18 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-with-bigint": {
       "version": "3.5.11",
@@ -7039,11 +7571,45 @@
         "marked": ">=1 <16"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7092,6 +7658,31 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -7151,8 +7742,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -7186,6 +7776,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -9285,6 +9891,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9511,6 +10141,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -9525,7 +10164,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -9534,6 +10172,16 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -9590,6 +10238,15 @@
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-conf": {
@@ -9659,6 +10316,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9904,6 +10562,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-agent-negotiate": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
@@ -9948,6 +10619,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9966,6 +10653,34 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -10328,6 +11043,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -10411,6 +11135,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10451,6 +11191,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -10697,6 +11443,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.35.3",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
@@ -10751,7 +11548,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -10763,9 +11559,80 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -11034,6 +11901,15 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -11579,6 +12455,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/traverse": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
@@ -11643,6 +12528,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {
@@ -11750,6 +12653,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -11845,6 +12757,15 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/victory-vendor": {
@@ -12025,7 +12946,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -12265,6 +13185,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev -H 127.0.0.1",
-    "build": "next build",
+    "build": "tsc -p mcp && next build",
+    "mcp:build": "tsc -p mcp",
     "start": "next start -H 127.0.0.1",
     "test": "vitest run",
     "test:e2e": "playwright test",
@@ -16,6 +17,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.4.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-dialog": "^1.1.18",
     "@radix-ui/react-dropdown-menu": "^2.1.24",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "mcp/dist"]
 }


### PR DESCRIPTION
Closes #64.

Adds an MCP server at `mcp/` so an assistant can read the dashboard and move items through it. 35 tools, each mapping to exactly one existing API route.

## Shape

- `mcp/client.ts` talks to the running app over HTTP. Not a direct SQLite reader: the routes hold orchestration the tables do not, and a second writer on the database file is worth avoiding.
- `mcp/tools.ts` is the registry, as data. One tool per route, with Zod input schemas and read-only / destructive annotations.
- `mcp/server.ts` wires the registry onto an `McpServer`. Separate from the entrypoint so tests can drive it over an in-memory transport.
- `mcp/index.ts` is the stdio entrypoint. Nothing goes to stdout but JSON-RPC.

`tsc -p mcp` is folded into `npm run build`, emitting CommonJS to `mcp/dist`. Compiled rather than run through `tsx` or `npm run` because stdout purity is a correctness property here: one stray line from a wrapper corrupts the stream. It also means the Docker image already carries a built server, which is what makes #65 cheap.

## Keeping it inside the philosophy

Ariadne is not supposed to take action the user did not trigger, so:

- **Narrow verbs only.** One tool, one route. No `triage_my_day`, no `auto_complete_stale`.
- **No silent guesses.** `complete_item` requires an explicit `durationHours`, so the duration gets asked for rather than invented.

Read-only-to-GitHub-and-ADO is untouched, local-only is untouched, nothing new is stored.

**Not exposed:** `POST /api/settings`, which writes arbitrary key/value pairs including the PATs (reading works and stays redacted), and `POST /api/items/:id/open-claude`, which spawns Claude in a terminal.

**No committed `.mcp.json`.** It would prompt every contributor who opens the repo to approve a server that mutates their own task database, and relying on one would mean the documented install path never gets exercised. It is gitignored instead, with the `claude mcp add` one-liner in the README.

## Testing

77 new Vitest tests, per CONTRIBUTING:

- `client.test.ts` builds requests, Basic auth, error surfacing, and the "is Ariadne running" message
- `tools.test.ts` maps every tool to its method, path and body, and sweeps the registry to assert no write tool touches `/api/settings` and that read-only annotations match actual behaviour
- `server.test.ts` drives a real MCP client and server over a linked in-memory transport, so the protocol is exercised rather than mocked
- `config.test.ts` covers env resolution

Also verified by hand end to end against a live Ariadne on a throwaway database, driving the compiled server as a real subprocess over stdio: create, add to today, start, running timer, complete with hours, today's summary showing the logged time, report, undo, park, snooze, redacted settings, and both schema rejection paths.

All five CI gates pass locally: `npm test` (498), `npx tsc --noEmit`, `npm run build`, `npm run test:e2e` (13), `npm audit --omit=dev --audit-level=high`.

## Found on the way

That manual round trip turned up a pre-existing bug, filed as #66: deleting an item with logged time or plan membership fails on a foreign key and the dashboard silently swallows it. Not fixed here, since it is an app bug rather than MCP scope and deserves its own `fix:` commit. `delete_item`'s tool description already tells the caller that logged time blocks a delete, which stays true after #66 lands.

Two tool descriptions also call out sharp edges in existing routes rather than papering over them: `reorder_saved_views` replaces the whole list, so an omitted id deletes that view, and `reorder_plan_items` leaves omitted items on stale sort orders.

## Follow-up

#65 covers distribution. As it stands only people running Ariadne from a checkout can use this, since Docker users may have neither a checkout nor Node. Required, not optional.
