### PR TITLE
fix(items): refuse to delete an item with logged time instead of failing silently

### DIFF
--- a/app/api/items/[id]/route.test.ts
+++ b/app/api/items/[id]/route.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { openDb } from '@/lib/db';
 import { createAdhocItem, getItemById } from '@/lib/items-repo';
+import { startTimer, completeTimer } from '@/lib/time-logs-repo';
+import { addPlanItem, getPlanItems } from '@/lib/plans-repo';
 
 const testDb = openDb(':memory:');
 vi.mock('@/lib/db-instance', () => ({ db: testDb }));
@@ -10,16 +12,52 @@ const { DELETE: deleteRoute } = await import('./route');
 let itemId: number;
 
 beforeEach(() => {
-  testDb.exec('DELETE FROM items; DELETE FROM time_logs;');
+  testDb.exec('DELETE FROM plan_items; DELETE FROM item_links; DELETE FROM time_logs; DELETE FROM items;');
   itemId = createAdhocItem(testDb, { title: 'Test item' }).id;
 });
 
+const del = (id: number) =>
+  deleteRoute(new Request('http://localhost', { method: 'DELETE' }), {
+    params: Promise.resolve({ id: String(id) }),
+  });
+
 describe('DELETE /api/items/[id]', () => {
   it('deletes the item', async () => {
-    const res = await deleteRoute(new Request('http://localhost', { method: 'DELETE' }), {
-      params: Promise.resolve({ id: String(itemId) }),
-    });
+    const res = await del(itemId);
+
     expect(res.status).toBe(200);
     expect(getItemById(testDb, itemId)).toBeUndefined();
+  });
+
+  it("deletes an item that is on a day's plan, and its plan membership with it", async () => {
+    addPlanItem(testDb, '2026-08-31', itemId);
+
+    const res = await del(itemId);
+
+    expect(res.status).toBe(200);
+    expect(getItemById(testDb, itemId)).toBeUndefined();
+    expect(getPlanItems(testDb, '2026-08-31')).toEqual([]);
+  });
+
+  it('refuses an item with logged time with a 400, not a 500', async () => {
+    startTimer(testDb, itemId);
+    completeTimer(testDb, itemId, { durationHours: 1.5 });
+
+    const res = await del(itemId);
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: 'This item has logged time and cannot be deleted. Park it instead.',
+    });
+    expect(getItemById(testDb, itemId)).toBeDefined();
+  });
+
+  it('refuses an item whose timer is still running', async () => {
+    startTimer(testDb, itemId);
+
+    const res = await del(itemId);
+
+    expect(res.status).toBe(400);
+    expect(getItemById(testDb, itemId)).toBeDefined();
   });
 });

--- a/app/api/items/[id]/route.ts
+++ b/app/api/items/[id]/route.ts
@@ -1,10 +1,19 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
-import { deleteItem } from '@/lib/items-repo';
+import { deleteItem, ItemHasLoggedTimeError } from '@/lib/items-repo';
 
 export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = await params;
   const id = Number(idParam);
