### PR TITLE
feat(scoring): give ad-hoc items a starting priority

### DIFF
--- a/app/api/items/[id]/priority/route.test.ts
+++ b/app/api/items/[id]/priority/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openDb } from '@/lib/db';
+import { createAdhocItem, upsertSyncedItem } from '@/lib/items-repo';
+
+const testDb = openDb(':memory:');
+vi.mock('@/lib/db-instance', () => ({ db: testDb }));
+
+const { POST } = await import('./route');
+
+beforeEach(() => {
+  testDb.exec('DELETE FROM items;');
+});
+
+function post(id: number, priority: unknown) {
+  return POST(
+    new Request('http://localhost/api/items/1/priority', {
+      method: 'POST',
+      body: JSON.stringify({ priority }),
+    }),
+    { params: Promise.resolve({ id: String(id) }) }
+  );
+}
+
+describe('POST /api/items/:id/priority', () => {
+  it('sets a priority on an ad-hoc item and returns the updated row', async () => {
+    const item = createAdhocItem(testDb, { title: 'Weigh me' });
+    const res = await post(item.id, 'high');
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.priority).toBe('high');
+    expect(body.prioritySetAt).not.toBeNull();
+  });
+
+  it('clears a priority when given null', async () => {
+    const item = createAdhocItem(testDb, { title: 'Never mind', priority: 'high' });
+    const body = await (await post(item.id, null)).json();
+    expect(body.priority).toBeNull();
+    expect(body.prioritySetAt).toBeNull();
+  });
+
+  it('rejects a value outside the scale', async () => {
+    const item = createAdhocItem(testDb, { title: 'Nope' });
+    const res = await post(item.id, 'urgent');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/low, medium, high/);
+  });
+
+  // The refusal has to carry prose, not just a status code: an MCP client
+  // shows the message to the model, and the row menu shows it in a toast.
+  it('refuses a synced item with a message explaining why', async () => {
+    const pr = upsertSyncedItem(testDb, {
+      source: 'github_pr',
+      externalId: 'gh-route-1',
+      title: 'A PR',
+      url: null,
+      reason: 'authored',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: null,
+      repo: 'x/y',
+    });
+    const res = await post(pr.id, 'high');
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/Only ad-hoc items/);
+  });
+});

--- a/app/api/items/[id]/priority/route.ts
+++ b/app/api/items/[id]/priority/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { setPriority, getItemById, PriorityNotAllowedError } from '@/lib/items-repo';
+import type { Priority } from '@/lib/types';
+
+const VALID: Priority[] = ['low', 'medium', 'high'];
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const id = Number(idParam);
+  const { priority } = (await request.json()) as { priority: Priority | null };
+
+  if (priority !== null && !VALID.includes(priority)) {
+    return NextResponse.json({ error: 'priority must be low, medium, high, or null' }, { status: 400 });
+  }
+
+  try {
+    setPriority(db, id, priority);
+  } catch (error) {
+    // A synced row refusing a priority is a rule the caller should show, not
+    // a server fault -- the message names the reason so an MCP client or a
+    // menu can repeat it verbatim.
+    if (error instanceof PriorityNotAllowedError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    throw error;
+  }
+  return NextResponse.json(getItemById(db, id));
+}

--- a/app/api/items/route.test.ts
+++ b/app/api/items/route.test.ts
@@ -46,3 +46,30 @@ describe('POST /api/items', () => {
     expect(body.source).toBe('adhoc');
   });
 });
+
+describe('POST /api/items with a priority', () => {
+  it('stores a starting priority and stamps when it was set', async () => {
+    const res = await POST(
+      new Request('http://localhost/api/items', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Someone asked at my desk', priority: 'high' }),
+      })
+    );
+    const body = await res.json();
+    expect(res.status).toBe(201);
+    expect(body.priority).toBe('high');
+    expect(body.prioritySetAt).not.toBeNull();
+  });
+
+  it('leaves the priority unset when none is given', async () => {
+    const res = await POST(
+      new Request('http://localhost/api/items', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Just record it' }),
+      })
+    );
+    const body = await res.json();
+    expect(body.priority).toBeNull();
+    expect(body.prioritySetAt).toBeNull();
+  });
+});

--- a/app/api/items/route.ts
+++ b/app/api/items/route.ts
@@ -2,13 +2,19 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db-instance';
 import { createAdhocItem } from '@/lib/items-repo';
 import { getGroupedItems } from '@/lib/dashboard';
+import type { Priority } from '@/lib/types';
 
 export async function GET() {
   return NextResponse.json(getGroupedItems(db, new Date()));
 }
 
 export async function POST(request: Request) {
-  const body = (await request.json()) as { title: string; category?: string; dueDate?: string };
+  const body = (await request.json()) as {
+    title: string;
+    category?: string;
+    dueDate?: string;
+    priority?: Priority | null;
+  };
   const item = createAdhocItem(db, body);
   return NextResponse.json(item, { status: 201 });
 }

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -26,6 +26,7 @@ interface Props {
   onWrapUp: () => void;
   onOpenScoringReference: () => void;
   onOpenHelp: () => void;
+  onQuickAdd: () => void;
 }
 
 const QUERY_PREFIXES = ['source:', 'group:', 'state:', 'score:', 'repo:', 'sprint:', 'is:', 'stale:', 'reason:'];
