### PR TITLE
feat(dashboard): explain and list what "waiting on you" counts

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -50,8 +50,8 @@ import {
   fetchTodaySummaryFor,
   fetchCalibration,
 } from '@/lib/api-client';
-import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
-import { groupOf } from '@/lib/grouping';
+import { isSnoozed, SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
+import { needsYou } from '@/lib/grouping';
 import { localDateString, addDays } from '@/lib/date';
 import { DEFAULT_CAPACITY_MINUTES } from '@/lib/config';
 import type { CalibrationEntry } from '@/lib/calibration';
@@ -373,7 +373,13 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, data]);
 
-  const needsYouCount = data.signals.filter((i) => groupOf(i) === 'blocked' || groupOf(i) === 'waiting_on_you').length;
+  // Filtered the same way SignalsBoard filters before it counts: a snoozed or
+  // triaged-done signal is not on the plate, so counting it here would make
+  // the header disagree with the Signals sub-heading and list rows you cannot
+  // find below.
+  const needsYouItems = data.signals.filter(
+    (i) => i.triageState !== 'done' && !isSnoozed(i.snoozedUntil, new Date()) && needsYou(i)
+  );
   const SOURCE_STATUS_TO_ITEM_SOURCE: Record<SourceStatus['source'], Item['source']> = {
     github: 'github_pr',
     ado: 'ado_workitem',
@@ -408,7 +414,8 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
       <SprintProgressHeader
         sprint={data.sprint}
         sourceStatuses={sourceStatuses}
-        needsYouCount={needsYouCount}
+        needsYouItems={needsYouItems}
+        onShowNeedsYouInSignals={() => setSignalsQuery('group:waiting,blocked')}
         onRefresh={handleRefresh}
         syncing={syncing}
         onAddClick={() => setQuickAddOpen(true)}

--- a/components/NeedsYouPopover.tsx
+++ b/components/NeedsYouPopover.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useId, useState } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { REASON_LABEL } from '@/lib/scoring';
+import { GROUP_LABEL, groupOf } from '@/lib/grouping';
+import type { ScoredItem } from '@/lib/dashboard';
+
+// A bare count is a number you have to trust. This names what the number
+// means in one line and then shows its working -- the same "a figure that
+// exists must be explainable" rule the score chip follows.
+const EXPLANATION = "The next move is yours on these, or they're blocked and need someone else to clear the way.";
+
+// Blocked rows say Blocked; the reason underneath ("Assigned to you") is not
+// the thing that put them in this count. Everything else is here because of
+// its reason, so the reason is the useful label.
+function labelFor(item: ScoredItem): string {
+  return groupOf(item) === 'blocked' ? GROUP_LABEL.blocked : REASON_LABEL[item.reason];
+}
+
+interface Props {
+  items: ScoredItem[];
+  onShowInSignals: () => void;
+}
+
+export default function NeedsYouPopover({ items, onShowInSignals }: Props) {
+  const [open, setOpen] = useState(false);
+  const titleId = useId();
+  const count = (
+    <>
+      <span className="font-mono tabular-nums">{items.length}</span> waiting on you
+    </>
+  );
+
+  // Nothing to explain and nothing to list at zero, so the stat stays plain
+  // text rather than offering an empty popover.
+  if (items.length === 0) return <span className="text-warning">{count}</span>;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="text-warning underline decoration-dotted underline-offset-2 hover:decoration-solid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+          aria-label={`${items.length} waiting on you, show which`}
+        >
+          {count}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent role="dialog" aria-labelledby={titleId} align="start" className="w-80">
+        <div className="space-y-2 text-sm">
+          <h2 id={titleId} className="font-medium">
+            {items.length} waiting on you
+          </h2>
+          <p className="text-xs text-muted-foreground">{EXPLANATION}</p>
+          <ul className="max-h-64 space-y-2 overflow-y-auto border-t pt-2">
+            {items.map((item) => (
+              <li key={item.id} className="min-w-0">
+                <p className="text-xs text-muted-foreground">{labelFor(item)}</p>
+                <p className="truncate">{item.title}</p>
+              </li>
+            ))}
+          </ul>
+          <div className="border-t pt-2">
+            <button
+              type="button"
+              className="text-xs text-primary underline-offset-2 hover:underline"
+              onClick={() => {
+                setOpen(false);
+                onShowInSignals();
+              }}
+            >
+              Show these in Signals →
+            </button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import ItemRow from './ItemRow';
 import QueryBar from './QueryBar';
-import { groupOf, isKeptVisible, GROUP_ORDER, GROUP_LABEL, type ObligationGroup } from '@/lib/grouping';
+import { groupOf, isKeptVisible, needsYou, GROUP_ORDER, GROUP_LABEL, type ObligationGroup } from '@/lib/grouping';
 import { parseQuery, applyQuery, withoutFilter } from '@/lib/query';
 import { isSnoozed, type SnoozeOption } from '@/lib/snooze';
 import { createSavedView, deleteSavedView } from '@/lib/api-client';
@@ -130,7 +130,7 @@ export default function SignalsBoard({
   );
 
   const needsYouCount = useMemo(
-    () => withoutHiddenTriage.filter((item) => groupOf(item) === 'blocked' || groupOf(item) === 'waiting_on_you').length,
+    () => withoutHiddenTriage.filter(needsYou).length,
     [withoutHiddenTriage]
   );
 

--- a/components/SprintProgressHeader.tsx
+++ b/components/SprintProgressHeader.tsx
@@ -6,14 +6,17 @@ import { Progress } from '@/components/ui/progress';
 import { formatRelativeTime } from '@/lib/utils';
 import { classifyError, type SourceStatus } from '@/lib/sync-status';
 import type { SprintProgress } from '@/lib/sprint';
+import type { ScoredItem } from '@/lib/dashboard';
+import NeedsYouPopover from './NeedsYouPopover';
 
 interface Props {
   sprint: SprintProgress;
   sourceStatuses: SourceStatus[];
-  needsYouCount: number;
+  needsYouItems: ScoredItem[];
   onRefresh: () => void;
   syncing: boolean;
   onAddClick: () => void;
+  onShowNeedsYouInSignals: () => void;
 }
 
 const SOURCE_LABEL: Record<SourceStatus['source'], string> = { github: 'GitHub', ado: 'Azure DevOps' };
@@ -45,7 +48,8 @@ function SourceChip({ status }: { status: SourceStatus }) {
 export default function SprintProgressHeader({
   sprint,
   sourceStatuses,
-  needsYouCount,
+  needsYouItems,
+  onShowNeedsYouInSignals,
   onRefresh,
   syncing,
   onAddClick,
@@ -91,9 +95,7 @@ export default function SprintProgressHeader({
               ''
             )}
             {' · '}
-            <span className="text-warning">
-              <span className="font-mono tabular-nums">{needsYouCount}</span> waiting on you
-            </span>
+            <NeedsYouPopover items={needsYouItems} onShowInSignals={onShowNeedsYouInSignals} />
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-3">

--- a/e2e/needs-you-popover.spec.ts
+++ b/e2e/needs-you-popover.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { seedNeedsYou } from './seed-needs-you';
+
+test('the waiting-on-you stat explains itself and lists exactly what it counts', async ({ page, request }) => {
+  const { waitingTitle, snoozedId, snoozedTitle, movingTitle } = seedNeedsYou('popover');
+  await request.post(`/api/items/${snoozedId}/snooze`, { data: { option: 'next_week' } });
+
+  await page.goto('/');
+
+  const trigger = page.getByRole('button', { name: /waiting on you, show which$/ });
+  await expect(trigger).toBeVisible();
+  const count = Number((await trigger.innerText()).match(/\d+/)?.[0]);
+  expect(count).toBeGreaterThan(0);
+
+  await trigger.click();
+  const popover = page.getByRole('dialog', { name: /waiting on you$/ });
+  await expect(popover).toBeVisible();
+  await expect(popover).toContainText('The next move is yours on these');
+
+  // The number and the list are the same set: every counted item is listed,
+  // and nothing is listed that isn't counted.
+  await expect(popover.locator('li')).toHaveCount(count);
+
+  await expect(popover).toContainText(waitingTitle);
+  await expect(popover).toContainText('Review requested');
+  // Snoozed and non-needs-you items are counted by neither the header nor
+  // the Signals sub-heading, so they must not appear here either.
+  await expect(popover).not.toContainText(snoozedTitle);
+  await expect(popover).not.toContainText(movingTitle);
+
+  await popover.getByRole('button', { name: /Show these in Signals/ }).click();
+  await expect(popover).toBeHidden();
+  await expect(page.locator('#query-bar-input')).toHaveValue('group:waiting,blocked');
+  await expect(page.getByText(waitingTitle)).toBeVisible();
+  await expect(page.getByText(movingTitle)).toHaveCount(0);
+});

--- a/e2e/seed-needs-you.ts
+++ b/e2e/seed-needs-you.ts
@@ -1,0 +1,64 @@
+import { openDb } from '../lib/db';
+import { upsertSyncedItem } from '../lib/items-repo';
+import { E2E_DB_PATH } from './db-path';
+
+// The needs-you count only fires on synced reasons (review_requested,
+// mention, approved_unmerged) or a blocked ADO state, none of which the
+// ad-hoc create API can produce -- an ad-hoc item is always `manual`, i.e.
+// lower priority. Seed straight into the sqlite file the dev server under
+// test points at, the same way seed-links.ts does.
+export function seedNeedsYou(suffix: string): {
+  waitingId: number;
+  waitingTitle: string;
+  snoozedId: number;
+  snoozedTitle: string;
+  movingId: number;
+  movingTitle: string;
+} {
+  const db = openDb(E2E_DB_PATH);
+  try {
+    const base = `${Date.now()}${suffix}`;
+    const waitingTitle = `Needs-you review requested ${suffix}`;
+    const snoozedTitle = `Needs-you but snoozed ${suffix}`;
+    const movingTitle = `Needs-you excluded authored ${suffix}`;
+
+    const common = {
+      source: 'github_pr' as const,
+      url: 'https://example.test/pr',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: new Date().toISOString(),
+      repo: null,
+    };
+
+    const waiting = upsertSyncedItem(db, {
+      ...common,
+      externalId: `${base}@waiting`,
+      title: waitingTitle,
+      reason: 'review_requested',
+    });
+    const snoozed = upsertSyncedItem(db, {
+      ...common,
+      externalId: `${base}@snoozed`,
+      title: snoozedTitle,
+      reason: 'review_requested',
+    });
+    const moving = upsertSyncedItem(db, {
+      ...common,
+      externalId: `${base}@moving`,
+      title: movingTitle,
+      reason: 'authored',
+    });
+
+    return {
+      waitingId: waiting.id,
+      waitingTitle,
+      snoozedId: snoozed.id,
+      snoozedTitle,
+      movingId: moving.id,
+      movingTitle,
+    };
+  } finally {
+    db.close();
+  }
+}

--- a/lib/grouping.test.ts
+++ b/lib/grouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupOf, isKeptVisible, GROUP_ORDER } from './grouping';
+import { groupOf, isKeptVisible, needsYou, GROUP_ORDER } from './grouping';
 import type { Reason } from './types';
 
 const ALL_REASONS: Reason[] = [
@@ -43,6 +43,32 @@ describe('groupOf', () => {
 
   it('a non-blocked ADO state does not trigger the blocked group', () => {
     expect(groupOf(item({ source: 'ado_workitem', adoStatus: 'In Progress', reason: 'assigned' }))).toBe('lower_priority');
+  });
+});
+
+describe('needsYou', () => {
+  it('is true for every waiting_on_you reason', () => {
+    expect(needsYou(item({ reason: 'review_requested' }))).toBe(true);
+    expect(needsYou(item({ reason: 'mention' }))).toBe(true);
+    expect(needsYou(item({ reason: 'approved_unmerged' }))).toBe(true);
+  });
+
+  it('is true for a blocked item, whatever its reason', () => {
+    expect(needsYou(item({ source: 'ado_workitem', adoStatus: 'Blocked', reason: 'assigned' }))).toBe(true);
+  });
+
+  it('is false for moving_without_you and lower_priority', () => {
+    expect(needsYou(item({ reason: 'stale_own_pr' }))).toBe(false);
+    expect(needsYou(item({ reason: 'authored' }))).toBe(false);
+    expect(needsYou(item({ reason: 'assigned' }))).toBe(false);
+    expect(needsYou(item({ reason: 'manual' }))).toBe(false);
+  });
+
+  it('agrees with groupOf for every reason', () => {
+    for (const reason of ALL_REASONS) {
+      const group = groupOf(item({ reason }));
+      expect(needsYou(item({ reason }))).toBe(group === 'waiting_on_you' || group === 'blocked');
+    }
   });
 });
 

--- a/lib/grouping.ts
+++ b/lib/grouping.ts
@@ -43,6 +43,15 @@ export function groupOf(item: Pick<Item, 'source' | 'adoStatus' | 'reason'>): Ob
   return 'lower_priority';
 }
 
+// The header stat and the Signals sub-heading both count "needs something
+// from you", and they must never disagree -- one predicate so there is only
+// one definition. Blocked is included: the next move is not yours, but
+// getting someone to make it is.
+export function needsYou(item: Pick<Item, 'source' | 'adoStatus' | 'reason'>): boolean {
+  const group = groupOf(item);
+  return group === 'waiting_on_you' || group === 'blocked';
+}
+
 // Ad-hoc items always render, even below the score threshold that used to
 // gate the old "Needs attention" section -- this says which rows are only
 // visible because of that exemption, so the UI can name it (score-chip


### PR DESCRIPTION
Closes #74

The sprint header ended with a bare `N waiting on you` — no indication of what put an item in that count, and no way to find out which items it meant.

## What changed

The stat is now a popover trigger, following the `ScoreChip` pattern already used for the urgency score:

- **One line saying what it means** — "The next move is yours on these, or they're blocked and need someone else to clear the way."
- **The items**, in urgency order, each labelled with the reason that put it there: Review requested, Mentioned you, Ready to merge, or Blocked.
- **`Show these in Signals →`** sets the Signals query to `group:waiting,blocked`, the same set, in the list where you can act on it.

At a count of 0 the stat stays plain text with no trigger — nothing to list.

## The count fix

`Dashboard.tsx` counted **all** signals; `SignalsBoard.tsx` counted the same predicate *after* dropping snoozed and triage-done items. The header could read 8 while Signals read 6, and a popover built on the old count would have listed rows you could not find below.

`needsYou()` now lives in `lib/grouping.ts` and both call sites use it, with the header applying the same snoozed / triage-done filter. The header number, the Signals sub-heading, and the popover list are the same set by construction.

Worth flagging: **the header number will drop** for anyone currently holding snoozed review requests. That is the correction landing, not a regression.

## Verification

- `needsYou()` unit tests in `lib/grouping.test.ts`, including a totality check that it agrees with `groupOf()` for every `Reason`.
- New e2e spec `e2e/needs-you-popover.spec.ts`: asserts the popover's row count equals the trigger's number, that a waiting-on-you item is listed with its reason, that a snoozed one and a `moving_without_you` one are not, and that the footer action filters the query bar.
- `tsc --noEmit` clean, 521 unit tests pass, 16/16 e2e pass, `npm run build` succeeds.
- Opened in the running app to check the render: reason labels, urgency ordering, and the scroll cut past ~5 rows.