-  deleteItem(db, id);
+  try {
+    deleteItem(db, id);
+  } catch (error) {
+    // Logged time is history the time report is built on, so this is a
+    // refusal the caller should show, not a server fault.
+    if (error instanceof ItemHasLoggedTimeError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
+  }
   return NextResponse.json({ ok: true });
 }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -329,8 +329,9 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
   }
 
   async function handleDelete(id: number) {
-    await deleteAdhocItem(id);
+    const result = await deleteAdhocItem(id);
     await refresh();
+    if (result.error) toast(result.error);
   }
 
   useEffect(() => {

--- a/e2e/delete-refusal.spec.ts
+++ b/e2e/delete-refusal.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { createItem, ensureNoRunningTimer } from './helpers';
+
+test('deleting an item with logged time is refused with an explanation, not silently ignored', async ({
+  page,
+  request,
+}) => {
+  await ensureNoRunningTimer(request);
+  const title = `Delete refusal test ${Date.now()}`;
+  const itemId = await createItem(request, title);
+
+  await page.goto('/');
+  const row = page.locator(`[data-row-id="${itemId}"]`);
+  await row.waitFor();
+
+  // Starting it opens a time log, which is the history a delete must not
+  // quietly discard.
+  await row.getByRole('button', { name: /^Start$/ }).click();
+  await expect(page.getByRole('button', { name: 'Pause timer' })).toBeVisible();
+
+  await row.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name: /Delete/ }).click();
+  await page.getByRole('button', { name: /^Delete$/ }).click();
+
+  await expect(page.getByText(/logged time and cannot be deleted/i)).toBeVisible();
+  await expect(row).toBeVisible();
+
+  await ensureNoRunningTimer(request);
+});
+
+test('deleting an untouched ad-hoc item still works', async ({ page, request }) => {
+  await ensureNoRunningTimer(request);
+  const title = `Delete clean test ${Date.now()}`;
+  const itemId = await createItem(request, title);
+
+  await page.goto('/');
+  const row = page.locator(`[data-row-id="${itemId}"]`);
+  await row.waitFor();
+
+  await row.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name: /Delete/ }).click();
+  await page.getByRole('button', { name: /^Delete$/ }).click();
+
+  await expect(row).toBeHidden();
+});

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -134,8 +134,13 @@ export async function createAdhocItemRequest(input: { title: string; category?: 
   await fetch('/api/items', { method: 'POST', body: JSON.stringify(input) });
 }
 
-export async function deleteAdhocItem(id: number) {
-  await fetch(`/api/items/${id}`, { method: 'DELETE' });
+export async function deleteAdhocItem(id: number): Promise<{ error?: string }> {
+  const res = await fetch(`/api/items/${id}`, { method: 'DELETE' });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    return { error: body.error ?? 'Could not delete this item.' };
+  }
+  return {};
 }
 
 export async function fetchTimeReport(start: string, end: string): Promise<TimeReport> {

--- a/lib/items-repo.test.ts
+++ b/lib/items-repo.test.ts
@@ -15,7 +15,11 @@ import {
   deleteItem,
   getOpenGithubPrCandidates,
   setPrStatus,
+  ItemHasLoggedTimeError,
 } from './items-repo';
+import { addPlanItem, getPlanItems } from './plans-repo';
+import { startTimer, completeTimer, listLogsByItem } from './time-logs-repo';
+import { getLinksForItems } from './links-repo';
 
 let db: Database.Database;
 
@@ -346,11 +350,93 @@ describe('createAdhocItem', () => {
   });
 });
 
