### PR TITLE
docs(mcp): document running the MCP server inside the app's container

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Without compose:
 
 ```bash
 docker build -t ariadne .
-docker run -d -p 127.0.0.1:3000:3000 -v $(pwd)/data:/data \
+docker run -d --name ariadne -p 127.0.0.1:3000:3000 -v $(pwd)/data:/data \
   -e ARIADNE_DB_PATH=/data/ariadne.db ariadne
 ```
 
@@ -139,6 +139,25 @@ Two optional environment variables:
 |---|---|---|
 | `ARIADNE_URL` | `http://127.0.0.1:3000` | Where Ariadne is listening |
 | `ARIADNE_AUTH_TOKEN` | unset | Same value as the app's, if you have exposed Ariadne beyond loopback |
+
+### Setup with Docker
+
+If you run Ariadne from the published image rather than a checkout, the
+server is already inside it: `npm run build` compiles it during the image
+build. Run it in the app's own container, so it reaches Ariadne on
+`127.0.0.1:3000` with no networking to configure:
+
+```bash
+claude mcp add --scope user ariadne -- docker exec -i ariadne node mcp/dist/index.js
+```
+
+That assumes the container is named `ariadne`, which `docker compose up`
+takes care of. If you started it by hand, add `--name ariadne` to your
+`docker run`, or substitute whatever `docker ps` shows.
+
+`docker exec` inherits the container's environment, so a setup that sets
+`ARIADNE_AUTH_TOKEN` needs nothing extra here: the server picks up the same
+value the app is using.
 
 ### What it can do
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   ariadne:
     build: .
+    # Named so `docker exec -i ariadne ...` works without looking up a
+    # generated name -- see the MCP section of the README.
+    container_name: ariadne
     ports:
       # Loopback-only by default. Change to "3000:3000" to reach Ariadne
       # from other devices on your network — but Ariadne has no login of its


### PR DESCRIPTION
Closes #65.

The MCP server from #64 was only usable from a checkout. Docker users may have neither a checkout nor Node, and the app package is `"private": true` with `npmPublish: false`, so there was no published artifact to point an MCP config at.

## There already is one

`tsc -p mcp` runs as part of `npm run build`, and the Dockerfile runs `npm run build`, so the published image already contains `mcp/dist`. Confirmed against a fresh image build:

```
$ docker run --rm ariadne ls mcp/dist
client.js  config.js  index.js  server.js  tools.js
```

So the answer is not a second entrypoint or an npm package. Run the server in the app's own container:

```bash
claude mcp add --scope user ariadne -- docker exec -i ariadne node mcp/dist/index.js
```

Because it runs beside the app, `127.0.0.1:3000` is already correct and there is no networking to configure, no second container, and no `host.docker.internal` or `--network host` divergence between Linux and Docker Desktop.

It also inherits the container's environment, so a setup with `ARIADNE_AUTH_TOKEN` needs nothing extra: the server picks up the same value the app is using.

## Changes

- `container_name: ariadne` in `docker-compose.yml`, and `--name ariadne` on the no-compose `docker run`, so the documented exec command works without looking up a generated name.
- A "Setup with Docker" subsection in the README's MCP section.

## Verification

Built the image and drove the server through `docker exec -i` as a real subprocess with a real MCP client:

```
✓ handshake: ariadne 1.4.0
✓ tools/list: 35 tools
✓ create_item / start_item / complete_item / get_today
```

Then repeated it with `ARIADNE_AUTH_TOKEN=sekrit` on the container: an outside `curl` got 401 while `list_items` through `docker exec` succeeded.

Also confirmed the documented command end to end via `docker compose up -d`, which produces a container named `ariadne` as intended.

No automated test for this. Exercising it in CI would mean building the image on every run, and the two things that could break it are already covered: `tsc -p mcp` is part of `npm run build`, and the MCP server has its own suite. Gates still pass locally: `npm test`, `npx tsc --noEmit`, `npm run build`, `npm run test:e2e` (13), `npm audit --omit=dev --audit-level=high`.

## Deliberately not done

**Publishing `mcp/` to npm.** #65 offered it as the alternative. It buys `npx ariadne-mcp` ergonomics but costs an `NPM_TOKEN` in CI, a package name to hold, a second semantic-release target, and a public API contract. Both install paths are now covered without it, so it stays a nicety for when someone actually asks.

**The version-skew guard** #65 also listed. Both paths co-locate the server with the app: the Docker path is literally the same image, and a checkout runs both from the same tree. Skew now requires deliberately pointing `ARIADNE_URL` at a different instance, and detecting it would mean adding a version endpoint for a case nobody hits by accident.