### PR TITLE
fix(saved-views): refuse a partial reorder instead of deleting the views left out

### DIFF
--- a/app/api/saved-views/route.test.ts
+++ b/app/api/saved-views/route.test.ts
@@ -61,4 +61,32 @@ describe('/api/saved-views', () => {
     ).json();
     expect(reordered.map((v: { id: string }) => v.id)).toEqual([idB, idA]);
   });
+  it('refuses a reorder that leaves a view out, with a 400 rather than deleting it', async () => {
+    const add = (label: string, query: string) =>
+      POST(
+        new Request('http://localhost/api/saved-views', {
+          method: 'POST',
+          body: JSON.stringify({ label, query, shortcut: null }),
+        })
+      );
+    await add('A', 'is:starred');
+    await add('B', 'is:snoozed');
+    const all = await (await add('C', 'is:parked')).json();
+    const ids = all.map((v: { id: string }) => v.id);
+
+    const res = await PUT(
+      new Request('http://localhost/api/saved-views', {
+        method: 'PUT',
+        body: JSON.stringify({ orderedIds: [ids[1], ids[0]] }),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/every saved view/i);
+    expect(body.error).toContain(ids[2]);
+
+    const stillThere = await (await GET()).json();
+    expect(stillThere.map((v: { id: string }) => v.id)).toEqual(ids);
+  });
 });

