### PR TITLE
fix(dashboard): keep the Signals cut off ties and unfreeze row-menu dialogs

### DIFF
--- a/components/GlobalKeymapProvider.tsx
+++ b/components/GlobalKeymapProvider.tsx
@@ -57,7 +57,15 @@ export default function GlobalKeymapProvider({
         // the plain dashboard surface, not out of an active overlay.
         if (document.querySelector('[role="dialog"]')) return;
         e.preventDefault();
-        const rows = Array.from(document.querySelectorAll<HTMLElement>('[data-row-id]'));
+        // `[data-row-nav]` picks up the group-disclosure controls alongside
+        // the rows themselves. They are the only controls that decide
+        // whether rows exist in the DOM at all, so j/k has to be able to
+        // land on one rather than stepping silently over the cut into the
+        // next group -- which is how a keyboard user could walk past four
+        // hidden review requests without ever being told they were there.
+        const rows = Array.from(
+          document.querySelectorAll<HTMLElement>('[data-row-id],[data-row-nav]')
+        );
         const currentIndex = rows.findIndex((el) => el === document.activeElement);
         const nextIndex = e.key === 'j' ? Math.min(rows.length - 1, currentIndex + 1) : Math.max(0, currentIndex - 1);
         rows[nextIndex === -1 ? 0 : nextIndex]?.focus();

--- a/components/ItemRow.tsx
+++ b/components/ItemRow.tsx
@@ -269,7 +269,14 @@ function OverflowMenu({
   density: Density;
 }) {
   return (
-    <DropdownMenu>
+    // modal={false} is load-bearing, not a preference. A modal menu sets
+    // `pointer-events: none` on <body> while it is open; three items here
+    // (Snooze, Delete, Open in Claude) open a dialog, and that dialog mounts
+    // while the menu is still up. Radix keeps one module-level "original"
+    // body value, so the dialog captures the menu's `none` as the value to
+    // restore, then writes it back on close -- leaving the whole page
+    // unclickable until a reload. See e2e/row-menu-dialog.spec.ts.
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <Button
           type="button"

--- a/components/SignalsBoard.tsx
+++ b/components/SignalsBoard.tsx
@@ -10,6 +10,7 @@ import {
   groupOf,
   needsYou,
   sortStarredFirst,
+  visibleCount,
   GROUP_ORDER,
   GROUP_LABEL,
   type ObligationGroup,
@@ -20,8 +21,6 @@ import { createSavedView, deleteSavedView } from '@/lib/api-client';
 import type { SavedView } from '@/lib/saved-views';
 import type { Priority, Source } from '@/lib/types';
 import type { ScoredItem } from '@/lib/dashboard';
-
-const VISIBLE_PER_GROUP = 5;
 
 const STATUS_KEY: { label: string; description: string }[] = [
   { label: 'Blocked', description: 'Needs a nudge, not work.' },
@@ -159,6 +158,27 @@ export default function SignalsBoard({
     onSavedViewsChange(await deleteSavedView(id));
   }
 
+  // One row renderer for both halves of a group, so the visible rows and the
+  // ones behind the disclosure can never drift apart in what they support.
+  const renderRow = (item: ScoredItem) => (
+    <ItemRow
+      key={item.id}
+      item={item}
+      onStart={onStart}
+      onComplete={onComplete}
+      onOpenClaude={onOpenClaude}
+      onDelete={onDelete}
+      onPinToday={onPinToday}
+      onStar={onStar}
+      onSnooze={onSnooze}
+      onUnsnooze={onUnsnooze}
+      onDone={onDone}
+      onSetPriority={onSetPriority}
+      sourceIsStale={failingSources?.has(item.source)}
+      onOpenScoringReference={onOpenScoringReference}
+    />
+  );
+
   const grouped = useMemo(() => {
     const buckets: Record<ObligationGroup, ScoredItem[]> = {
       waiting_on_you: [],
@@ -249,9 +269,13 @@ export default function SignalsBoard({
         const exempt = groupItems.filter((i) => i.source === 'adhoc');
         const rest = groupItems.filter((i) => i.source !== 'adhoc');
         const isExpanded = expanded[group];
-        const visibleRest = isExpanded ? rest : rest.slice(0, VISIBLE_PER_GROUP);
-        const hiddenCount = rest.length - visibleRest.length;
-        const visible = [...visibleRest, ...exempt];
+        // hiddenCount is measured from the cut, not from what is currently
+        // on screen, so the control can keep its label and its count while
+        // expanded instead of unmounting itself under the user's focus.
+        const cut = visibleCount(rest, group, activeParsed.filters.length > 0);
+        const hiddenCount = rest.length - cut;
+        const visible = [...rest.slice(0, cut), ...exempt];
+        const collapsed = rest.slice(cut);
         return (
           <section key={group} className="mb-4">
             <div className="mb-1 flex items-center gap-1.5">
@@ -261,35 +285,28 @@ export default function SignalsBoard({
               </span>
               {group === GROUP_ORDER[0] && <StatusKeyPopover />}
             </div>
-            <div>
-              {visible.map((item) => (
-                <ItemRow
-                  key={item.id}
-                  item={item}
-                  onStart={onStart}
-                  onComplete={onComplete}
-                  onOpenClaude={onOpenClaude}
-                  onDelete={onDelete}
-                  onPinToday={onPinToday}
-                  onStar={onStar}
-                  onSnooze={onSnooze}
-                  onUnsnooze={onUnsnooze}
-                  onDone={onDone}
-                  onSetPriority={onSetPriority}
-                  sourceIsStale={failingSources?.has(item.source)}
-                  onOpenScoringReference={onOpenScoringReference}
-                />
-              ))}
-            </div>
+            <div>{visible.map(renderRow)}</div>
             {hiddenCount > 0 && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setExpanded((prev) => ({ ...prev, [group]: true }))}
-              >
-                Show {hiddenCount} more
-              </Button>
+              <>
+                {/* Same disclosure grammar as Snoozed and Paused: a bare
+                    button at label weight, the count in the instrument
+                    register, and a toggle that goes both ways. "Lower
+                    scoring" rather than "Show more" because it is a claim
+                    about the score, and visibleCount() is what makes it a
+                    true one -- the cut can no longer fall inside a tie, so
+                    everything behind this really does score less. */}
+                <button
+                  type="button"
+                  data-row-nav
+                  aria-expanded={isExpanded}
+                  aria-controls={`signals-${group}-collapsed`}
+                  onClick={() => setExpanded((prev) => ({ ...prev, [group]: !prev[group] }))}
+                  className="flex w-full items-center pb-1 pt-3 text-xs font-medium text-muted-foreground hover:text-foreground"
+                >
+                  Lower scoring · <span className="ml-1 font-mono tabular-nums">{hiddenCount}</span>
+                </button>
+                {isExpanded && <div id={`signals-${group}-collapsed`}>{collapsed.map(renderRow)}</div>}
+              </>
             )}
           </section>
         );

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -15,3 +15,19 @@ export async function ensureNoRunningTimer(request: APIRequestContext): Promise<
   const timer = await res.json();
   if (timer) await request.post(`/api/items/${timer.itemId}/stop-timer`);
 }
+
+// Every spec shares one database, so rows seeded by earlier specs land in the
+// same obligation groups a collapse test is trying to count. Marking them
+// triage-done drops them out of Signals (SignalsBoard filters on
+// `triageState !== 'done'`) without deleting anything a later spec might
+// still want.
+export async function hideExistingItems(request: APIRequestContext): Promise<void> {
+  const res = await request.get('/api/items');
+  const buckets = await res.json();
+  const ids = (['today', 'signals', 'inProgress', 'parked'] as const).flatMap((bucket) =>
+    (buckets[bucket] ?? []).map((item: { id: number }) => item.id)
+  );
+  for (const id of new Set(ids)) {
+    await request.post(`/api/items/${id}/done`, { data: { done: true } });
+  }
+}

--- a/e2e/row-menu-dialog.spec.ts
+++ b/e2e/row-menu-dialog.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { createItem, ensureNoRunningTimer } from './helpers';
+
+// Three row-menu items open a dialog: Snooze, Delete and Open in Claude. The
+// dialog mounts while the menu is still up, and Radix keeps a single
+// module-level "original" value for <body>'s pointer-events: a modal menu has
+// already written `none` there, so the dialog captures `none` as the value to
+// restore and writes it back when it closes. The page then swallows every
+// click until a reload -- no error, no visible cause.
+//
+// ItemRow's menu is `modal={false}` to keep that capture clean. These tests
+// fail if it goes back to modal, which is why they assert on real clicks and
+// not just on the style value.
+async function bodyPointerEvents(page: Page): Promise<string> {
+  return page.evaluate(() => getComputedStyle(document.body).pointerEvents);
+}
+
+async function openRowMenuItem(page: Page, itemId: number, name: string | RegExp) {
+  const row = page.locator(`[data-row-id="${itemId}"]`);
+  await row.waitFor();
+  await row.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name }).click();
+  await page.getByRole('dialog').waitFor();
+}
+
+for (const item of [
+  { menuItem: /^Snooze/, dialogName: /snooze/i },
+  { menuItem: 'Delete', dialogName: /delete/i },
+  { menuItem: 'Open in Claude', dialogName: /claude/i },
+]) {
+  test(`dismissing the ${String(item.menuItem)} dialog leaves the page clickable`, async ({
+    page,
+    request,
+  }) => {
+    await ensureNoRunningTimer(request);
+    const itemId = await createItem(request, `Menu dialog ${String(item.menuItem)} ${Date.now()}`);
+
+    await page.goto('/');
+    await openRowMenuItem(page, itemId, item.menuItem);
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+
+    expect(await bodyPointerEvents(page)).not.toBe('none');
+
+    // The style is the mechanism; this is the symptom. Opening the same row's
+    // menu again has to actually work.
+    const row = page.locator(`[data-row-id="${itemId}"]`);
+    await row.getByRole('button', { name: 'More actions' }).click();
+    await expect(page.getByRole('menu')).toBeVisible();
+  });
+}
+
+test('deleting a row from its menu leaves the rest of the page clickable', async ({ page, request }) => {
+  await ensureNoRunningTimer(request);
+  const doomedId = await createItem(request, `Doomed ${Date.now()}`);
+  const survivorId = await createItem(request, `Survivor ${Date.now()}`);
+
+  await page.goto('/');
+  await openRowMenuItem(page, doomedId, 'Delete');
+  await page.getByRole('dialog').getByRole('button', { name: /^Delete$/ }).click();
+
+  await expect(page.locator(`[data-row-id="${doomedId}"]`)).toHaveCount(0);
+  expect(await bodyPointerEvents(page)).not.toBe('none');
+
+  // The row that unmounted took its open dialog with it; the surviving row
+  // must still respond.
+  const survivor = page.locator(`[data-row-id="${survivorId}"]`);
+  await survivor.getByRole('button', { name: 'More actions' }).click();
+  await expect(page.getByRole('menu')).toBeVisible();
+});

--- a/e2e/seed-collapse.ts
+++ b/e2e/seed-collapse.ts
@@ -1,0 +1,44 @@
+import { openDb } from '../lib/db';
+import { upsertSyncedItem } from '../lib/items-repo';
+import { E2E_DB_PATH } from './db-path';
+
+const DAY_MS = 86_400_000;
+
+// Synced ADO work items assigned to you, seeded straight into sqlite the way
+// seed-links.ts does. `assigned` scores 10, and anything untouched for more
+// than 5 days picks up the +15 staleness bonus, so `ageDays` is how a test
+// dials a row to exactly 25 or exactly 10 and builds a run of equal scores
+// on purpose. `reason` picks the obligation group: 'assigned' lands in
+// "Lower priority", which collapses, and 'mention' lands in "Waiting on
+// you", which never does.
+export function seedAssignedItems(
+  suffix: string,
+  rows: { ageDays: number; count: number }[],
+  reason: 'assigned' | 'mention' = 'assigned'
+): number[] {
+  const db = openDb(E2E_DB_PATH);
+  try {
+    const ids: number[] = [];
+    let n = 0;
+    for (const { ageDays, count } of rows) {
+      for (let i = 0; i < count; i++) {
+        n++;
+        const item = upsertSyncedItem(db, {
+          source: 'ado_workitem',
+          externalId: `collapse-${suffix}-${n}`,
+          title: `Collapse ${suffix} row ${n} (${ageDays}d)`,
+          url: `https://example.test/ado/collapse-${suffix}-${n}`,
+          reason,
+          dueDate: null,
+          sprintIteration: null,
+          rawUpdatedAt: new Date(Date.now() - ageDays * DAY_MS).toISOString(),
+          repo: null,
+        });
+        ids.push(item.id);
+      }
+    }
+    return ids;
+  } finally {
+    db.close();
+  }
+}

--- a/e2e/signals-collapse.spec.ts
+++ b/e2e/signals-collapse.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+import { ensureNoRunningTimer, hideExistingItems } from './helpers';
+import { seedAssignedItems } from './seed-collapse';
+
+// A group collapses to its highest-scoring rows, but the cut may never fall
+// inside a run of equal scores: rows on the same score lost no comparison,
+// so hiding one and showing another claims a ranking the score does not
+// have. Every case here is about that promise, plus the two groups the cut
+// is not allowed to touch at all.
+//
+// `assigned` scores 10; anything untouched for more than 5 days adds +15.
+// So a 30-day row is 25 and a 1-day row is 10, and a count of each builds a
+// tie run of a known length. All of them land in "Lower priority", the group
+// that does collapse.
+
+test('the cut extends past five rather than splitting a run of equal scores', async ({
+  page,
+  request,
+}) => {
+  await ensureNoRunningTimer(request);
+  await hideExistingItems(request);
+  // Six rows at 25, then three at 10. The five-row target lands inside the
+  // 25s, so the cut has to slide to six and keep them together.
+  seedAssignedItems(`tie-${Date.now()}`, [
+    { ageDays: 30, count: 6 },
+    { ageDays: 1, count: 3 },
+  ]);
+
+  await page.goto('/');
+  const section = page.locator('section').filter({ hasText: 'Lower priority' }).first();
+  await section.waitFor();
+
+  await expect(section.locator('[data-row-id]')).toHaveCount(6);
+  await expect(section.getByRole('button', { name: /Lower scoring/ })).toContainText('3');
+
+  // The point of the whole exercise: no row scoring 25 is hidden while
+  // another row scoring 25 is on screen.
+  await expect(section.getByRole('button', { name: /Urgency 25 of 105/ })).toHaveCount(6);
+});
+
+test('the disclosure toggles both ways and keeps its label while open', async ({ page, request }) => {
+  await ensureNoRunningTimer(request);
+  await hideExistingItems(request);
+  seedAssignedItems(`toggle-${Date.now()}`, [
+    { ageDays: 30, count: 5 },
+    { ageDays: 1, count: 2 },
+  ]);
+
+  await page.goto('/');
+  const section = page.locator('section').filter({ hasText: 'Lower priority' }).first();
+  await section.waitFor();
+
+  // Five rows at 25 then two at 10: the score changes exactly at the
+  // target, so the cut falls at five and needs no extending.
+  await expect(section.locator('[data-row-id]')).toHaveCount(5);
+  const disclosure = section.getByRole('button', { name: /Lower scoring/ });
+  await expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+
+  await disclosure.click();
+  await expect(section.locator('[data-row-id]')).toHaveCount(7);
+  await expect(disclosure).toHaveAttribute('aria-expanded', 'true');
+  // It must survive expansion rather than unmounting under the user's focus,
+  // and it must still say how many rows it is holding.
+  await expect(disclosure).toContainText('2');
+
+  await disclosure.click();
+  await expect(section.locator('[data-row-id]')).toHaveCount(5);
+  await expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+});
+
+test('j reaches the disclosure instead of stepping over the rows it hides', async ({
+  page,
+  request,
+}) => {
+  await ensureNoRunningTimer(request);
+  await hideExistingItems(request);
+  seedAssignedItems(`keys-${Date.now()}`, [
+    { ageDays: 30, count: 5 },
+    { ageDays: 1, count: 2 },
+  ]);
+
+  await page.goto('/');
+  const section = page.locator('section').filter({ hasText: 'Lower priority' }).first();
+  await section.waitFor();
+
+  // Focus lands on row 1, so five presses walk rows 2-5 and then step onto
+  // the disclosure instead of jumping to the next group.
+  await section.locator('[data-row-id]').first().focus();
+  for (let i = 0; i < 5; i++) await page.keyboard.press('j');
+
+  const disclosure = section.getByRole('button', { name: /Lower scoring/ });
+  await expect(disclosure).toBeFocused();
+
+  // And Enter on it works, so the keyboard route is complete rather than
+  // just reachable.
+  await page.keyboard.press('Enter');
+  await expect(section.locator('[data-row-id]')).toHaveCount(7);
+});
+
+test('"Waiting on you" never collapses, however many rows it holds', async ({ page, request }) => {
+  await ensureNoRunningTimer(request);
+  await hideExistingItems(request);
+  // Nine mentions, all stale, so they all tie at 55 -- the exact shape that
+  // hid a review request behind the old cut. This group owes action on every
+  // row, so the header count has to be a promise the rows keep.
+  seedAssignedItems(`waiting-${Date.now()}`, [{ ageDays: 30, count: 9 }], 'mention');
+
+  await page.goto('/');
+  const waiting = page.locator('section').filter({ hasText: 'Waiting on you' }).first();
+  await waiting.waitFor();
+
+  await expect(waiting.locator('[data-row-id]')).toHaveCount(9);
+  await expect(waiting.getByRole('button', { name: /Lower scoring/ })).toHaveCount(0);
+});
+
+test('a query is never collapsed, so filtering shows the whole answer', async ({ page, request }) => {
+  await ensureNoRunningTimer(request);
+  await hideExistingItems(request);
+  seedAssignedItems(`query-${Date.now()}`, [
+    { ageDays: 30, count: 5 },
+    { ageDays: 1, count: 2 },
+  ]);
+
+  await page.goto('/');
+  const section = page.locator('section').filter({ hasText: 'Lower priority' }).first();
+  await section.waitFor();
+  await expect(section.locator('[data-row-id]')).toHaveCount(5);
+
+  // Narrowing to the same set is an explicit request to see it. All 7 match
+  // `source:ado`, so all 7 have to render and the disclosure has to go.
+  await page.locator('body').press('/');
+  await page.keyboard.type('source:ado');
+
+  const filtered = page.locator('section').filter({ hasText: 'Lower priority' }).first();
+  await expect(filtered.locator('[data-row-id]')).toHaveCount(7);
+  await expect(filtered.getByRole('button', { name: /Lower scoring/ })).toHaveCount(0);
+});

--- a/lib/grouping.test.ts
+++ b/lib/grouping.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { groupOf, isKeptVisible, needsYou, GROUP_ORDER, sortStarredFirst } from './grouping';
+import {
+  groupOf,
+  isKeptVisible,
+  needsYou,
+  GROUP_ORDER,
+  sortStarredFirst,
+  visibleCount,
+  VISIBLE_PER_GROUP_MAX,
+} from './grouping';
 import type { Reason } from './types';
 
 const ALL_REASONS: Reason[] = [
@@ -123,5 +131,41 @@ describe('sortStarredFirst', () => {
       { id: 2, starred: false },
     ];
     expect(sortStarredFirst(input).map((i) => i.id)).toEqual([1, 2]);
+  });
+});
+
+describe('visibleCount', () => {
+  const rows = (...scores: number[]) => scores.map((score, i) => ({ id: i, score }));
+
+  it('shows everything when the group is no bigger than the cap', () => {
+    expect(visibleCount(rows(40, 40, 40), 'lower_priority', false)).toBe(3);
+    expect(visibleCount(rows(50, 40, 30, 20, 10), 'lower_priority', false)).toBe(5);
+  });
+
+  it('cuts at the cap when the scores actually differ there', () => {
+    expect(visibleCount(rows(60, 50, 40, 30, 20, 10), 'lower_priority', false)).toBe(5);
+  });
+
+  // The bug this function exists for: eight review requests all score 40,
+  // so cutting at index 5 hid four rows that had lost no comparison.
+  it('extends past the cap rather than splitting a run of equal scores', () => {
+    expect(visibleCount(rows(55, 40, 40, 40, 40, 40, 40, 40, 40), 'lower_priority', false)).toBe(9);
+  });
+
+  it('stops extending as soon as the score changes', () => {
+    expect(visibleCount(rows(40, 40, 40, 40, 40, 40, 25, 25), 'lower_priority', false)).toBe(6);
+  });
+
+  it('gives up at the hard ceiling so one huge tie cannot render unbounded', () => {
+    const huge = rows(...Array<number>(40).fill(40));
+    expect(visibleCount(huge, 'lower_priority', false)).toBe(VISIBLE_PER_GROUP_MAX);
+  });
+
+  it('never collapses waiting_on_you, because every row in it is owed action', () => {
+    expect(visibleCount(rows(60, 50, 40, 30, 20, 10), 'waiting_on_you', false)).toBe(6);
+  });
+
+  it('never collapses a filtered result, because a query is a request to see a set', () => {
+    expect(visibleCount(rows(60, 50, 40, 30, 20, 10), 'lower_priority', true)).toBe(6);
   });
 });

--- a/lib/grouping.ts
+++ b/lib/grouping.ts
@@ -78,3 +78,44 @@ export function isKeptVisible(item: Pick<Item, 'source'>, score: number): boolea
 export function sortStarredFirst<T extends { starred: boolean }>(items: T[]): T[] {
   return [...items].sort((a, b) => Number(b.starred) - Number(a.starred));
 }
+
+// How many rows a group shows before it collapses the rest, and the ceiling
+// a tie is allowed to push that to.
+export const VISIBLE_PER_GROUP = 5;
+export const VISIBLE_PER_GROUP_MAX = 12;
+
+// "Waiting on you" means the next move is yours on every row in it. A group
+// defined by owed action cannot hide part of what is owed -- the header
+// count is a promise the rows have to keep -- so it never collapses.
+const NEVER_COLLAPSED = new Set<ObligationGroup>(['waiting_on_you']);
+
+// The fourth non-point rule, and the one that cost the most: how many rows a
+// group renders. It lives here rather than as a bare constant inside
+// SignalsBoard for the same reason sortStarredFirst does -- it changes what
+// you can see, PRODUCT.md commits to disclosing every such rule, and an
+// anonymous `slice(0, 5)` inside a component is not disclosure.
+//
+// The cut may never split a run of equal scores. Rows that score the same
+// lost no comparison, so showing one and hiding another claims a ranking
+// sortByUrgency does not have at that index -- it only has its
+// oldest-activity-first tie-break, which is anti-correlated with what a
+// triage surface is for: it pushes the rows that changed today to the back.
+// That is exactly how a freshly-opened review request ended up behind
+// "Show 4 more" while five older ones stayed visible.
+//
+// `filtered` is true when a query is narrowing the board. A query is an
+// explicit request to see a set, so collapsing the answer to it truncates
+// something the user just asked for -- and it is what made the
+// "Show these in Signals" handoff from the waiting-on-you popover land on
+// fewer rows than the count it came from promised.
+export function visibleCount(
+  rows: { score: number }[],
+  group: ObligationGroup,
+  filtered: boolean
+): number {
+  if (filtered || NEVER_COLLAPSED.has(group)) return rows.length;
+  if (rows.length <= VISIBLE_PER_GROUP) return rows.length;
+  let n = VISIBLE_PER_GROUP;
+  while (n < rows.length && n < VISIBLE_PER_GROUP_MAX && rows[n].score === rows[n - 1].score) n++;
+  return n;
+}

--- a/lib/keymap.ts
+++ b/lib/keymap.ts
@@ -11,8 +11,12 @@ export interface KeyBinding {
 // Most of them (enter/o, x, c, s, e, d, t) fire from that row's own bubbled
 // onKeyDown; j/k are the exception -- they navigate *between* rows, so they
 // fire from GlobalKeymapProvider's document-level listener instead, which
-// scans every `[data-row-id]` on the page (Today, In-progress, and Signals
-// alike) rather than one section's own container. `scope: 'global'`
+// scans every `[data-row-id]` and `[data-row-nav]` on the page (Today,
+// In-progress, and Signals alike) rather than one section's own container.
+// `[data-row-nav]` is how Signals' group-disclosure controls join that
+// walk: they gate whether rows are in the DOM at all, so j/k must be able
+// to stop on one instead of stepping over the rows it is hiding.
+// `scope: 'global'`
 // bindings are page-level and always fire from GlobalKeymapProvider, which
 // checks isTypingTarget before acting on any binding (naturally inert while
 // typing, since focus never reaches a row while an input has it).
@@ -31,6 +35,7 @@ export const KEYMAP: KeyBinding[] = [
   { keys: 'j', description: 'Move focus to the next item', scope: 'row' },
   { keys: 'k', description: 'Move focus to the previous item', scope: 'row' },
   { keys: '↵ / o', description: 'Open upstream in a new tab', scope: 'row' },
+  { keys: '↵', description: "Expand a group's lower-scoring rows, when focused", scope: 'row' },
   { keys: 'x', description: 'Show the score breakdown', scope: 'row' },
   { keys: 'c', description: 'Complete the focused item', scope: 'row' },
   { keys: 's', description: 'Star (local only)', scope: 'row' },

--- a/lib/scoring.test.ts
+++ b/lib/scoring.test.ts
@@ -301,12 +301,28 @@ describe('getScoringReference', () => {
     ]);
   });
 
-  it('discloses all three rules that are not points, including the starred-first sort', () => {
+  it('discloses all five rules that are not points, including the starred-first sort', () => {
     const ref = getScoringReference();
-    expect(ref.nonPointRules).toHaveLength(3);
+    expect(ref.nonPointRules).toHaveLength(5);
     expect(ref.nonPointRules[0]).toMatch(/in progress/i);
     expect(ref.nonPointRules[1]).toMatch(/starred/i);
     expect(ref.nonPointRules[2]).toMatch(/ad-hoc/i);
+    expect(ref.nonPointRules[3]).toMatch(/same score/i);
+    expect(ref.nonPointRules[4]).toMatch(/collapse/i);
+  });
+
+  // Both of these were live rules with no entry here, and the tie-break is
+  // what pushed a review request opened that morning behind a collapsed
+  // group: it decides order, so PRODUCT.md requires it to be disclosed.
+  it('discloses the tie-break direction, not just that a tie-break exists', () => {
+    const ref = getScoringReference();
+    expect(ref.nonPointRules[3]).toMatch(/oldest/i);
+  });
+
+  it('promises the collapse never splits a tie and never hides waiting-on-you', () => {
+    const ref = getScoringReference();
+    expect(ref.nonPointRules[4]).toMatch(/never splits a tie/i);
+    expect(ref.nonPointRules[4]).toMatch(/waiting on you/i);
   });
 
   // The old copy claimed ad-hoc items "have no upstream activity to earn

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -267,6 +267,8 @@ export function getScoringReference(): ScoringReference {
       'Anything you’ve started sorts first, whatever it scores. Work in progress outranks work you haven’t touched.',
       'Starred items sort first inside their group, whatever they score. Starring is a bookmark, not a score.',
       'Ad-hoc requests stay visible below 25, because the signals that lift other rows (review activity, staleness) never reach them. Rows held by that rule are marked "Kept visible".',
+      'Rows on the same score sort oldest activity first, so something that has sat untouched for a week comes before something that moved this morning.',
+      'Each group shows its highest-scoring rows and collapses the rest behind "Lower scoring". The cut never splits a tie: rows on the same score are always shown together, and "Waiting on you" never collapses at all.',
     ],
   };
 }


### PR DESCRIPTION
Closes #79

Two fixes in the Signals list: the group cut no longer hides rows the score does not rank, and the row overflow menu no longer leaves the page unclickable.

## The cut

`VISIBLE_PER_GROUP` moves out of `SignalsBoard.tsx` and becomes `visibleCount(rows, group, filtered)` in `lib/grouping.ts`, next to `sortStarredFirst` and for the same reason: it changes what you can see, so it is a rule the product has to be able to name.

- **It never splits a tie.** The cut starts at 5 and walks forward while `rows[n].score === rows[n - 1].score`, so a run of equal scores is always shown whole. `VISIBLE_PER_GROUP_MAX = 12` stops one huge tie from rendering unbounded.
- **"Waiting on you" never collapses.** Every row in that group is owed action, so the header count has to be a promise the rows keep.
- **A filtered board never collapses.** A query is an explicit request to see a set. This is also what made the `Show these in Signals →` handoff from the waiting-on-you popover land on fewer rows than the count it came from.

## The control

Rebuilt on the same disclosure grammar as `Snoozed · N` and `Paused · N`:

| | before | after |
|---|---|---|
| element | shadcn ghost `Button` | bare `<button>` |
| label | `Show 4 more` (an action) | `Lower scoring · 4` (a state, count in mono/tabular) |
| toggle | one-way, only ever wrote `true` | both ways |
| semantics | none | `aria-expanded` + `aria-controls` on the collapsed wrapper |
| keyboard | unreachable | `data-row-nav`, so `j`/`k` stops on it |

`hiddenCount` is measured from the cut rather than from what is on screen, so the control keeps its label and its count while expanded instead of unmounting under the user's focus. Both halves of a group now render through one `renderRow`, so the visible rows and the hidden ones cannot drift apart in what they support.

`j`/`k` scan `[data-row-id],[data-row-nav]` in `GlobalKeymapProvider.tsx`, and the Enter binding is in `KEYMAP` so it shows up in the `?` cheat sheet.

## Disclosure

`getScoringReference()` goes from three non-point rules to five. Both new entries were already live rules with no entry:

- Rows on the same score sort oldest activity first. This is the one that pushed a review request opened that morning behind the cut while five older ones stayed visible.
- Each group collapses its lower-scoring rows, the cut never splits a tie, and "Waiting on you" never collapses at all.

## The row menu freeze

`ItemRow`'s overflow menu is now `modal={false}`. Snooze, Delete and Open in Claude each mount a dialog while the menu is still up. A modal menu has already written `pointer-events: none` onto `<body>`, and Radix keeps one module-level "original" value, so the dialog captured `none` as the value to restore and wrote it back on close. The page swallowed every click from then until a reload, with no error and no visible cause.

## Verification

- `visibleCount` unit tests in `lib/grouping.test.ts`: under the cap, a clean cut at the cap, extending across a tie, stopping the moment the score changes, the hard ceiling, `waiting_on_you`, and the filtered case.
- `lib/scoring.test.ts` asserts the tie-break direction and the collapse promise, not just that five rules exist.
- New e2e `e2e/signals-collapse.spec.ts`: the cut sliding to 6 to keep six rows at 25 together (asserted on the score chips, not just the row count), the two-way toggle keeping its label while open, `j` landing on the disclosure and Enter expanding it, `Waiting on you` holding 9 tied rows with no control, and a query rendering all 7 matches.
- New e2e `e2e/row-menu-dialog.spec.ts`: each of the three dialog-opening menu items, plus a real delete, asserting the page is still clickable afterwards by reopening a menu rather than by reading the style value.
- `hideExistingItems()` in `e2e/helpers.ts` marks pre-existing rows triage-done so counts in a shared database are the seeded ones.
- 575 unit tests pass, 29/29 e2e pass, `tsc --noEmit` clean, `npm run build` succeeds.
