### PR TITLE
fix(mcp): report an empty read as null instead of "Done."

### DIFF
--- a/lib/dashboard.ts
+++ b/lib/dashboard.ts
@@ -57,10 +57,11 @@ export function getGroupedItems(db: Database.Database, now: Date): GroupedItems 
     .sort((a, b) => (sortOrderByItemId.get(a.id) ?? Infinity) - (sortOrderByItemId.get(b.id) ?? Infinity));
   const todayIds = new Set(today.map((i) => i.id));
 
-  // Sourced from plan_items rather than the `today` bucket above: starting or
-  // completing an item moves it out of that bucket (and start even clears
-  // today_date), but it's still part of what was planned for today, so its
-  // estimate and any hours logged against it must keep counting here.
+  // Sourced from plan_items rather than the `today` bucket above. The two
+  // usually agree, but plan membership is the thing that actually defines what
+  // was planned for today: an item removed from the bucket (today_date cleared)
+  // keeps its estimate and its logged hours counting here, which is what these
+  // totals are for.
   const todayPlannedMinutes = planItems.reduce((sum, pi) => sum + (pi.estimateMinutes ?? 0), 0);
   const todayLoggedMinutes = planItems.reduce(
     (sum, pi) => sum + Math.round((loggedTodayByItemId.get(pi.itemId) ?? 0) * 60),

--- a/mcp/server.test.ts
+++ b/mcp/server.test.ts
@@ -131,4 +131,29 @@ describe('createServer', () => {
     expect(result.isError).toBeFalsy();
     expect((result.content as { type: string; text: string }[])[0].text).toContain('recovered');
   });
+  it('reports an empty read as null rather than as "Done."', async () => {
+    // GET /api/timer/running answers `null` when nothing is running. Calling
+    // that "Done." tells the model an action succeeded instead of telling it
+    // the answer is "nothing".
+    const { client } = await connected(() => jsonOk(null));
+
+    const result = await client.callTool({ name: 'get_running_timer', arguments: {} });
+
+    const text = (result.content as { type: string; text: string }[])[0].text;
+    expect(text).toBe('null');
+    expect(text).not.toContain('Done');
+  });
+
+  it('still confirms a write that returns no body', async () => {
+    // DELETE /api/plan/items answers 204 with an empty body, where "Done." is
+    // the useful thing to say.
+    const { client } = await connected(() => new Response(null, { status: 204 }));
+
+    const result = await client.callTool({
+      name: 'remove_plan_item',
+      arguments: { date: '2026-08-31', itemId: 1 },
+    });
+
+    expect((result.content as { type: string; text: string }[])[0].text).toBe('Done.');
+  });
 });

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -5,7 +5,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { AriadneClient } from './client';
-import { TOOLS } from './tools';
+import { TOOLS, type ToolDefinition } from './tools';
 
 export const SERVER_NAME = 'ariadne';
 
@@ -38,7 +38,7 @@ export function createServer(client: AriadneClient, version = '0.0.0'): McpServe
       async (args: unknown) => {
         try {
           const result = await tool.run(client, args as Record<string, unknown>);
-          return { content: [{ type: 'text' as const, text: format(result) }] };
+          return { content: [{ type: 'text' as const, text: format(result, tool) }] };
         } catch (error) {
           // Returned rather than thrown: a 400 from Ariadne is a fact the model
           // should read and act on, not a transport failure that kills the call.
@@ -54,8 +54,13 @@ export function createServer(client: AriadneClient, version = '0.0.0'): McpServe
   return server;
 }
 
-function format(result: unknown): string {
-  if (result === null || result === undefined) return 'Done.';
+function format(result: unknown, tool: ToolDefinition): string {
+  // An empty read is an answer, not a confirmation: GET /api/timer/running
+  // returns null when nothing is running, and saying "Done." there would tell
+  // the model an action succeeded rather than that the answer is "nothing".
+  if (result === null || result === undefined) {
+    return tool.annotations.readOnlyHint ? 'null' : 'Done.';
+  }
   return JSON.stringify(result, null, 2);
 }
 


### PR DESCRIPTION
Two things found while walking a new skill through the MCP tool sequence against a live Ariadne.

## The bug

`GET /api/timer/running` answers `null` when no timer is running. The formatter in `mcp/server.ts` turned any null result into `"Done."`:

```ts
if (result === null || result === undefined) return 'Done.';
```

So `get_running_timer` with nothing running reported a successful action instead of the answer, which is "nothing". A caller could not tell "no timer" from "did a thing", and the natural next step from "Done." is to assume a timer exists.

Now an empty result renders as `null` for read-only tools and stays `"Done."` for writes, where a 204 with no body genuinely means the confirmation is the useful part. The distinction comes off the `readOnlyHint` annotation the registry already carries.

## Also in here: a stale comment that caused a real error

`getGroupedItems` claimed:

> starting or completing an item moves it out of that bucket (and start even clears `today_date`)

Neither half holds. `setStatus` deliberately leaves `today_date` alone, with its own comment saying so, and the `today` filter tests `todayDate` with no status condition. It describes the behaviour that the 2026-08-18 bucket decision replaced.

This is not a hypothetical: I wrote a skill instruction based on that comment, and only caught it because the end-to-end run disagreed. The comment's conclusion (source the plan totals from `plan_items`) is still right, so only the premise is rewritten.

## Testing

Two cases on the formatter: a read returning null renders as `null` and must not contain "Done", and a write answering 204 still renders "Done.". Both verified failing first.

Worth noting the second test initially failed for the wrong reason. `new Response('', { status: 204 })` throws, because a 204 cannot carry a body, and the client's catch-all reported that as "Cannot reach Ariadne". The test now passes `null`. The catch-all staying broad is fine in production, where the client only ever builds well-formed requests, but it is worth knowing it can mask a programming error that way.

Gates: `npm test` (517), `npx tsc --noEmit`, `npm run build`, `npm run test:e2e` (15), `npm audit --omit=dev --audit-level=high`.