+/**
+ * Asserts the refusal is deliberate. A bare toThrow() would also be satisfied
+ * by the raw SQLITE_CONSTRAINT_FOREIGNKEY this fix exists to replace.
+ */
+function expectLoggedTimeRefusal(deleting: () => void): void {
+  let caught: unknown;
+  try {
+    deleting();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(ItemHasLoggedTimeError);
+  expect((caught as Error).message).toMatch(/park it instead/i);
+  expect((caught as Error).message).not.toMatch(/FOREIGN KEY/i);
+}
+
 describe('deleteItem', () => {
   it('removes the item', () => {
     const item = createAdhocItem(db, { title: 'Test' });
     deleteItem(db, item.id);
     expect(getItemById(db, item.id)).toBeUndefined();
+  });
+
+  it("removes the item's plan membership along with it", () => {
+    const item = createAdhocItem(db, { title: 'Planned then deleted' });
+    addPlanItem(db, '2026-08-31', item.id);
+
+    deleteItem(db, item.id);
+
+    expect(getItemById(db, item.id)).toBeUndefined();
+    expect(getPlanItems(db, '2026-08-31')).toEqual([]);
+  });
+
+  it("removes the item's links along with it", () => {
+    const pr = upsertSyncedItem(db, {
+      source: 'github_pr',
+      externalId: 'gh-linked',
+      title: 'PR with a linked work item',
+      url: null,
+      reason: 'authored',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: null,
+      repo: 'acme/app',
+      linkedAdoExternalIds: ['1234'],
+    });
+    expect(getLinksForItems(db, [pr]).get(pr.id)).toHaveLength(1);
+
+    deleteItem(db, pr.id);
+
+    expect(getItemById(db, pr.id)).toBeUndefined();
+  });
+
+  it('refuses to delete an item with logged time, rather than rewriting the time report', () => {
+    const item = createAdhocItem(db, { title: 'Timed then deleted' });
+    startTimer(db, item.id);
+    completeTimer(db, item.id, { durationHours: 1.5 });
+
+    expectLoggedTimeRefusal(() => deleteItem(db, item.id));
+    expect(getItemById(db, item.id)).toBeDefined();
+    expect(listLogsByItem(db, item.id)).toHaveLength(1);
+  });
+
+  it('tells the caller to park the item instead', () => {
+    const item = createAdhocItem(db, { title: 'Timed then deleted' });
+    startTimer(db, item.id);
+    completeTimer(db, item.id, { durationHours: 0.25 });
+
+    expect(() => deleteItem(db, item.id)).toThrow(/park it instead/i);
+  });
+
+  it('refuses while a timer is still running, before any duration is logged', () => {
+    const item = createAdhocItem(db, { title: 'Running right now' });
+    startTimer(db, item.id);
+
+    expectLoggedTimeRefusal(() => deleteItem(db, item.id));
+    expect(getItemById(db, item.id)).toBeDefined();
+  });
+
+  it('leaves plan membership intact when the delete is refused', () => {
+    const item = createAdhocItem(db, { title: 'Planned and timed' });
+    addPlanItem(db, '2026-08-31', item.id);
+    startTimer(db, item.id);
+    completeTimer(db, item.id, { durationHours: 1 });
+
+    expectLoggedTimeRefusal(() => deleteItem(db, item.id));
+    expect(getPlanItems(db, '2026-08-31')).toHaveLength(1);
   });
 });
 

--- a/lib/items-repo.ts
+++ b/lib/items-repo.ts
@@ -148,6 +148,40 @@ export function setPrStatus(db: Database.Database, id: number, prStatus: Item['p
   db.prepare('UPDATE items SET pr_status = ? WHERE id = ?').run(prStatus, id);
 }
 
+/**
+ * Thrown instead of letting the delete hit a FOREIGN KEY constraint, so the
+ * caller gets something it can act on and show.
+ */
+export class ItemHasLoggedTimeError extends Error {
+  readonly itemId: number;
+  readonly logCount: number;
+
+  constructor(itemId: number, logCount: number) {
+    super('This item has logged time and cannot be deleted. Park it instead.');
+    this.name = 'ItemHasLoggedTimeError';
+    this.itemId = itemId;
+    this.logCount = logCount;
+  }
+}
+
+/**
+ * Three tables reference items(id) and foreign_keys is ON, so a bare delete
+ * fails for any item that has ever been timed or planned.
+ *
+ * plan_items and item_links carry no history worth keeping, so they go with
+ * the item. time_logs does: the time report is built on it, and deleting an
+ * item should not quietly rewrite what you have already reported. An item with
+ * logged time is refused, and parking covers that case instead.
+ */
 export function deleteItem(db: Database.Database, id: number): void {
-  db.prepare('DELETE FROM items WHERE id = ?').run(id);
+  const { count } = db
+    .prepare('SELECT COUNT(*) AS count FROM time_logs WHERE item_id = ?')
+    .get(id) as { count: number };
+  if (count > 0) throw new ItemHasLoggedTimeError(id, count);
+
+  db.transaction(() => {
+    db.prepare('DELETE FROM plan_items WHERE item_id = ?').run(id);
+    db.prepare('DELETE FROM item_links WHERE pr_item_id = ?').run(id);
+    db.prepare('DELETE FROM items WHERE id = ?').run(id);
+  })();
 }


### PR DESCRIPTION
Closes #66.

Deleting an ad-hoc item that had ever been timed or planned did nothing, and the dashboard gave no sign of it. Found while testing the MCP server in #64.

## The bug

Three tables reference `items(id)` and `lib/db.ts:149` sets `foreign_keys = ON`, so the bare delete in `deleteItem` threw and the route 500d:

```
SqliteError: FOREIGN KEY constraint failed
    at deleteItem (lib/items-repo.ts:152:48)
```

`deleteAdhocItem` never checked `res.ok`, so `Dashboard.tsx` awaited it, carried on, and a failed delete was indistinguishable from a no-op.

## The fix

Split the dependents by whether they are history:

- **`plan_items` and `item_links`** carry none, so they go with the item, in one transaction.
- **`time_logs`** does. The time report is built on it, and a delete should not quietly rewrite what you have already reported. An item with logged time throws `ItemHasLoggedTimeError`, the route turns that into a 400, and the dashboard toasts the message, which points at Park instead.

Park already existed for exactly this case, so the refusal has somewhere to send you.

`deleteAdhocItem` now returns `{ error?: string }`, matching the shape `openInClaude` already uses, and `handleDelete` toasts it the same way `handleOpenClaude` does.

## Testing

- 6 new cases on `deleteItem`: plan membership and links cascade, logged time refuses, a running timer refuses before any duration exists, and a refused delete leaves plan membership intact.
- 4 on the route: a clean delete, a delete with plan membership, and both refusal paths asserting 400 with the message rather than a 500.
- A Playwright spec covering both halves: the refusal shows an explanation and the row survives, and an untouched ad-hoc item still deletes.

One note on the unit tests. A bare `toThrow(ItemHasLoggedTimeError)` passed against the *unfixed* code, because the import resolved to `undefined` and the raw foreign-key error satisfied it. The tests now assert the error's identity and message, and explicitly that it does not mention `FOREIGN KEY`, so they only pass for the real fix. Verified all six failing first.

All gates pass locally: `npm test` (507), `npx tsc --noEmit`, `npm run build`, `npm run test:e2e` (15), `npm audit --omit=dev --audit-level=high`.

## Not covered

The Delete menu item is still offered on an item with logged time, and the refusal only arrives after confirming. Disabling it up front would mean knowing the log count per row, which the dashboard payload does not carry today. The toast seemed the honest stopping point rather than growing the payload for it.