--- a/app/api/saved-views/route.ts
+++ b/app/api/saved-views/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
-import { getSavedViews, addSavedView, removeSavedView, reorderSavedViews } from '@/lib/saved-views';
+import {
+  getSavedViews,
+  addSavedView,
+  removeSavedView,
+  reorderSavedViews,
+  SavedViewOrderMismatchError,
+} from '@/lib/saved-views';
 
 export async function GET() {
   return NextResponse.json(getSavedViews(db));
@@ -18,5 +24,14 @@ export async function DELETE(request: Request) {
 
 export async function PUT(request: Request) {
   const { orderedIds } = await request.json();
-  return NextResponse.json(reorderSavedViews(db, orderedIds));
+  try {
+    return NextResponse.json(reorderSavedViews(db, orderedIds));
+  } catch (error) {
+    // A partial list used to delete every view it left out. Refusing is the
+    // caller's problem to fix, not a server fault.
+    if (error instanceof SavedViewOrderMismatchError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
+  }
 }

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -98,11 +98,6 @@ export async function deleteSavedView(id: string) {
   return res.json();
 }
 
-export async function reorderSavedViewsRequest(orderedIds: string[]) {
-  const res = await fetch('/api/saved-views', { method: 'PUT', body: JSON.stringify({ orderedIds }) });
-  return res.json();
-}
-
 export async function fetchTodaySummary(): Promise<TodaySummaryResponse> {
   const res = await fetch('/api/today/summary');
   return res.json();

--- a/lib/saved-views.test.ts
+++ b/lib/saved-views.test.ts
@@ -43,4 +43,67 @@ describe('saved views', () => {
     const reordered = reorderSavedViews(db, [idB, idA]);
     expect(reordered.map((v) => v.id)).toEqual([idB, idA]);
   });
+
+  describe('reorderSavedViews refuses a list that is not the stored set', () => {
+    function threeViews(): string[] {
+      addSavedView(db, { label: 'A', query: 'is:starred', shortcut: '1' });
+      addSavedView(db, { label: 'B', query: 'is:snoozed', shortcut: '2' });
+      const all = addSavedView(db, { label: 'C', query: 'is:parked', shortcut: '3' });
+      return all.map((v) => v.id);
+    }
+
+    it('does not delete the views left out of orderedIds', () => {
+      const [idA, idB, idC] = threeViews();
+
+      expect(() => reorderSavedViews(db, [idB, idA])).toThrow(/every saved view/i);
+
+      expect(getSavedViews(db).map((v) => v.id)).toEqual([idA, idB, idC]);
+    });
+
+    it('names the ids that were missing', () => {
+      const [idA, idB, idC] = threeViews();
+
+      expect(() => reorderSavedViews(db, [idB, idA])).toThrow(new RegExp(idC));
+    });
+
+    it('rejects an unknown id rather than silently dropping it', () => {
+      const [idA, idB, idC] = threeViews();
+
+      expect(() => reorderSavedViews(db, [idA, idB, idC, 'not-a-view'])).toThrow(/not-a-view/);
+
+      expect(getSavedViews(db)).toHaveLength(3);
+    });
+
+    it('rejects a duplicated id, which would otherwise drop a view', () => {
+      const [idA, idB] = threeViews();
+
+      expect(() => reorderSavedViews(db, [idA, idB, idB])).toThrow(/every saved view/i);
+
+      expect(getSavedViews(db)).toHaveLength(3);
+    });
+
+    it('names a duplicated id, even when nothing is missing', () => {
+      addSavedView(db, { label: 'A', query: 'is:starred', shortcut: '1' });
+      const all = addSavedView(db, { label: 'B', query: 'is:snoozed', shortcut: '2' });
+      const [idA, idB] = all.map((v) => v.id);
+
+      expect(() => reorderSavedViews(db, [idA, idB, idB])).toThrow(
+        new RegExp(`duplicated: ${idB}`),
+      );
+
+      expect(getSavedViews(db).map((v) => v.id)).toEqual([idA, idB]);
+    });
+
+    it('rejects an empty list when views exist', () => {
+      threeViews();
+
+      expect(() => reorderSavedViews(db, [])).toThrow(/every saved view/i);
+
+      expect(getSavedViews(db)).toHaveLength(3);
+    });
+
+    it('accepts an empty list when there is nothing stored', () => {
+      expect(reorderSavedViews(db, [])).toEqual([]);
+    });
+  });
 });

--- a/lib/saved-views.ts
+++ b/lib/saved-views.ts
@@ -47,10 +47,49 @@ export function removeSavedView(db: Database.Database, id: string): SavedView[] 
   return remaining;
 }
 
+/**
+ * Thrown rather than writing a shortened list. writeViews replaces the whole
+ * stored blob, so a partial orderedIds used to delete every view it left out.
+ * Deleting is removeSavedView's job, not this one's.
+ */
+export class SavedViewOrderMismatchError extends Error {
+  readonly unknownIds: string[];
+  readonly missingIds: string[];
+  readonly duplicatedIds: string[];
+
+  constructor(unknownIds: string[], missingIds: string[], duplicatedIds: string[]) {
+    const parts: string[] = [];
+    if (unknownIds.length > 0) parts.push(`unknown: ${unknownIds.join(', ')}`);
+    if (missingIds.length > 0) parts.push(`missing: ${missingIds.join(', ')}`);
+    if (duplicatedIds.length > 0) parts.push(`duplicated: ${duplicatedIds.join(', ')}`);
+    super(`orderedIds must list every saved view exactly once (${parts.join('; ')}).`);
+    this.name = 'SavedViewOrderMismatchError';
+    this.unknownIds = unknownIds;
+    this.missingIds = missingIds;
+    this.duplicatedIds = duplicatedIds;
+  }
+}
+
 export function reorderSavedViews(db: Database.Database, orderedIds: string[]): SavedView[] {
   const views = readViews(db);
   const byId = new Map(views.map((v) => [v.id, v]));
-  const reordered = orderedIds.map((id) => byId.get(id)).filter((v): v is SavedView => Boolean(v));
+  const requested = new Set(orderedIds);
+
+  const unknownIds = orderedIds.filter((id) => !byId.has(id));
+  const missingIds = views.filter((v) => !requested.has(v.id)).map((v) => v.id);
+  // A duplicate makes the list longer than the set, which would push a view
+  // off the end just as surely as omitting it.
+  const seen = new Set<string>();
+  const duplicatedIds = new Set<string>();
+  for (const id of orderedIds) {
+    if (seen.has(id) && byId.has(id)) duplicatedIds.add(id);
+    seen.add(id);
+  }
+  if (unknownIds.length > 0 || missingIds.length > 0 || duplicatedIds.size > 0) {
+    throw new SavedViewOrderMismatchError(unknownIds, missingIds, [...duplicatedIds]);
+  }
+
+  const reordered = orderedIds.map((id) => byId.get(id) as SavedView);
   writeViews(db, reordered);
   return reordered;
 }

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -384,7 +384,7 @@ export const TOOLS: readonly ToolDefinition[] = [
     name: 'reorder_saved_views',
     title: 'Reorder saved views',
     description:
-      'Sets the display order of the saved views. This replaces the whole list, so any saved view whose id you leave out is deleted. Call list_saved_views first and pass every id back.',
+      'Sets the display order of the saved views. Must list every saved view id exactly once: an incomplete or duplicated list is refused rather than applied. Call list_saved_views first and pass every id back. Use delete_saved_view to remove one.',
     inputSchema: { orderedIds: z.array(z.string()) },
     annotations: WRITES,
     run: (client, { orderedIds }) => client.put('/api/saved-views', { orderedIds }),


### PR DESCRIPTION
Closes #68.

## The bug

`reorderSavedViews` wrote its filtered result back over the whole stored blob:

```ts
const reordered = orderedIds.map((id) => byId.get(id)).filter((v): v is SavedView => Boolean(v));
writeViews(db, reordered);
```

So any saved view whose id was left out of `orderedIds` was deleted. Unknown ids were swallowed by the same `filter`, and a duplicated id pushed a view off the end. Nothing reported any of it, because the response returned exactly what had just been written and therefore looked correct.

## The fix

A function called "reorder" should not be able to delete. It now refuses unless `orderedIds` is exactly the stored set, naming what was wrong:

```
orderedIds must list every saved view exactly once (missing: abc-123).
```

`PUT /api/saved-views` turns that into a 400. `removeSavedView` stays the only way to remove a view.

I went with refusing rather than the softer append-the-omitted-views option, on the same reasoning as #66: it cannot lose data either, but it hides a stale caller instead of telling them, and a reorder that quietly half-applies is its own surprise.

## Why it matters now

Nothing in the UI called this route, so it had not bitten yet. The MCP server's `reorder_saved_views` is its first real caller, and an assistant working from a stale `list_saved_views` result is precisely the caller that passes an incomplete list. That tool's description warned about the old destructive behaviour; it now describes the refusal, since the warning would otherwise be wrong.

## Testing

7 new cases at the repo layer: an omitted id, the missing id being named, an unknown id, a duplicated id both with and without something also missing, an empty list when views exist, and an empty list when nothing is stored (which is legitimately a no-op). Plus a route case asserting 400, the message naming the dropped id, and all three views still present afterwards.

The duplicate-with-nothing-missing case earned its place. My first implementation used `!seen.add(id)`, and `Set.prototype.add` returns the Set, so the check never fired. The other duplicate test passed anyway because `missingIds` happened to catch that input. Only the narrower test caught the real defect.

All gates pass locally: `npm test` (506), `npx tsc --noEmit`, `npm run build`, `npm run test:e2e` (13), `npm audit --omit=dev --audit-level=high`.

## Also in here

`reorderSavedViewsRequest` is removed. It had no callers and ignored `res.ok`, which is the exact shape that made the delete bug in #66 invisible in the dashboard. Better gone than waiting to acquire a caller.