@@ -44,6 +45,7 @@ export default function CommandPalette({
   onWrapUp,
   onOpenScoringReference,
   onOpenHelp,
+  onQuickAdd,
 }: Props) {
   const isQueryToken = QUERY_PREFIXES.some((p) => search.startsWith(p));
   const matchingItems =
@@ -104,6 +106,12 @@ export default function CommandPalette({
           </CommandItem>
           <CommandItem value="go-keyboard-shortcuts" onSelect={() => select(onOpenHelp)}>
             Keyboard shortcuts
+          </CommandItem>
+        </CommandGroup>
+        <CommandGroup heading="Actions">
+          <CommandItem value="add-adhoc-item" onSelect={() => select(onQuickAdd)}>
+            Add an ad-hoc item
+            <span className="ml-auto font-mono text-xs text-muted-foreground">a</span>
           </CommandItem>
         </CommandGroup>
         <CommandGroup heading="Rituals">

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -37,6 +37,7 @@ import {
   pinToday,
   unpinToday,
   starItem,
+  setItemPriority,
   snoozeItem,
   unsnoozeItem,
   setItemDone,
@@ -59,7 +60,7 @@ import type { ScoredItem } from '@/lib/dashboard';
 import type { SprintProgress } from '@/lib/sprint';
 import type { SavedView } from '@/lib/saved-views';
 import type { SourceStatus } from '@/lib/sync-status';
-import type { Item, Plan, PlanItem } from '@/lib/types';
+import type { Item, Plan, PlanItem, Priority } from '@/lib/types';
 
 const AUTO_SYNC_INTERVAL_MS = 5 * 60 * 1000;
 
@@ -284,6 +285,18 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
     await refresh();
   }
 
+  async function handleSetPriority(id: number, priority: Priority | null) {
+    try {
+      await setItemPriority(id, priority);
+    } catch (error) {
+      // The refusal on a synced row carries its own wording, so show that
+      // rather than a generic failure.
+      toast(error instanceof Error ? error.message : 'Could not set the priority.');
+      return;
+    }
+    await refresh();
+  }
+
   async function handleSnooze(id: number, option: SnoozeOption) {
     await snoozeItem(id, option);
     await refresh();
@@ -323,7 +336,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
     }
   }
 
-  async function handleQuickAdd(input: { title: string; category?: string; dueDate?: string }) {
+  async function handleQuickAdd(input: { title: string; dueDate?: string; priority?: Priority | null }) {
     await createAdhocItemRequest(input);
     await refresh();
   }
@@ -409,6 +422,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
       onGoToDashboard={() => router.push('/')}
       onGoToSettings={() => router.push('/settings')}
       onPlanDay={() => setPlanDayOpen(true)}
+      onQuickAdd={() => setQuickAddOpen(true)}
     >
     <main className="mx-auto max-w-6xl space-y-6 p-6">
       <SprintProgressHeader
@@ -438,6 +452,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
             onPark={handlePark}
             onUnpark={handleUnpark}
             onUnpinToday={handleUnpinToday}
+            onSetPriority={handleSetPriority}
             onPlanDay={() => setPlanDayOpen(true)}
             onReorder={handleReorderToday}
             failingSources={failingSources}
@@ -458,6 +473,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
                   onRequeue={handleRequeue}
                   onPark={handlePark}
                   onUnpark={handleUnpark}
+                  onSetPriority={handleSetPriority}
                   failingSources={failingSources}
                   onOpenScoringReference={() => setScoringReferenceOpen(true)}
                 />
@@ -473,6 +489,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
             onPinToday={handlePinToday}
             failingSources={failingSources}
             onStar={handleStar}
+            onSetPriority={handleSetPriority}
             onSnooze={handleSnooze}
             onUnsnooze={handleUnsnooze}
             onDone={handleDone}
@@ -539,6 +556,7 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
         onWrapUp={() => setReviewDayOpen(true)}
         onOpenScoringReference={() => setScoringReferenceOpen(true)}
         onOpenHelp={() => setHelpOpen(true)}
+        onQuickAdd={() => setQuickAddOpen(true)}
       />
     </main>
     </GlobalKeymapProvider>

--- a/components/GlobalKeymapProvider.tsx
+++ b/components/GlobalKeymapProvider.tsx
@@ -14,6 +14,7 @@ interface Props {
   onGoToDashboard: () => void;
   onGoToSettings: () => void;
   onPlanDay: () => void;
+  onQuickAdd: () => void;
 }
 
 export default function GlobalKeymapProvider({
@@ -27,6 +28,7 @@ export default function GlobalKeymapProvider({
   onGoToDashboard,
   onGoToSettings,
   onPlanDay,
+  onQuickAdd,
 }: Props) {
   useEffect(() => {
     let pendingG = false;
@@ -71,6 +73,13 @@ export default function GlobalKeymapProvider({
       }
 
       switch (e.key.toLowerCase()) {
+        case 'a':
+          // Capture is the one thing that has to work while someone is
+          // standing at your desk, so it gets a single letter and opens a
+          // form that focuses its own first field.
+          e.preventDefault();
+          onQuickAdd();
+          return;
         case '/':
           e.preventDefault();
           onFocusQueryBar();
@@ -111,6 +120,7 @@ export default function GlobalKeymapProvider({
     onGoToDashboard,
     onGoToSettings,
     onPlanDay,
+    onQuickAdd,
   ]);
 
   return <>{children}</>;

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -12,6 +12,7 @@ import {
   Pause,
   Play,
   MoreHorizontal,
+  Flag,
   Pin,
   Star,
   Clock,
@@ -36,14 +37,27 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn, formatRelativeTime } from '@/lib/utils';
-import { REASON_LABEL, MAX_SCORE, TIER_LABEL, getPriorityTier, type ScoreBreakdownEntry } from '@/lib/scoring';
+import {
+  REASON_LABEL,
+  BAND_LABEL,
+  canCarryPriority,
+  getUrgencyBand,
+  maxScoreFor,
+  PRIORITY_LABEL,
+  PRIORITY_ORDER,
+  priorityPoints,
+  type ScoreBreakdownEntry,
+} from '@/lib/scoring';
 import { getStatusPill, type BadgeVariant } from '@/lib/status-pill';
 import { isKeptVisible } from '@/lib/grouping';
 import { matchesQuery } from '@/lib/search';
-import type { Item, Status } from '@/lib/types';
+import type { Item, Priority, Status } from '@/lib/types';
 import type { LinkedRef } from '@/lib/links-repo';
 import { useSearch } from '@/components/SearchProvider';
 import { useDensity } from '@/components/DensityProvider';
@@ -52,6 +66,15 @@ import type { Density } from '@/lib/config';
 import ScoreChip from './ScoreChip';
 import { settledOutcome } from '@/lib/settled';
 import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
+
+// The order the `p` row binding walks. Unset lands on high first, so one
+// keystroke does the thing a user actually wants from a priority key.
+const PRIORITY_CYCLE: (Priority | null)[] = ['high', 'medium', 'low', null];
+
+function nextPriority(current: Priority | null): Priority | null {
+  const i = PRIORITY_CYCLE.indexOf(current);
+  return PRIORITY_CYCLE[(i + 1) % PRIORITY_CYCLE.length];
+}
 
 // Row height is fixed per mode so content can never reflow it — comfortable
 // is 44px (11 * 4px grid), compact is 36px (9 * 4px grid). Only applied from
@@ -143,6 +166,7 @@ interface Props {
   onSnooze?: (id: number, option: SnoozeOption) => void;
   onUnsnooze?: (id: number) => void;
   onDone?: (id: number, done: boolean) => void;
+  onSetPriority?: (id: number, priority: Priority | null) => void;
   sourceIsStale?: boolean;
   onOpenScoringReference: () => void;
   // Today shows a parked item at full detail (score chip, Complete button,
@@ -223,6 +247,7 @@ function OverflowMenu({
   onOpenSnooze,
   onUnsnooze,
   onDone,
+  onSetPriority,
   snoozed,
   density,
 }: {
@@ -239,6 +264,7 @@ function OverflowMenu({
   onOpenSnooze?: () => void;
   onUnsnooze?: (id: number) => void;
   onDone?: (id: number, done: boolean) => void;
+  onSetPriority?: (id: number, priority: Priority | null) => void;
   snoozed: boolean;
   density: Density;
 }) {
@@ -318,6 +344,46 @@ function OverflowMenu({
             <Play aria-hidden="true" /> Resume
           </DropdownMenuItem>
         )}
+        {/* Rendered on every row, including the ones that cannot have a
+            priority. An item that is silently missing teaches nothing; a
+            disabled one with its reason attached teaches the read-only
+            commitment at the moment the user reaches for it. */}
+        {onSetPriority && !canCarryPriority(item.source) && (
+          <DropdownMenuItem disabled>
+            <Flag aria-hidden="true" />
+            <span className="flex-1">Priority</span>
+            <span className="text-xs text-muted-foreground">ad-hoc only</span>
+          </DropdownMenuItem>
+        )}
+        {onSetPriority && canCarryPriority(item.source) && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Flag aria-hidden="true" />
+              <span className="flex-1">Priority</span>
+              <kbd className="mr-1 font-mono text-xs text-muted-foreground">f</kbd>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {/* The current value is marked here rather than shown on the
+                  trigger, so the trigger keeps the shortcut hint its siblings
+                  all carry. */}
+              {PRIORITY_ORDER.map((priority) => (
+                <DropdownMenuItem key={priority} onSelect={() => onSetPriority(item.id, priority)}>
+                  <Check
+                    aria-hidden="true"
+                    className={item.priority === priority ? undefined : 'invisible'}
+                  />
+                  <span className="flex-1">{PRIORITY_LABEL[priority]}</span>
+                  <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+                    +{priorityPoints(priority)}
+                  </span>
+                </DropdownMenuItem>
+              ))}
+              {item.priority && (
+                <DropdownMenuItem onSelect={() => onSetPriority(item.id, null)}>Clear</DropdownMenuItem>
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        )}
         <DropdownMenuItem onSelect={onOpenClaude}>
           <Bot aria-hidden="true" /> Open in Claude
         </DropdownMenuItem>
@@ -329,6 +395,7 @@ function OverflowMenu({
         {(onStar || onOpenSnooze || onDone) && (
           <div className="border-t px-2 py-1.5 text-xs text-muted-foreground">
             Starred, snoozed and done are local. Ariadne never changes anything in GitHub or Azure DevOps.
+            {onSetPriority && canCarryPriority(item.source) && ' Priority is local too, but it does change the score.'}
           </div>
         )}
       </DropdownMenuContent>
@@ -370,6 +437,7 @@ export default function ItemRow({
   onSnooze,
   onUnsnooze,
   onDone,
+  onSetPriority,
   sourceIsStale,
   onOpenScoringReference,
   fullDetailWhenParked = false,
@@ -494,6 +562,12 @@ export default function ItemRow({
         return;
       case 'd':
         onDone?.(item.id, item.triageState !== 'done');
+        return;
+      case 'f':
+        // high -> medium -> low -> unset -> high. Starts at high because the
+        // reason to reach for this key is almost always to raise something;
+        // stepping down and clearing are the rarer follow-ups.
+        if (onSetPriority && canCarryPriority(item.source)) onSetPriority(item.id, nextPriority(item.priority));
         return;
       case 't':
         if (item.todayDate) onUnpinToday?.(item.id);
@@ -768,8 +842,8 @@ export default function ItemRow({
     item.status === 'done' ? 'done' : null,
     settled === 'finished' ? 'done at the source' : null,
     settled === 'gone' ? 'gone from the source' : null,
-    `${TIER_LABEL[getPriorityTier(item.score)]} priority`,
-    `score ${item.score} of ${MAX_SCORE}`,
+    `${BAND_LABEL[getUrgencyBand(item.score)]} priority`,
+    `score ${item.score} of ${maxScoreFor(item.source)}`,
     inlineBadge?.label,
   ]
     .filter(Boolean)
@@ -794,6 +868,7 @@ export default function ItemRow({
     >
       <div className="flex w-full min-w-0 items-center gap-3 sm:w-auto">
         <ScoreChip
+          source={item.source}
           score={item.score}
           scoreBreakdown={item.scoreBreakdown ?? []}
           notFired={item.notFired ?? []}
@@ -907,6 +982,7 @@ export default function ItemRow({
           onOpenSnooze={onSnooze ? () => setSnoozeDialogOpen(true) : undefined}
           onUnsnooze={onUnsnooze}
           onDone={onDone}
+          onSetPriority={onSetPriority}
           snoozed={Boolean(item.snoozedUntil)}
           density={density}
         />

--- a/components/ItemSection.tsx
+++ b/components/ItemSection.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import ItemRow from './ItemRow';
 import type { ScoredItem } from '@/lib/dashboard';
-import type { Source } from '@/lib/types';
+import type { Source, Priority } from '@/lib/types';
 
 interface Props {
   value: string;
@@ -16,6 +16,7 @@ interface Props {
   onComplete: (id: number, durationHours: number, note?: string) => void;
   onOpenClaude: (id: number, workingDir?: string) => void;
   onDelete?: (id: number) => void;
+  onSetPriority?: (id: number, priority: Priority | null) => void;
   onRequeue?: (id: number) => void;
   onPark?: (id: number) => void;
   onUnpark?: (id: number) => void;
@@ -35,6 +36,7 @@ export default function ItemSection({
   onComplete,
   onOpenClaude,
   onDelete,
+  onSetPriority,
   onRequeue,
   onPark,
   onUnpark,
@@ -68,6 +70,7 @@ export default function ItemSection({
                 onComplete={onComplete}
                 onOpenClaude={onOpenClaude}
                 onDelete={onDelete}
+                    onSetPriority={onSetPriority}
                 onRequeue={onRequeue}
                 onPark={onPark}
                 onUnpark={onUnpark}
@@ -97,6 +100,7 @@ export default function ItemSection({
                         onComplete={onComplete}
                         onOpenClaude={onOpenClaude}
                         onDelete={onDelete}
+                    onSetPriority={onSetPriority}
                         onRequeue={onRequeue}
                         onUnpark={onUnpark}
                         onOpenScoringReference={onOpenScoringReference}

--- a/components/PlanDayDialog.tsx
+++ b/components/PlanDayDialog.tsx
@@ -143,6 +143,7 @@ export default function PlanDayDialog({
                       <div key={item.id} className="flex items-center justify-between gap-2 py-1 text-sm">
                         <span className="flex min-w-0 items-center gap-2">
                           <ScoreChip
+                            source={item.source}
                             score={item.score}
                             scoreBreakdown={item.scoreBreakdown}
                             notFired={item.notFired}

--- a/components/PrioritySegments.tsx
+++ b/components/PrioritySegments.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useRef } from 'react';
+import { cn } from '@/lib/utils';
+import { PRIORITY_LABEL, PRIORITY_ORDER, priorityPoints } from '@/lib/scoring';
+import type { Priority } from '@/lib/types';
+
+// Ordered low -> high for the control, the opposite of PRIORITY_ORDER (which
+// is high-first because the reference dialog lists the biggest number at the
+// top). Reading left-to-right as increasing weight is what a person expects
+// from a scale.
+const SEGMENTS: Priority[] = [...PRIORITY_ORDER].reverse();
+
+interface Props {
+  value: Priority | null;
+  onChange: (value: Priority | null) => void;
+  labelledBy?: string;
+  disabled?: boolean;
+}
+
+/**
+ * A three-value scale rendered as an instrument, not a colour code.
+ *
+ * Deliberately monochrome: the score chip owns the urgency colour channel,
+ * and a red/amber/grey control here would read as a fifth urgency band and
+ * break the Two-Band Rule in DESIGN.md. The weight of each option is carried
+ * by its point contribution in the mono/tabular register instead, which also
+ * means the control teaches the formula the first time you use it rather
+ * than asking you to remember what "high" is worth.
+ *
+ * One tab stop, arrow keys to move, per the radiogroup pattern -- three
+ * separate tab stops in the middle of a capture form is the kind of thing
+ * that makes a keyboard user stop using the form.
+ */
+export default function PrioritySegments({ value, onChange, labelledBy, disabled }: Props) {
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // With nothing selected the first segment holds the tab stop, so the group
+  // is always reachable in exactly one Tab press.
+  const focusIndex = value ? SEGMENTS.indexOf(value) : 0;
+
+  function move(delta: number) {
+    const next = (focusIndex + delta + SEGMENTS.length) % SEGMENTS.length;
+    onChange(SEGMENTS[next]);
+    refs.current[next]?.focus();
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-labelledby={labelledBy}
+      className={cn(
+        'inline-flex h-9 overflow-hidden rounded-md border border-input',
+        disabled && 'pointer-events-none opacity-50'
+      )}
+      onKeyDown={(e) => {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+          e.preventDefault();
+          move(1);
+        } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+          e.preventDefault();
+          move(-1);
+        }
+      }}
+    >
+      {SEGMENTS.map((priority, i) => {
+        const selected = value === priority;
+        return (
+          <button
+            key={priority}
+            ref={(el) => {
+              refs.current[i] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            tabIndex={i === focusIndex ? 0 : -1}
+            disabled={disabled}
+            // Clicking the selected segment clears it. Without this there is
+            // no way back to "I haven't decided", which is a real state and
+            // the one every item starts in.
+            onClick={() => onChange(selected ? null : priority)}
+            className={cn(
+              'flex items-baseline gap-1.5 px-3 text-sm transition-colors',
+              'border-r border-input last:border-r-0',
+              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset',
+              // The selected state has to be readable at a glance without
+              // reaching for a new colour: the urgency channel belongs to the
+              // score chip. So the gap is widened with weight and dimming
+              // instead -- Surface Raised fill, Ink text at semibold, against
+              // deliberately quieter unselected segments.
+              selected
+                ? 'bg-accent font-semibold text-accent-foreground'
+                : 'text-muted-foreground/80 hover:text-foreground'
+            )}
+          >
+            <span>{PRIORITY_LABEL[priority]}</span>
+            <span className={cn('font-mono text-[11px] tabular-nums', selected ? 'opacity-100' : 'opacity-60')}>
+              +{priorityPoints(priority)}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/QuickAddForm.tsx
+++ b/components/QuickAddForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useId } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -7,11 +8,13 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import PrioritySegments from '@/components/PrioritySegments';
+import type { Priority } from '@/lib/types';
 
 const quickAddSchema = z.object({
   title: z.string().min(1, 'Title is required'),
-  category: z.string().optional(),
   dueDate: z.string().optional(),
+  priority: z.enum(['low', 'medium', 'high']).nullable(),
 });
 
 type QuickAddValues = z.infer<typeof quickAddSchema>;
@@ -19,20 +22,32 @@ type QuickAddValues = z.infer<typeof quickAddSchema>;
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (input: { title: string; category?: string; dueDate?: string }) => void;
+  onSubmit: (input: { title: string; dueDate?: string; priority?: Priority | null }) => void;
 }
 
 // The closed-state trigger for this form lives in SprintProgressHeader's
 // ambient row (an icon-only button), not here — this component only ever
-// renders the open-state form itself, controlled from Dashboard.
+// renders the open-state form itself, controlled from Dashboard. It is also
+// opened by the global `a` binding (lib/keymap.ts), which is the path that
+// matters: capture happens while someone is standing at your desk.
+//
+// Category is deliberately absent. The column and the API field still exist
+// (the MCP create_item tool accepts one), but nothing in the app has ever
+// read it back -- not the row, not the score, not the query grammar -- so
+// asking for it at the one moment speed matters was a tax with no return.
 export default function QuickAddForm({ open, onOpenChange, onSubmit }: Props) {
+  const priorityLabelId = useId();
   const form = useForm<QuickAddValues>({
     resolver: zodResolver(quickAddSchema),
-    defaultValues: { title: '', category: '', dueDate: '' },
+    defaultValues: { title: '', dueDate: '', priority: null },
   });
 
   function handleSubmit(values: QuickAddValues) {
-    onSubmit({ title: values.title, category: values.category || undefined, dueDate: values.dueDate || undefined });
+    onSubmit({
+      title: values.title,
+      dueDate: values.dueDate || undefined,
+      priority: values.priority ?? null,
+    });
     form.reset();
     onOpenChange(false);
   }
@@ -43,7 +58,19 @@ export default function QuickAddForm({ open, onOpenChange, onSubmit }: Props) {
     <Card>
       <CardContent className="pt-6">
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-4"
+            // Submit from anywhere in the form, including from the priority
+            // segments, so the whole capture is one uninterrupted keyboard
+            // gesture: a, type, arrow, cmd-enter.
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                e.preventDefault();
+                void form.handleSubmit(handleSubmit)();
+              }
+            }}
+          >
             <FormField
               control={form.control}
               name="title"
@@ -51,40 +78,48 @@ export default function QuickAddForm({ open, onOpenChange, onSubmit }: Props) {
                 <FormItem>
                   <FormLabel>Title</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <Input autoFocus {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
-            <div className="flex gap-3">
-              <FormField
-                control={form.control}
-                name="category"
-                render={({ field }) => (
-                  <FormItem className="flex-1">
-                    <FormLabel>Category</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="dueDate"
-                render={({ field }) => (
-                  <FormItem className="flex-1">
-                    <FormLabel>Due date (optional)</FormLabel>
-                    <FormControl>
-                      <Input type="date" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+            <FormField
+              control={form.control}
+              name="dueDate"
+              render={({ field }) => (
+                <FormItem className="max-w-[12rem]">
+                  <FormLabel>Due date (optional)</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="priority"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel id={priorityLabelId}>Priority (optional)</FormLabel>
+                  <FormControl>
+                    <div>
+                      <PrioritySegments
+                        value={field.value}
+                        onChange={field.onChange}
+                        labelledBy={priorityLabelId}
+                      />
+                    </div>
+                  </FormControl>
+                  <p className="text-xs text-muted-foreground">
+                    Ad-hoc items have no review activity or staleness to earn points from, so this is how they
+                    earn a place in the ranking.
+                  </p>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
             <div className="flex gap-2">
               <Button type="submit">Add</Button>
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>

--- a/components/ScoreChip.tsx
+++ b/components/ScoreChip.tsx
@@ -4,15 +4,17 @@ import { useId } from 'react';
 import { Check, Minus } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
-import { getPriorityTier, MAX_SCORE, TIER_LABEL, type PriorityTier, type ScoreBreakdownEntry } from '@/lib/scoring';
+import { getUrgencyBand, maxScoreFor, BAND_LABEL, type UrgencyBand, type ScoreBreakdownEntry } from '@/lib/scoring';
+import { NEEDS_ATTENTION_THRESHOLD } from '@/lib/config';
 import type { SettledOutcome } from '@/lib/settled';
+import type { Source } from '@/lib/types';
 
 // Urgency bands per docs/wireframes/phase-0-foundation.html: only the top two
 // bands are filled, medium is an outline, low has no border at all -- visual
 // weight falls off in the same direction the score does. The two filled
 // bands use dark ink, never white (see the paired *-foreground tokens).
 // Indigo never appears here; that channel is interactive-only.
-const TIER_CHIP_CLASS: Record<PriorityTier, string> = {
+const BAND_CHIP_CLASS: Record<UrgencyBand, string> = {
   low: 'border border-urgency-low/40 bg-transparent text-muted-foreground',
   medium: 'border-2 border-urgency-medium bg-transparent text-foreground',
   high: 'border-transparent bg-urgency-high text-urgency-high-foreground',
@@ -49,6 +51,7 @@ const SETTLED_EXPLANATION: Record<SettledOutcome, string> = {
 };
 
 interface Props {
+  source: Source;
   score: number;
   scoreBreakdown: ScoreBreakdownEntry[];
   notFired: string[];
@@ -60,7 +63,20 @@ interface Props {
   children?: React.ReactNode;
 }
 
+function BreakdownRow({ entry }: { entry: ScoreBreakdownEntry }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span>
+        {entry.label}
+        {entry.detail && <span className="ml-1.5 text-xs text-muted-foreground">{entry.detail}</span>}
+      </span>
+      <span className="font-mono tabular-nums">+{entry.points}</span>
+    </div>
+  );
+}
+
 export default function ScoreChip({
+  source,
   score,
   scoreBreakdown,
   notFired,
@@ -71,9 +87,23 @@ export default function ScoreChip({
   onOpenScoringReference,
   children,
 }: Props) {
-  const tier = getPriorityTier(score);
+  const band = getUrgencyBand(score);
+  const maxScore = maxScoreFor(source);
   const titleId = useId();
   const SettledIcon = settled ? SETTLED_ICON[settled] : null;
+
+  // Split by provenance so a number the user asserted can never sit in the
+  // same list as one a source system reported. This is the whole reason a
+  // manual term is admissible in a formula that claims to be transparent:
+  // the claim is not "everything here is observed", it is "you can always
+  // see which half is which".
+  const reported = scoreBreakdown.filter((entry) => entry.provenance !== 'you');
+  const selfSet = scoreBreakdown.filter((entry) => entry.provenance === 'you');
+
+  // The ad-hoc exemption is what keeps a low-scoring ad-hoc row on screen.
+  // Earning your way past the threshold retires it, and that transition is
+  // invisible unless the popover says so -- the badge just disappears.
+  const clearedThresholdAlone = source === 'adhoc' && !keptVisible && score >= NEEDS_ATTENTION_THRESHOLD;
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
@@ -83,12 +113,12 @@ export default function ScoreChip({
           className={cn(
             'inline-flex h-5 min-w-[1.5rem] shrink-0 items-center justify-center rounded px-1 font-mono text-[11px] font-semibold tabular-nums',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-            settled ? SETTLED_CHIP_CLASS[settled] : TIER_CHIP_CLASS[tier]
+            settled ? SETTLED_CHIP_CLASS[settled] : BAND_CHIP_CLASS[band]
           )}
           aria-label={
             settled
-              ? `${SETTLED_CHIP_LABEL[settled]}, urgency ${score} of ${MAX_SCORE}, show breakdown`
-              : `Urgency ${score} of ${MAX_SCORE}, show breakdown`
+              ? `${SETTLED_CHIP_LABEL[settled]}, urgency ${score} of ${maxScore}, show breakdown`
+              : `Urgency ${score} of ${maxScore}, show breakdown`
           }
           onKeyDown={(e) => {
             if (e.key.toLowerCase() === 'x') {
@@ -107,14 +137,25 @@ export default function ScoreChip({
           </h2>
           {settled && <p className="text-xs text-muted-foreground">{SETTLED_EXPLANATION[settled]}</p>}
           {settled && <p className="border-t pt-2 text-xs text-muted-foreground">It still scores {score}:</p>}
-          <div className={cn('space-y-1 pt-2', !settled && 'border-t')}>
-            {scoreBreakdown.map((entry, i) => (
-              <div key={i} className="flex items-center justify-between gap-3">
-                <span>{entry.label}</span>
-                <span className="font-mono tabular-nums">+{entry.points}</span>
-              </div>
+
+          {selfSet.length > 0 && (
+            <div className={cn('space-y-1 pt-2', !settled && 'border-t')}>
+              <p className="text-xs font-medium text-muted-foreground">What you set</p>
+              {selfSet.map((entry, i) => (
+                <BreakdownRow key={i} entry={entry} />
+              ))}
+            </div>
+          )}
+
+          <div className={cn('space-y-1 pt-2', (!settled || selfSet.length > 0) && 'border-t')}>
+            {selfSet.length > 0 && (
+              <p className="text-xs font-medium text-muted-foreground">What the sources report</p>
+            )}
+            {reported.map((entry, i) => (
+              <BreakdownRow key={i} entry={entry} />
             ))}
           </div>
+
           {notFired.length > 0 && (
             <div className="space-y-1 border-t pt-2 text-muted-foreground">
               {notFired.map((label) => (
@@ -130,8 +171,10 @@ export default function ScoreChip({
             <span className="font-mono tabular-nums">{score}</span>
           </div>
           <p className="border-t pt-2 text-xs text-muted-foreground">
-            {TIER_LABEL[tier]} band. Ties break by oldest activity first.
+            {BAND_LABEL[band]} band. Ties break by oldest activity first.
             {keptVisible && ' Kept visible: ad-hoc items skip the needs-attention score threshold.'}
+            {clearedThresholdAlone &&
+              ` Above ${NEEDS_ATTENTION_THRESHOLD} on its own, so it no longer needs the ad-hoc exemption.`}
           </p>
           <button
             type="button"

--- a/components/ScoringReferenceDialog.tsx
+++ b/components/ScoringReferenceDialog.tsx
@@ -38,7 +38,9 @@ export default function ScoringReferenceDialog({ open, onOpenChange }: Props) {
           </div>
 
           <div>
-            <p className="mb-1.5 text-xs font-medium text-muted-foreground">Then these stack on top · any number</p>
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+              Then these stack on top · any number · reported by the sources
+            </p>
             <div className="space-y-1">
               {ref.stackingRules.map((row) => (
                 <div key={row.label} className="flex items-center justify-between gap-3">
@@ -49,9 +51,33 @@ export default function ScoringReferenceDialog({ open, onOpenChange }: Props) {
             </div>
           </div>
 
-          <div className="flex items-center justify-between gap-3 border-t pt-2 font-medium">
-            <span>Highest score possible</span>
-            <span className="font-mono tabular-nums">{ref.maxScore}</span>
+          <div>
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+              And this one you set yourself · ad-hoc items only
+            </p>
+            <div className="space-y-1">
+              {ref.selfSetRules.map((row) => (
+                <div key={row.label} className="flex items-center justify-between gap-3">
+                  <span>{row.label}</span>
+                  <span className="font-mono tabular-nums">+{row.points}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-1 border-t pt-2">
+            <div className="flex items-center justify-between gap-3 font-medium">
+              <span>Highest score possible</span>
+              <span className="font-mono tabular-nums">{ref.maxScore}</span>
+            </div>
+            {/* Ad-hoc items are created without review activity or an
+                activity timestamp, and nothing ever gives them one, so two
+                of the stacking rules can never fire on them. Reporting the
+                same ceiling for both would overstate their headroom. */}
+            <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span>For an ad-hoc item, where staleness and reviews never apply</span>
+              <span className="font-mono tabular-nums">{ref.maxScoreAdhoc}</span>
+            </div>
           </div>
 
           <div>
@@ -67,7 +93,9 @@ export default function ScoringReferenceDialog({ open, onOpenChange }: Props) {
           </div>
 
           <div className="space-y-2 border-t pt-2">
-            <p className="text-xs font-medium text-muted-foreground">The two rules that aren&apos;t points</p>
+            {/* Deliberately uncounted. This heading used to hardcode "two"
+                and was wrong the moment a third rule was disclosed. */}
+            <p className="text-xs font-medium text-muted-foreground">The rules that aren&apos;t points</p>
             {ref.nonPointRules.map((rule) => (
               <p key={rule} className="text-xs text-muted-foreground">
                 {rule}

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -6,12 +6,19 @@ import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import ItemRow from './ItemRow';
 import QueryBar from './QueryBar';
-import { groupOf, isKeptVisible, needsYou, GROUP_ORDER, GROUP_LABEL, type ObligationGroup } from '@/lib/grouping';
+import {
+  groupOf,
+  needsYou,
+  sortStarredFirst,
+  GROUP_ORDER,
+  GROUP_LABEL,
+  type ObligationGroup,
+} from '@/lib/grouping';
 import { parseQuery, applyQuery, withoutFilter } from '@/lib/query';
 import { isSnoozed, type SnoozeOption } from '@/lib/snooze';
 import { createSavedView, deleteSavedView } from '@/lib/api-client';
 import type { SavedView } from '@/lib/saved-views';
-import type { Source } from '@/lib/types';
+import type { Priority, Source } from '@/lib/types';
 import type { ScoredItem } from '@/lib/dashboard';
 
 const VISIBLE_PER_GROUP = 5;
@@ -67,6 +74,7 @@ interface Props {
   onSnooze?: (id: number, option: SnoozeOption) => void;
   onUnsnooze?: (id: number) => void;
   onDone?: (id: number, done: boolean) => void;
+  onSetPriority?: (id: number, priority: Priority | null) => void;
   currentSprintIteration: string | null;
   queryText: string;
   onQueryTextChange: (raw: string) => void;
@@ -87,6 +95,7 @@ export default function SignalsBoard({
   onSnooze,
   onUnsnooze,
   onDone,
+  onSetPriority,
   currentSprintIteration,
   queryText,
   onQueryTextChange,
@@ -159,7 +168,7 @@ export default function SignalsBoard({
     };
     for (const item of filtered) buckets[groupOf(item)].push(item);
     for (const key of Object.keys(buckets) as ObligationGroup[]) {
-      buckets[key].sort((a, b) => Number(b.starred) - Number(a.starred));
+      buckets[key] = sortStarredFirst(buckets[key]);
     }
     return buckets;
   }, [filtered]);
@@ -232,8 +241,13 @@ export default function SignalsBoard({
       {GROUP_ORDER.map((group) => {
         const groupItems = grouped[group];
         if (groupItems.length === 0) return null;
-        const exempt = groupItems.filter((i) => isKeptVisible(i, i.score));
-        const rest = groupItems.filter((i) => !isKeptVisible(i, i.score));
+        // Every ad-hoc row is exempt from the collapse cut, not just the
+        // ones the "Kept visible" rule is holding up. Splitting on
+        // isKeptVisible instead meant that giving an item a priority -- an
+        // action whose entire point is "this matters more" -- could push it
+        // behind "Show N more" the moment it crossed the threshold.
+        const exempt = groupItems.filter((i) => i.source === 'adhoc');
+        const rest = groupItems.filter((i) => i.source !== 'adhoc');
         const isExpanded = expanded[group];
         const visibleRest = isExpanded ? rest : rest.slice(0, VISIBLE_PER_GROUP);
         const hiddenCount = rest.length - visibleRest.length;
@@ -261,6 +275,7 @@ export default function SignalsBoard({
                   onSnooze={onSnooze}
                   onUnsnooze={onUnsnooze}
                   onDone={onDone}
+                  onSetPriority={onSetPriority}
                   sourceIsStale={failingSources?.has(item.source)}
                   onOpenScoringReference={onOpenScoringReference}
                 />
@@ -305,6 +320,7 @@ export default function SignalsBoard({
                   onSnooze={onSnooze}
                   onUnsnooze={onUnsnooze}
                   onDone={onDone}
+                  onSetPriority={onSetPriority}
                   sourceIsStale={failingSources?.has(item.source)}
                   onOpenScoringReference={onOpenScoringReference}
                 />

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import ItemRow from './ItemRow';
 import SortableRows from './SortableRows';
 import type { ScoredItem } from '@/lib/dashboard';
-import type { Item } from '@/lib/types';
+import type { Item, Priority } from '@/lib/types';
 
 interface Props {
   items: ScoredItem[];
@@ -16,6 +16,7 @@ interface Props {
   onComplete: (id: number, durationHours: number, note?: string) => void;
   onOpenClaude: (id: number, workingDir?: string) => void;
   onDelete?: (id: number) => void;
+  onSetPriority?: (id: number, priority: Priority | null) => void;
   onPark?: (id: number) => void;
   onUnpark?: (id: number) => void;
   onUnpinToday?: (id: number) => void;
@@ -42,6 +43,7 @@ export default function TodaySection({
   onComplete,
   onOpenClaude,
   onDelete,
+  onSetPriority,
   onPark,
   onUnpark,
   onUnpinToday,
@@ -91,6 +93,7 @@ export default function TodaySection({
                     onComplete={onComplete}
                     onOpenClaude={onOpenClaude}
                     onDelete={onDelete}
+                    onSetPriority={onSetPriority}
                     onPark={onPark}
                     onUnpark={onUnpark}
                     onUnpinToday={onUnpinToday}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { ChevronRight } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -42,4 +43,49 @@ const DropdownMenuItem = React.forwardRef<
 ))
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
-export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem }
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" aria-hidden="true" />
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[9rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/e2e/adhoc-priority.spec.ts
+++ b/e2e/adhoc-priority.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { createItem, ensureNoRunningTimer } from './helpers';
+import { seedSettledPair } from './seed-settled';
+
+test('capturing an ad-hoc item with a high priority is a keyboard-only gesture that outranks a review request', async ({
+  page,
+  request,
+}) => {
+  await ensureNoRunningTimer(request);
+  const title = `Priority capture ${Date.now()}`;
+
+  await page.goto('/');
+  // The whole point of the feature: someone is at your desk, so `a` opens
+  // the form and the first field already has focus.
+  await page.locator('body').press('a');
+  const titleInput = page.getByLabel('Title');
+  await expect(titleInput).toBeFocused();
+  await titleInput.fill(title);
+
+  const priority = page.getByRole('radiogroup', { name: 'Priority (optional)' });
+  await expect(priority.getByRole('radio', { name: /High/ })).toHaveAttribute('aria-checked', 'false');
+  await priority.getByRole('radio', { name: /High/ }).click();
+  await expect(priority.getByRole('radio', { name: /High/ })).toHaveAttribute('aria-checked', 'true');
+
+  await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+  // 10 for being ad-hoc + 40 for the priority. Nothing else can fire on a
+  // brand new ad-hoc item.
+  const row = page.locator(`[data-row-id]`).filter({ hasText: title });
+  await row.waitFor();
+  await expect(row.getByRole('button', { name: /Urgency 50 of 75/ })).toBeVisible();
+});
+
+test('the score popover separates what you set from what the sources report', async ({ page, request }) => {
+  await ensureNoRunningTimer(request);
+  const title = `Priority provenance ${Date.now()}`;
+  const itemId = await createItem(request, title);
+  await request.post(`/api/items/${itemId}/priority`, { data: { priority: 'medium' } });
+
+  await page.goto('/');
+  const row = page.locator(`[data-row-id="${itemId}"]`);
+  await row.waitFor();
+  await row.getByRole('button', { name: /Urgency 30 of 75/ }).click();
+
+  const popover = page.getByRole('dialog', { name: /Why 30/ });
+  await expect(popover.getByText('What you set')).toBeVisible();
+  await expect(popover.getByText('You marked this medium')).toBeVisible();
+  await expect(popover.getByText('set today')).toBeVisible();
+  await expect(popover.getByText('What the sources report')).toBeVisible();
+
+  // 30 clears the needs-attention threshold on its own, so the ad-hoc
+  // exemption is retired and the popover has to say so -- otherwise the
+  // "Kept visible" badge just vanishes when you raise something.
+  await expect(popover.getByText(/no longer needs the ad-hoc exemption/i)).toBeVisible();
+});
+
+test('the priority action is present but refused on a row that came from a source system', async ({
+  page,
+  request,
+}) => {
+  await ensureNoRunningTimer(request);
+  // The e2e database starts empty, so a synced row has to be seeded straight
+  // into sqlite -- a real sync is not available to a test.
+  const { openPrId } = seedSettledPair(`priority-${Date.now()}`);
+
+  await page.goto('/');
+  const syncedRow = page.locator(`[data-row-id="${openPrId}"]`);
+  await syncedRow.waitFor();
+  await syncedRow.getByRole('button', { name: 'More actions' }).click();
+
+  const priorityItem = page.getByRole('menuitem', { name: /Priority/ });
+  await expect(priorityItem).toBeVisible();
+  await expect(priorityItem).toBeDisabled();
+  await expect(priorityItem).toContainText('ad-hoc only');
+});
+
+test('the f key cycles priority on a focused ad-hoc row without firing the global p binding', async ({
+  page,
+  request,
+}) => {
+  await ensureNoRunningTimer(request);
+  const title = `Priority cycle ${Date.now()}`;
+  const itemId = await createItem(request, title);
+
+  await page.goto('/');
+  const row = page.locator(`[data-row-id="${itemId}"]`);
+  await row.waitFor();
+  await row.focus();
+
+  // Unset -> high on the first press, because raising something is the only
+  // reason to reach for the key.
+  await row.press('f');
+  await expect(row.getByRole('button', { name: /Urgency 50 of 75/ })).toBeVisible();
+
+  await row.press('f');
+  await expect(row.getByRole('button', { name: /Urgency 30 of 75/ })).toBeVisible();
+
+  await row.press('f');
+  await expect(row.getByRole('button', { name: /Urgency 10 of 75/ })).toBeVisible();
+
+  // No dialog should have opened at any point: the plan-the-day dialog is on
+  // the global `p`, and a row binding must never collide with it.
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+});

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,7 +1,7 @@
 import type { TimeReport } from '@/lib/report';
 import type { LocalRepo } from '@/lib/warp';
 import { localDateString, addDays } from '@/lib/date';
-import type { Item, Plan } from '@/lib/types';
+import type { Item, Plan, Priority } from '@/lib/types';
 import type { SnoozeOption } from '@/lib/snooze';
 import type { SourceStatus } from '@/lib/sync-status';
 import type { CalibrationEntry } from '@/lib/calibration';
@@ -71,6 +71,17 @@ export async function starItem(id: number, starred: boolean) {
   await fetch(`/api/items/${id}/star`, { method: 'POST', body: JSON.stringify({ starred }) });
 }
 
+export async function setItemPriority(id: number, priority: Priority | null) {
+  const res = await fetch(`/api/items/${id}/priority`, {
+    method: 'POST',
+    body: JSON.stringify({ priority }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as { error?: string } | null;
+    throw new Error(body?.error ?? 'Could not set the priority.');
+  }
+}
+
 export async function snoozeItem(id: number, option: SnoozeOption) {
   await fetch(`/api/items/${id}/snooze`, { method: 'POST', body: JSON.stringify({ option }) });
 }
@@ -125,7 +136,12 @@ export async function openInClaude(id: number, workingDir?: string): Promise<{ w
   return body;
 }
 
-export async function createAdhocItemRequest(input: { title: string; category?: string; dueDate?: string }) {
+export async function createAdhocItemRequest(input: {
+  title: string;
+  category?: string;
+  dueDate?: string;
+  priority?: Priority | null;
+}) {
   await fetch('/api/items', { method: 'POST', body: JSON.stringify(input) });
 }
 

--- a/lib/date.test.ts
+++ b/lib/date.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { localDateString, addDays } from './date';
+import { localDateString, addDays, relativeAge } from './date';
 
 describe('localDateString', () => {
   it('formats a date as YYYY-MM-DD using local calendar fields', () => {
@@ -22,5 +22,41 @@ describe('addDays', () => {
 
   it('rolls over a year boundary', () => {
     expect(addDays('2026-12-31', 1)).toBe('2027-01-01');
+  });
+});
+
+describe('relativeAge', () => {
+  const now = new Date('2026-09-02T12:00:00.000Z');
+
+  it('reports the same day as today', () => {
+    expect(relativeAge('2026-09-02T09:00:00.000Z', now)).toBe('today');
+  });
+
+  it('reports one day back as yesterday', () => {
+    expect(relativeAge('2026-09-01T09:00:00.000Z', now)).toBe('yesterday');
+  });
+
+  it('reports days up to a week', () => {
+    expect(relativeAge('2026-08-30T12:00:00.000Z', now)).toBe('3 days ago');
+    expect(relativeAge('2026-08-27T12:00:00.000Z', now)).toBe('6 days ago');
+  });
+
+  it('reports whole weeks from a week out', () => {
+    expect(relativeAge('2026-08-26T12:00:00.000Z', now)).toBe('1 week ago');
+    expect(relativeAge('2026-08-12T12:00:00.000Z', now)).toBe('3 weeks ago');
+  });
+
+  it('reports whole months past four weeks', () => {
+    expect(relativeAge('2026-07-20T12:00:00.000Z', now)).toBe('1 month ago');
+    expect(relativeAge('2026-06-02T12:00:00.000Z', now)).toBe('3 months ago');
+  });
+
+  // A clock skew or a future timestamp must not render "-2 days ago".
+  it('treats a future timestamp as today rather than going negative', () => {
+    expect(relativeAge('2026-09-05T12:00:00.000Z', now)).toBe('today');
+  });
+
+  it('returns null for a missing timestamp', () => {
+    expect(relativeAge(null, now)).toBeNull();
   });
 });

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -15,3 +15,26 @@ export function addDays(dateStr: string, days: number): string {
   const date = new Date(y, m - 1, d + days);
   return localDateString(date);
 }
+
+// Coarse, human relative age for a timestamp the user set themselves. It
+// deliberately loses precision as it goes back -- the point is never "how
+// long exactly", it is "is this assertion still fresh?", and "3 weeks ago"
+// answers that better than "23 days ago". Clamped at zero so a future
+// timestamp (clock skew, a hand-edited row) reads as today rather than
+// rendering a negative age.
+export function relativeAge(iso: string | null | undefined, now: Date): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return null;
+
+  const days = Math.max(0, Math.floor((now.getTime() - then) / 86_400_000));
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days} days ago`;
+
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks} week${weeks === 1 ? '' : 's'} ago`;
+
+  const months = Math.max(1, Math.round(days / 30));
+  return `${months} month${months === 1 ? '' : 's'} ago`;
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -19,6 +19,8 @@ CREATE TABLE IF NOT EXISTS items (
   pr_status TEXT,
   repo TEXT,
   has_unresolved_conversations INTEGER,
+  priority TEXT CHECK (priority IS NULL OR priority IN ('low','medium','high')),
+  priority_set_at TEXT,
   UNIQUE(source, external_id)
 );
 
@@ -159,6 +161,11 @@ export function openDb(path: string): Database.Database {
       addColumnIfMissing(db, 'items', 'snoozed_until', 'TEXT');
       addColumnIfMissing(db, 'items', 'triage_state', 'TEXT');
       addColumnIfMissing(db, 'items', 'woke_early', 'INTEGER');
+      // No CHECK on the added column: SQLite cannot add a constraint to an
+      // existing table without a full rebuild, and the value domain is
+      // already enforced by setPriority/createAdhocItem.
+      addColumnIfMissing(db, 'items', 'priority', 'TEXT');
+      addColumnIfMissing(db, 'items', 'priority_set_at', 'TEXT');
       migrateTimeLogsToHours(db);
 
       return db;

--- a/lib/grouping.test.ts
+++ b/lib/grouping.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { groupOf, isKeptVisible, needsYou, GROUP_ORDER } from './grouping';
+import { groupOf, isKeptVisible, needsYou, GROUP_ORDER, sortStarredFirst } from './grouping';
 import type { Reason } from './types';
 
 const ALL_REASONS: Reason[] = [
@@ -83,5 +83,45 @@ describe('isKeptVisible', () => {
 
   it('is false for a non-ad-hoc item, regardless of score', () => {
     expect(isKeptVisible({ source: 'github_pr' }, 5)).toBe(false);
+  });
+});
+
+describe('sortStarredFirst', () => {
+  it('lifts starred items above unstarred ones', () => {
+    const sorted = sortStarredFirst([
+      { id: 1, starred: false },
+      { id: 2, starred: true },
+      { id: 3, starred: false },
+    ]);
+    expect(sorted.map((i) => i.id)).toEqual([2, 1, 3]);
+  });
+
+  // This is what makes the rule safe to layer on top of sortByUrgency: it
+  // only moves starred rows, it never reshuffles the score order underneath.
+  it('preserves the incoming order within each half', () => {
+    const sorted = sortStarredFirst([
+      { id: 1, starred: true },
+      { id: 2, starred: false },
+      { id: 3, starred: true },
+      { id: 4, starred: false },
+    ]);
+    expect(sorted.map((i) => i.id)).toEqual([1, 3, 2, 4]);
+  });
+
+  it('does not mutate the array it was given', () => {
+    const input = [
+      { id: 1, starred: false },
+      { id: 2, starred: true },
+    ];
+    sortStarredFirst(input);
+    expect(input.map((i) => i.id)).toEqual([1, 2]);
+  });
+
+  it('leaves a list with no stars untouched', () => {
+    const input = [
+      { id: 1, starred: false },
+      { id: 2, starred: false },
+    ];
+    expect(sortStarredFirst(input).map((i) => i.id)).toEqual([1, 2]);
   });
 });

--- a/lib/grouping.ts
+++ b/lib/grouping.ts
@@ -54,8 +54,27 @@ export function needsYou(item: Pick<Item, 'source' | 'adoStatus' | 'reason'>): b
 
 // Ad-hoc items always render, even below the score threshold that used to
 // gate the old "Needs attention" section -- this says which rows are only
-// visible because of that exemption, so the UI can name it (score-chip
-// popover) and exempt it from the collapse-after-5 cut (SignalsBoard).
+// visible because of that exemption, so the UI can name it (the score-chip
+// popover, and the row's inline badge).
+//
+// It no longer drives the collapse-after-5 cut: SignalsBoard exempts every
+// ad-hoc row from that, not just the ones below the threshold, so earning a
+// priority can never push an item behind "Show N more".
 export function isKeptVisible(item: Pick<Item, 'source'>, score: number): boolean {
   return item.source === 'adhoc' && score < NEEDS_ATTENTION_THRESHOLD;
+}
+
+// The third non-point ordering rule, and until now the only undisclosed one:
+// a starred item sorts to the top of its group whatever it scores. Extracted
+// out of SignalsBoard so it has a name, a test, and a single definition that
+// getScoringReference()'s nonPointRules can be checked against -- PRODUCT.md
+// commits that every rule affecting order stays disclosed wherever the
+// scoring is explained, and an anonymous comparator inside a component is
+// not disclosure.
+//
+// Stable by construction: Array.prototype.sort is stable in every runtime
+// this ships on, so items that are both starred or both unstarred keep the
+// score order sortByUrgency already put them in.
+export function sortStarredFirst<T extends { starred: boolean }>(items: T[]): T[] {
+  return [...items].sort((a, b) => Number(b.starred) - Number(a.starred));
 }

--- a/lib/items-repo.test.ts
+++ b/lib/items-repo.test.ts
@@ -10,6 +10,8 @@ import {
   setParked,
   setTodayDate,
   setStarred,
+  setPriority,
+  PriorityNotAllowedError,
   setSnoozedUntil,
   setTriageState,
   deleteItem,
@@ -727,5 +729,84 @@ describe('upsertSyncedItem item_links', () => {
     });
     const rows = db.prepare('SELECT * FROM item_links WHERE pr_item_id = ?').all(wi.id);
     expect(rows).toHaveLength(0);
+  });
+});
+
+describe('priority', () => {
+  it('creates an ad-hoc item with no priority by default', () => {
+    const item = createAdhocItem(db, { title: 'Someone asked at my desk' });
+    expect(item.priority).toBeNull();
+    expect(item.prioritySetAt).toBeNull();
+  });
+
+  it('creates an ad-hoc item with a starting priority and stamps when it was set', () => {
+    const item = createAdhocItem(db, { title: 'Urgent favour', priority: 'high' });
+    expect(item.priority).toBe('high');
+    expect(item.prioritySetAt).not.toBeNull();
+    expect(new Date(item.prioritySetAt!).getTime()).toBeGreaterThan(0);
+  });
+
+  it('sets a priority on an existing ad-hoc item', () => {
+    const created = createAdhocItem(db, { title: 'Later' });
+    setPriority(db, created.id, 'medium');
+    const item = getItemById(db, created.id);
+    expect(item?.priority).toBe('medium');
+    expect(item?.prioritySetAt).not.toBeNull();
+  });
+
+  it('clears a priority and its timestamp together, so no orphan age survives', () => {
+    const created = createAdhocItem(db, { title: 'Never mind', priority: 'high' });
+    setPriority(db, created.id, null);
+    const item = getItemById(db, created.id);
+    expect(item?.priority).toBeNull();
+    expect(item?.prioritySetAt).toBeNull();
+  });
+
+  // The age shown in the popover is the age of the assertion, so re-marking
+  // an item high has to move the clock forward.
+  it('restamps prioritySetAt when the priority changes', () => {
+    const created = createAdhocItem(db, { title: 'Rethought', priority: 'low' });
+    const first = getItemById(db, created.id)!.prioritySetAt;
+    setPriority(db, created.id, 'high');
+    const second = getItemById(db, created.id)!.prioritySetAt;
+    expect(second).not.toBeNull();
+    expect(new Date(second!).getTime()).toBeGreaterThanOrEqual(new Date(first!).getTime());
+  });
+
+  it('refuses a priority on a synced item, because Ariadne does not re-rank what the sources send', () => {
+    const pr = upsertSyncedItem(db, {
+      source: 'github_pr',
+      externalId: 'gh-prio-1',
+      title: 'A PR',
+      url: null,
+      reason: 'authored',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: '2026-07-01T00:00:00.000Z',
+      repo: 'x/y',
+    });
+    expect(() => setPriority(db, pr.id, 'high')).toThrow(PriorityNotAllowedError);
+    expect(getItemById(db, pr.id)?.priority).toBeNull();
+  });
+
+  it('carries a message the caller can show rather than a bare status code', () => {
+    const pr = upsertSyncedItem(db, {
+      source: 'ado_workitem',
+      externalId: 'ado-prio-1',
+      title: 'A work item',
+      url: null,
+      reason: 'assigned',
+      dueDate: null,
+      sprintIteration: null,
+      rawUpdatedAt: null,
+      repo: null,
+    });
+    try {
+      setPriority(db, pr.id, 'high');
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(PriorityNotAllowedError);
+      expect((error as Error).message).toMatch(/ad-hoc/i);
+    }
   });
 });

--- a/lib/items-repo.ts
+++ b/lib/items-repo.ts
@@ -1,5 +1,6 @@
 import type Database from 'better-sqlite3';
-import type { Item, NewSyncedItemInput, NewAdhocItemInput, Status } from './types';
+import type { Item, NewSyncedItemInput, NewAdhocItemInput, Priority, Source, Status } from './types';
+import { canCarryPriority } from './scoring';
 
 function rowToItem(row: any): Item {
   return {
@@ -23,6 +24,8 @@ function rowToItem(row: any): Item {
     parked: !!row.parked,
     todayDate: row.today_date,
     starred: !!row.starred,
+    priority: row.priority ?? null,
+    prioritySetAt: row.priority_set_at ?? null,
     snoozedUntil: row.snoozed_until,
     triageState: (row.triage_state ?? 'none') as Item['triageState'],
     wokeEarly: !!row.woke_early,
@@ -88,10 +91,19 @@ export function createAdhocItem(db: Database.Database, input: NewAdhocItemInput)
   const now = new Date().toISOString();
   const result = db
     .prepare(
-      `INSERT INTO items (source, external_id, title, url, reason, category, due_date, status, created_at)
-       VALUES ('adhoc', NULL, @title, NULL, 'manual', @category, @dueDate, 'inbox', @now)`
+      `INSERT INTO items (source, external_id, title, url, reason, category, due_date, status, created_at, priority, priority_set_at)
+       VALUES ('adhoc', NULL, @title, NULL, 'manual', @category, @dueDate, 'inbox', @now, @priority, @prioritySetAt)`
     )
-    .run({ title: input.title, category: input.category ?? null, dueDate: input.dueDate ?? null, now });
+    .run({
+      title: input.title,
+      category: input.category ?? null,
+      dueDate: input.dueDate ?? null,
+      now,
+      priority: input.priority ?? null,
+      // Stamped together with the value so the popover can report the age of
+      // the assertion, never a priority with no known age.
+      prioritySetAt: input.priority ? now : null,
+    });
   return rowToItem(db.prepare('SELECT * FROM items WHERE id = ?').get(result.lastInsertRowid));
 }
 
@@ -122,6 +134,31 @@ export function setTodayDate(db: Database.Database, id: number, date: string | n
 
 export function setStarred(db: Database.Database, id: number, starred: boolean): void {
   db.prepare('UPDATE items SET starred = ? WHERE id = ?').run(starred ? 1 : 0, id);
+}
+
+export class PriorityNotAllowedError extends Error {
+  readonly itemId: number;
+
+  constructor(itemId: number) {
+    super('Only ad-hoc items can carry a priority. Ariadne does not re-rank what GitHub and Azure DevOps send.');
+    this.name = 'PriorityNotAllowedError';
+    this.itemId = itemId;
+  }
+}
+
+// Value and timestamp always move together: clearing the priority clears
+// its age too, and re-marking an item restamps it, because the age the
+// popover reports is the age of the assertion rather than of the row.
+export function setPriority(db: Database.Database, id: number, priority: Priority | null): void {
+  const row = db.prepare('SELECT source FROM items WHERE id = ?').get(id) as { source: Source } | undefined;
+  if (!row) return;
+  if (!canCarryPriority(row.source)) throw new PriorityNotAllowedError(id);
+
+  db.prepare('UPDATE items SET priority = ?, priority_set_at = ? WHERE id = ?').run(
+    priority,
+    priority ? new Date().toISOString() : null,
+    id
+  );
 }
 
 // Setting a new snooze always clears any previous "woke early" marker -- a

--- a/lib/keymap.test.ts
+++ b/lib/keymap.test.ts
@@ -50,3 +50,32 @@ describe('isTypingTarget', () => {
     expect(isTypingTarget(undefined)).toBe(false);
   });
 });
+
+describe('KEYMAP priority and capture bindings', () => {
+  it('declares the row-scoped priority cycle wired up in ItemRow', () => {
+    expect(KEYMAP.find((b) => b.keys === 'f')).toEqual({
+      keys: 'f',
+      description: 'Cycle priority (ad-hoc only)',
+      scope: 'row',
+    });
+  });
+
+  it('declares the global capture binding wired up in GlobalKeymapProvider', () => {
+    expect(KEYMAP.find((b) => b.keys === 'a')).toEqual({
+      keys: 'a',
+      description: 'Add an ad-hoc item',
+      scope: 'global',
+    });
+  });
+
+  // GlobalKeymapProvider matches `/ ? r w p g` case-insensitively and does
+  // not bail when a row has focus, so a row binding on any of those letters
+  // would fire two handlers at once.
+  it('never puts a row binding on a letter the global switch also matches', () => {
+    const globallyMatched = new Set(['/', '?', 'r', 'w', 'p', 'g']);
+    const rowKeys = KEYMAP.filter((b) => b.scope === 'row').map((b) => b.keys);
+    for (const keys of rowKeys) {
+      expect(globallyMatched.has(keys.toLowerCase())).toBe(false);
+    }
+  });
+});

--- a/lib/keymap.ts
+++ b/lib/keymap.ts
@@ -17,10 +17,16 @@ export interface KeyBinding {
 // checks isTypingTarget before acting on any binding (naturally inert while
 // typing, since focus never reaches a row while an input has it).
 //
-// Deliberately NOT included yet: `space` (start/stop timer) and `P` (plan
-// the day) -- both trigger Phase 3 features that don't exist in this
-// codebase yet. Declaring a binding for a nonexistent action would ship a
-// dead shortcut; they're added here once Phase 3 builds what they call.
+// A row binding must not reuse a letter the global switch also matches:
+// GlobalKeymapProvider does not bail when a row has focus, so both handlers
+// would fire. That switch currently matches `/ ? r w p g` case-insensitively
+// even though `P`/`R`/`W` are declared uppercase here, which is why the
+// priority cycle is `f` (for the flag icon it carries) and not `p`.
+//
+// Deliberately NOT included yet: `space` (start/stop timer) -- it triggers a
+// Phase 3 feature that doesn't exist in this codebase yet. Declaring a
+// binding for a nonexistent action would ship a dead shortcut; it gets added
+// here once Phase 3 builds what it calls.
 export const KEYMAP: KeyBinding[] = [
   { keys: 'j', description: 'Move focus to the next item', scope: 'row' },
   { keys: 'k', description: 'Move focus to the previous item', scope: 'row' },
@@ -28,9 +34,11 @@ export const KEYMAP: KeyBinding[] = [
   { keys: 'x', description: 'Show the score breakdown', scope: 'row' },
   { keys: 'c', description: 'Complete the focused item', scope: 'row' },
   { keys: 's', description: 'Star (local only)', scope: 'row' },
+  { keys: 'f', description: 'Cycle priority (ad-hoc only)', scope: 'row' },
   { keys: 'e', description: 'Snooze (local only)', scope: 'row' },
   { keys: 'd', description: 'Mark done (local only)', scope: 'row' },
   { keys: 't', description: 'Pin to Today', scope: 'row' },
+  { keys: 'a', description: 'Add an ad-hoc item', scope: 'global' },
   { keys: '/', description: 'Focus the query bar', scope: 'global' },
   { keys: 'P', description: 'Plan the day', scope: 'global' },
   { keys: '⌘K / Ctrl+K', description: 'Search or jump to', scope: 'global' },

--- a/lib/query.test.ts
+++ b/lib/query.test.ts
@@ -29,6 +29,8 @@ function item(overrides: Partial<ScoredItem> = {}): ScoredItem {
     snoozedUntil: null,
     triageState: 'none',
     wokeEarly: false,
+    priority: null,
+    prioritySetAt: null,
     score: 40,
     scoreBreakdown: [],
     notFired: [],
@@ -215,5 +217,45 @@ describe('withoutBareWord', () => {
   it('drops the correct occurrence when the same word appears twice', () => {
     const result = withoutBareWord('flaky flaky', 1);
     expect(result).toBe('flaky');
+  });
+});
+
+describe('priority filter', () => {
+  it('matches items by their hand-set priority', () => {
+    const items = [
+      item({ id: 1, source: 'adhoc', priority: 'high' }),
+      item({ id: 2, source: 'adhoc', priority: 'low' }),
+      item({ id: 3, source: 'github_pr', priority: null }),
+    ];
+    const result = applyQuery(items, parseQuery('priority:high'), { now: NOW, currentSprintIteration: null });
+    expect(result.map((i) => i.id)).toEqual([1]);
+  });
+
+  it('accepts several values at once', () => {
+    const items = [
+      item({ id: 1, source: 'adhoc', priority: 'high' }),
+      item({ id: 2, source: 'adhoc', priority: 'medium' }),
+      item({ id: 3, source: 'adhoc', priority: 'low' }),
+    ];
+    const result = applyQuery(items, parseQuery('priority:high,medium'), {
+      now: NOW,
+      currentSprintIteration: null,
+    });
+    expect(result.map((i) => i.id)).toEqual([1, 2]);
+  });
+
+  it('finds the ad-hoc items never weighed, via priority:none', () => {
+    const items = [
+      item({ id: 1, source: 'adhoc', priority: 'high' }),
+      item({ id: 2, source: 'adhoc', priority: null }),
+    ];
+    const result = applyQuery(items, parseQuery('priority:none'), { now: NOW, currentSprintIteration: null });
+    expect(result.map((i) => i.id)).toEqual([2]);
+  });
+
+  it('rejects an unknown value with a message naming the ad-hoc scope', () => {
+    const parsed = parseQuery('priority:urgent');
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors[0]).toMatch(/ad-hoc items only/);
   });
 });

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -7,7 +7,7 @@ import type { ScoredItem } from './dashboard';
 
 export type QueryState = 'blocked' | 'review' | 'progress' | 'draft' | 'todo';
 
-const PREFIXES = ['source', 'group', 'state', 'score', 'repo', 'sprint', 'is', 'stale', 'reason'] as const;
+const PREFIXES = ['source', 'group', 'state', 'score', 'repo', 'sprint', 'is', 'stale', 'reason', 'priority'] as const;
 type Prefix = (typeof PREFIXES)[number];
 
 export interface ParsedFilter {
@@ -27,6 +27,9 @@ const GROUP_VALUES = new Set(['waiting', 'blocked', 'moving', 'lower']);
 const STATE_VALUES = new Set(['blocked', 'review', 'todo', 'progress', 'draft']);
 const IS_VALUES = new Set(['starred', 'snoozed', 'done', 'stale']);
 const REASON_KEYS = new Set(Object.keys(REASON_LABEL));
+// 'none' is a first-class value, not an omission: "which ad-hoc items have I
+// never weighed?" is the question this filter exists to answer.
+const PRIORITY_VALUES = new Set(['low', 'medium', 'high', 'none']);
 
 function isValidScoreExpr(expr: string | undefined): boolean {
   if (!expr) return false;
@@ -47,6 +50,10 @@ function validateValues(prefix: Prefix, values: string[]): string | null {
       return values.every((v) => IS_VALUES.has(v)) ? null : `is: expects starred, snoozed, done, or stale`;
     case 'reason':
       return values.every((v) => REASON_KEYS.has(v)) ? null : `reason: unknown reason key`;
+    case 'priority':
+      return values.every((v) => PRIORITY_VALUES.has(v))
+        ? null
+        : `priority: expects low, medium, high, or none (ad-hoc items only)`;
     case 'score':
       return isValidScoreExpr(values[0]) ? null : `score: expected >n, <n, or n..n`;
     case 'stale':
@@ -170,6 +177,8 @@ function matchesFilter(item: ScoredItem, filter: ParsedFilter, context: QueryCon
     }
     case 'reason':
       return values.some((v) => item.reason === (v as Reason));
+    case 'priority':
+      return values.some((v) => (v === 'none' ? item.priority === null : item.priority === v));
   }
 }
 

--- a/lib/scoring.test.ts
+++ b/lib/scoring.test.ts
@@ -1,11 +1,24 @@
 import { describe, it, expect } from 'vitest';
 import fc from 'fast-check';
-import { scoreItem, scoreBreakdown, sortByUrgency, getPriorityTier, getScoringReference } from './scoring';
+import {
+  scoreItem,
+  scoreBreakdown,
+  sortByUrgency,
+  getUrgencyBand,
+  getScoringReference,
+  maxScoreFor,
+} from './scoring';
 
 const NOW = new Date('2026-07-02T12:00:00.000Z');
 
+function explain(item: Parameters<typeof scoreItem>[0]) {
+  const withScore = sortByUrgency([item], NOW)[0];
+  return { entries: withScore.scoreBreakdown, notFired: withScore.notFired };
+}
+
 function baseItem(overrides: Partial<Parameters<typeof scoreItem>[0]> = {}) {
   return {
+    source: 'adhoc' as const,
     reason: 'manual' as const,
     status: 'inbox' as const,
     dueDate: null,
@@ -212,6 +225,9 @@ describe('scoreBreakdown property', () => {
       { nil: null }
     );
     const itemArb = fc.record({
+      source: fc.constantFrom('github_pr', 'ado_workitem', 'adhoc'),
+      priority: fc.option(fc.constantFrom('low', 'medium', 'high'), { nil: null }),
+      prioritySetAt: fc.option(fc.constant('2026-08-01T00:00:00.000Z'), { nil: null }),
       reason: reasonArb,
       status: statusArb,
       dueDate: isoDateArb,
@@ -230,24 +246,24 @@ describe('scoreBreakdown property', () => {
   });
 });
 
-describe('getPriorityTier', () => {
+describe('getUrgencyBand', () => {
   it('returns low below the needs-attention threshold', () => {
-    expect(getPriorityTier(24)).toBe('low');
+    expect(getUrgencyBand(24)).toBe('low');
   });
 
   it('returns medium from 25 up to 39', () => {
-    expect(getPriorityTier(25)).toBe('medium');
-    expect(getPriorityTier(39)).toBe('medium');
+    expect(getUrgencyBand(25)).toBe('medium');
+    expect(getUrgencyBand(39)).toBe('medium');
   });
 
   it('returns high from 40 up to 59', () => {
-    expect(getPriorityTier(40)).toBe('high');
-    expect(getPriorityTier(59)).toBe('high');
+    expect(getUrgencyBand(40)).toBe('high');
+    expect(getUrgencyBand(59)).toBe('high');
   });
 
   it('returns critical at 60 and above', () => {
-    expect(getPriorityTier(60)).toBe('critical');
-    expect(getPriorityTier(85)).toBe('critical');
+    expect(getUrgencyBand(60)).toBe('critical');
+    expect(getUrgencyBand(85)).toBe('critical');
   });
 });
 
@@ -285,10 +301,127 @@ describe('getScoringReference', () => {
     ]);
   });
 
-  it('discloses the two rules that are not points', () => {
+  it('discloses all three rules that are not points, including the starred-first sort', () => {
     const ref = getScoringReference();
-    expect(ref.nonPointRules).toHaveLength(2);
+    expect(ref.nonPointRules).toHaveLength(3);
     expect(ref.nonPointRules[0]).toMatch(/in progress/i);
-    expect(ref.nonPointRules[1]).toMatch(/ad-hoc/i);
+    expect(ref.nonPointRules[1]).toMatch(/starred/i);
+    expect(ref.nonPointRules[2]).toMatch(/ad-hoc/i);
+  });
+
+  // The old copy claimed ad-hoc items "have no upstream activity to earn
+  // points from", which stopped being true the moment priority was a way
+  // to earn them.
+  it('no longer claims ad-hoc items cannot earn points', () => {
+    const ref = getScoringReference();
+    expect(ref.nonPointRules[2]).not.toMatch(/no upstream activity to earn points/i);
+  });
+
+  it('publishes the self-set priority rows separately from the source-observed ones', () => {
+    const ref = getScoringReference();
+    expect(ref.selfSetRules).toEqual([
+      { label: 'You marked it high', points: 40 },
+      { label: 'You marked it medium', points: 20 },
+      { label: 'You marked it low', points: 0 },
+    ]);
+  });
+});
+
+describe('manual priority', () => {
+  it('adds 40 for high, 20 for medium, and nothing for low', () => {
+    expect(scoreItem(baseItem({ priority: 'high' }), NOW)).toBe(10 + 40);
+    expect(scoreItem(baseItem({ priority: 'medium' }), NOW)).toBe(10 + 20);
+    expect(scoreItem(baseItem({ priority: 'low' }), NOW)).toBe(10);
+  });
+
+  it('lands a bare ad-hoc item in the band it was named after', () => {
+    expect(getUrgencyBand(scoreItem(baseItem({ priority: 'high' }), NOW))).toBe('high');
+    expect(getUrgencyBand(scoreItem(baseItem({ priority: 'medium' }), NOW))).toBe('medium');
+    expect(getUrgencyBand(scoreItem(baseItem({ priority: 'low' }), NOW))).toBe('low');
+  });
+
+  it('is ignored on synced items, which cannot carry a priority', () => {
+    const pr = baseItem({ source: 'github_pr', reason: 'authored', priority: 'high' });
+    expect(scoreItem(pr, NOW)).toBe(10);
+    expect(scoreBreakdown(pr, NOW)).toEqual([{ label: 'Your PR', points: 10 }]);
+  });
+
+  it('marks the priority entry as self-set, so the popover can separate provenance', () => {
+    const breakdown = scoreBreakdown(baseItem({ priority: 'high' }), NOW);
+    expect(breakdown).toEqual([
+      { label: 'You marked this high', points: 40, provenance: 'you', detail: null },
+      { label: 'Ad-hoc', points: 10 },
+    ]);
+  });
+
+  it('carries the age of the assertion when prioritySetAt is known', () => {
+    const breakdown = scoreBreakdown(
+      baseItem({ priority: 'high', prioritySetAt: '2026-06-11T12:00:00.000Z' }),
+      NOW
+    );
+    expect(breakdown[0]).toEqual({
+      label: 'You marked this high',
+      points: 40,
+      provenance: 'you',
+      detail: 'set 3 weeks ago',
+    });
+  });
+
+  it('shows a low priority as a fired 0-point entry, not as an unfired rule', () => {
+    const { entries, notFired } = explain(baseItem({ priority: 'low' }));
+    expect(entries).toContainEqual({
+      label: 'You marked this low',
+      points: 0,
+      provenance: 'you',
+      detail: null,
+    });
+    expect(notFired).not.toContain('No priority set');
+  });
+
+  it('reports an unset priority as an unfired rule on ad-hoc items only', () => {
+    expect(explain(baseItem()).notFired).toContain('No priority set');
+    expect(explain(baseItem({ source: 'github_pr', reason: 'authored' })).notFired).not.toContain(
+      'No priority set'
+    );
+  });
+
+  it('stacks with a deadline, so the named band is not the band you always land in', () => {
+    const score = scoreItem(baseItem({ priority: 'medium', dueDate: '2026-07-03T12:00:00.000Z' }), NOW);
+    expect(score).toBe(10 + 20 + 25);
+    expect(getUrgencyBand(score)).toBe('high');
+  });
+
+  it('sorts a high ad-hoc item above a review request', () => {
+    const sorted = sortByUrgency(
+      [
+        { ...baseItem({ source: 'github_pr', reason: 'review_requested' }), id: 'pr' },
+        { ...baseItem({ priority: 'high' }), id: 'adhoc' },
+      ],
+      NOW
+    );
+    expect(sorted.map((i) => i.id)).toEqual(['adhoc', 'pr']);
+  });
+});
+
+describe('maxScoreFor', () => {
+  // Ad-hoc items are created without raw_updated_at or unresolved
+  // conversations and nothing ever sets them, so the +15 and +20 rules are
+  // structurally unreachable there. Reporting "of 105" on a row capped at
+  // 75 overstates the headroom.
+  it('caps ad-hoc items at 75, the only rules that can actually fire', () => {
+    expect(maxScoreFor('adhoc')).toBe(75);
+  });
+
+  it('leaves synced items at the full 105', () => {
+    expect(maxScoreFor('github_pr')).toBe(105);
+    expect(maxScoreFor('ado_workitem')).toBe(105);
+  });
+
+  it('is never exceeded by any reachable ad-hoc score', () => {
+    const worst = scoreItem(
+      baseItem({ priority: 'high', dueDate: '2026-07-01T12:00:00.000Z', rawUpdatedAt: null }),
+      NOW
+    );
+    expect(worst).toBeLessThanOrEqual(maxScoreFor('adhoc'));
   });
 });

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -1,12 +1,16 @@
-import type { Reason, Status } from './types';
+import { relativeAge } from './date';
+import type { Priority, Reason, Source, Status } from './types';
 
 export interface ScorableItem {
+  source: Source;
   reason: Reason;
   status: Status;
   dueDate: string | null;
   sprintEnd: string | null;
   rawUpdatedAt: string | null;
   hasUnresolvedConversations?: boolean;
+  priority?: Priority | null;
+  prioritySetAt?: string | null;
 }
 
 const REASON_SCORE: Record<Reason, number> = {
@@ -29,12 +33,62 @@ export const REASON_LABEL: Record<Reason, string> = {
   manual: 'Ad-hoc',
 };
 
+// The one term in the formula you set yourself, so it is priced to land a
+// bare ad-hoc item in the band it was named after: high -> 50 (High starts
+// at 40), medium -> 30 (Medium starts at 25), low -> 10 (Low). That is a
+// teaching aid, not a promise -- the moment a second rule fires the totals
+// move, which is why the control is labelled with its points rather than
+// with the band it would produce on its own.
+const PRIORITY_SCORE: Record<Priority, number> = {
+  high: 40,
+  medium: 20,
+  low: 0,
+};
+
+export const PRIORITY_LABEL: Record<Priority, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+export const PRIORITY_ORDER: Priority[] = ['high', 'medium', 'low'];
+
+export function priorityPoints(priority: Priority): number {
+  return PRIORITY_SCORE[priority];
+}
+
+// Only ad-hoc items can carry one. Ariadne is read-only against GitHub and
+// Azure DevOps, and that commitment extends to ranking: you do not get to
+// hand-tune the position of work the sources gave you, only of work you
+// invented. Enforced here as well as in the repo layer so a score can never
+// disagree with what the row is allowed to store.
+export function canCarryPriority(source: Source): boolean {
+  return source === 'adhoc';
+}
+
+// 'you' marks a term the user asserted; everything else was reported by a
+// source system. The score chip groups by this so a hand-set number can
+// never masquerade as an observation.
+export type Provenance = 'you';
+
 export interface ScoreBreakdownEntry {
   label: string;
   points: number;
+  provenance?: Provenance;
+  detail?: string | null;
 }
 
 export const MAX_SCORE = 105;
+
+// Ad-hoc items are inserted without raw_updated_at or
+// has_unresolved_conversations, and only upsertSyncedItem ever writes
+// either, so the +15 staleness and +20 conversations rules are structurally
+// unreachable on them. Their real ceiling is 10 + 40 + 25.
+export const MAX_ADHOC_SCORE = 75;
+
+export function maxScoreFor(source: Source): number {
+  return source === 'adhoc' ? MAX_ADHOC_SCORE : MAX_SCORE;
+}
 
 interface ScoreExplanation {
   entries: ScoreBreakdownEntry[];
@@ -71,14 +125,33 @@ function explainScore(item: ScorableItem, now: Date): ScoreExplanation {
     } else {
       notFired.push(`Not stale yet (${Math.round(ageDays)}d of 5)`);
     }
-  } else {
+  } else if (!canCarryPriority(item.source)) {
+    // An ad-hoc item can never have one, so listing it as a rule that
+    // "didn't fire" reads as a defect rather than as disclosure.
     notFired.push('No activity timestamp');
   }
 
   if (item.hasUnresolvedConversations) {
     entries.push({ label: 'Unresolved conversations', points: 20 });
-  } else {
+  } else if (!canCarryPriority(item.source)) {
     notFired.push('No unresolved conversations');
+  }
+
+  // Deliberately last, and only on the rows that can hold one. A low
+  // priority still fires as a 0-point entry: the user made a decision and
+  // the breakdown should say so, rather than reporting it as an absence.
+  if (canCarryPriority(item.source)) {
+    if (item.priority) {
+      const age = relativeAge(item.prioritySetAt, now);
+      entries.push({
+        label: `You marked this ${item.priority}`,
+        points: PRIORITY_SCORE[item.priority],
+        provenance: 'you',
+        detail: age ? `set ${age}` : null,
+      });
+    } else {
+      notFired.push('No priority set');
+    }
   }
 
   entries.sort((a, b) => b.points - a.points);
@@ -115,21 +188,26 @@ export function sortByUrgency<T extends ScorableItem>(
     });
 }
 
-export type PriorityTier = 'low' | 'medium' | 'high' | 'critical';
+// The urgency band a score falls into. Named for what it is -- a derived
+// reading -- and deliberately NOT called a priority: `priority` is the
+// value the user sets by hand, and one of the two feeds the other.
+export type UrgencyBand = 'low' | 'medium' | 'high' | 'critical';
 
 // Boundaries line up with NEEDS_ATTENTION_THRESHOLD (25) in lib/config.ts —
 // 'low' never appears in the Needs Attention UI, only medium/high/critical do.
 // Max achievable score is 105: approved_unmerged (45) + due-date urgency (25)
-// + unresolved conversations (20) + stale (15). The --urgency-* CSS tokens
-// (app/globals.css) are keyed to these same cuts.
-export function getPriorityTier(score: number): PriorityTier {
+// + unresolved conversations (20) + stale (15); a hand-set priority is
+// excluded because it only applies to ad-hoc rows, which cap at 75 (see
+// MAX_ADHOC_SCORE). The --urgency-* CSS tokens (app/globals.css) are keyed
+// to these same cuts.
+export function getUrgencyBand(score: number): UrgencyBand {
   if (score >= 60) return 'critical';
   if (score >= 40) return 'high';
   if (score >= 25) return 'medium';
   return 'low';
 }
 
-export const TIER_LABEL: Record<PriorityTier, string> = {
+export const BAND_LABEL: Record<UrgencyBand, string> = {
   low: 'Low',
   medium: 'Medium',
   high: 'High',
@@ -142,7 +220,7 @@ export interface ScoringReferenceRow {
 }
 
 export interface ScoringReferenceBand {
-  tier: PriorityTier;
+  tier: UrgencyBand;
   label: string;
   range: string;
 }
@@ -150,7 +228,9 @@ export interface ScoringReferenceBand {
 export interface ScoringReference {
   primaryReasons: ScoringReferenceRow[];
   stackingRules: ScoringReferenceRow[];
+  selfSetRules: ScoringReferenceRow[];
   maxScore: number;
+  maxScoreAdhoc: number;
   bands: ScoringReferenceBand[];
   nonPointRules: string[];
 }
@@ -171,7 +251,12 @@ export function getScoringReference(): ScoringReference {
       { label: 'Unresolved review conversations', points: 20 },
       { label: 'No activity for more than 5 days', points: 15 },
     ],
+    selfSetRules: PRIORITY_ORDER.map((priority) => ({
+      label: `You marked it ${priority}`,
+      points: PRIORITY_SCORE[priority],
+    })),
     maxScore: MAX_SCORE,
+    maxScoreAdhoc: MAX_ADHOC_SCORE,
     bands: [
       { tier: 'critical', label: 'Critical', range: '60–105' },
       { tier: 'high', label: 'High', range: '40–59' },
@@ -180,7 +265,8 @@ export function getScoringReference(): ScoringReference {
     ],
     nonPointRules: [
       'Anything you’ve started sorts first, whatever it scores. Work in progress outranks work you haven’t touched.',
-      'Ad-hoc requests stay visible below 25, because they have no upstream activity to earn points from. Rows held by that rule are marked "Kept visible".',
+      'Starred items sort first inside their group, whatever they score. Starring is a bookmark, not a score.',
+      'Ad-hoc requests stay visible below 25, because the signals that lift other rows (review activity, staleness) never reach them. Rows held by that rule are marked "Kept visible".',
     ],
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,9 @@ export type Reason =
 export type PrStatus = 'draft' | 'ready_for_review' | 'changes_requested' | 'approved' | 'merged';
 export type Status = 'inbox' | 'in_progress' | 'done';
 export type TriageState = 'none' | 'done';
+// Set by hand, ad-hoc items only. Distinct from UrgencyBand in lib/scoring.ts,
+// which is the band a score lands in and is derived, never set.
+export type Priority = 'low' | 'medium' | 'high';
 
 export interface Item {
   id: number;
@@ -35,6 +38,8 @@ export interface Item {
   snoozedUntil: string | null;
   triageState: TriageState;
   wokeEarly: boolean;
+  priority: Priority | null;
+  prioritySetAt: string | null;
 }
 
 export interface NewSyncedItemInput {
@@ -57,6 +62,7 @@ export interface NewAdhocItemInput {
   title: string;
   category?: string | null;
   dueDate?: string | null;
+  priority?: Priority | null;
 }
 
 export interface TimeLog {

--- a/mcp/tools.ts
+++ b/mcp/tools.ts
@@ -33,6 +33,7 @@ export interface ToolDefinition {
 }
 
 const itemId = z.number().int().describe("The Ariadne item id, as returned by list_items");
+const priorityValue = z.enum(['low', 'medium', 'high']);
 const isoDate = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be a YYYY-MM-DD date')
@@ -171,10 +172,15 @@ export const TOOLS: readonly ToolDefinition[] = [
       title: z.string().min(1).describe('What the item is'),
       category: z.string().optional().describe('Optional grouping label'),
       dueDate: isoDate.optional(),
+      priority: priorityValue
+        .optional()
+        .describe(
+          'Starting priority. high adds 40 to the score, medium 20, low 0. Ad-hoc items have no review activity or staleness to earn points from, so this is how they earn a place in the ranking.'
+        ),
     },
     annotations: WRITES,
-    run: (client, { title, category, dueDate }) =>
-      client.post('/api/items', body({ title, category, dueDate })),
+    run: (client, { title, category, dueDate, priority }) =>
+      client.post('/api/items', body({ title, category, dueDate, priority })),
   }),
   define({
     name: 'start_item',
@@ -269,6 +275,15 @@ export const TOOLS: readonly ToolDefinition[] = [
     inputSchema: { itemId, starred: z.boolean() },
     annotations: WRITES,
     run: (client, { itemId: id, starred }) => client.post(`/api/items/${id}/star`, { starred }),
+  }),
+  define({
+    name: 'set_priority',
+    title: 'Set an item priority',
+    description:
+      'Sets the hand-set priority on an ad-hoc item, or clears it when priority is null. high adds 40 to the score, medium 20, low 0. Only ad-hoc items can carry one: Ariadne never re-ranks work that came from GitHub or Azure DevOps, and the call is refused on those.',
+    inputSchema: { itemId, priority: priorityValue.nullable() },
+    annotations: WRITES,
+    run: (client, { itemId: id, priority }) => client.post(`/api/items/${id}/priority`, { priority }),
   }),
   define({
     name: 'set_triage_done',


### PR DESCRIPTION
Closes #76.

A fresh ad-hoc item scored 10 and had no honest way up, so the workaround
was a fake due date on something with no deadline. This adds a hand-set
priority instead: **high +40, medium +20, low +0**, ad-hoc rows only.

A bare item lands in the band it was named after (50 High, 30 Medium, 10
Low). The buttons are labelled with their points rather than their level,
because that coincidence stops holding the moment a due date stacks on top,
and a control that teaches the formula beats one that asks you to remember
it.

## The part that matters

The breakdown splits **what you set** from **what the sources report**:

```
Why 50?
  What you set
    You marked this high   set today      +40
  What the sources report
    Ad-hoc                                +10
  No deadline                              --
  Total                                    50
```

Every other term in `explainScore()` answers "what did the world do to this
item?". This one answers "what did you say?". Keeping that visible is the
reason a manual term is admissible at all: the claim was never that
everything in the score is observed, it is that you can always see which
half is which.

`priority_set_at` is stamped with the value, so the popover reports the age
of the assertion. This is the only non-decaying term in a formula otherwise
built from time-sensitive signals, and a three-week-old "high" outranking a
live review request should at least say how old it is.

## Ad-hoc only

Enforced in the repo layer, surfaced as prose rather than a bare 400. The
row action is rendered **disabled** on synced rows rather than omitted, with
the reason inline: an absent menu item teaches nothing, a disabled one
teaches the read-only commitment at the moment you reach for it.

## Adjacent fixes this made visible, or would have made worse

- **`MAX_SCORE` was already wrong for ad-hoc rows.** The chip said "of 105"
  on items structurally capped at 35, because `createAdhocItem` writes
  neither `raw_updated_at` nor `has_unresolved_conversations` and only
  `upsertSyncedItem` ever does. Now per source: 75 for ad-hoc.
- **The starred-first sort overrode score order, undisclosed and untested.**
  `SignalsBoard.tsx:162` lifted starred rows above higher-scoring ones while
  `ScoringReferenceDialog` hardcoded "The two rules that aren't points", and
  PRODUCT.md commits that every ordering rule stays disclosed. Extracted to
  `sortStarredFirst()` with tests, disclosed as the third rule, heading no
  longer counts.
- **Setting a priority looked like a demotion.** The "Kept visible" badge
  vanished, the status pill took its place, and the row became collapsible
  behind "Show N more". The exempt split is by source now, so raising an
  item can never hide it, and the popover narrates the transition.
- **`PriorityTier` renamed to `UrgencyBand`.** `ItemRow.tsx:771` already
  announced "High priority" for the derived band, so a user-set "high" would
  have put two unrelated Priorities in one screen-reader sentence.
- **Keyboard path into capture.** There was none: no `autoFocus`, no
  `KEYMAP` binding, no palette entry. Now `a` opens the form, Title focuses,
  Cmd+Enter submits, the segments are one tab stop, and `f` cycles priority
  on a focused row.

  Not `p`: `GlobalKeymapProvider` matches it case-insensitively for "Plan the
  day" and does not bail when a row has focus, so both handlers would have
  fired. There is now a test forbidding any row binding on a globally
  matched letter.
- **Category is out of the capture form.** Column, API field and MCP param
  all stay; nothing has ever read it back, and it was taking half a row at
  the one moment speed matters.

## Design notes

The segments are deliberately monochrome. The score chip owns the urgency
colour channel, so colouring them by level would put a second
urgency-looking signal on screen and act as a fifth band. Weight and the
mono numerals carry the scale instead. No priority dot on the row either;
the chip already reports the consequence.

## Also exposed

`priority:high|medium|low|none` in the query bar, and MCP `create_item`
gains an optional priority alongside a new `set_priority` tool.

## Verification

566 unit tests and 20 e2e pass, typecheck and production build clean. Four
new e2e cover the keyboard-only capture, the provenance split, the disabled
state on a seeded synced row, and that `f` never opens the plan dialog. The
migration was checked against a copy of a real database: additive, existing
ad-hoc rows land at `null`.
