### PR TITLE
feat(suggest): propose a day from capacity, urgency, and a work-item lean

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,304 @@
+---
+name: Ariadne
+description: The anti-autopilot — a transparent, read-only dashboard for GitHub, Azure DevOps, and ad-hoc work
+colors:
+  backdrop: "hsl(240 10% 3.9%)"
+  ink: "hsl(0 0% 98%)"
+  surface: "hsl(240 5.9% 10%)"
+  surface-raised: "hsl(240 3.7% 15.9%)"
+  muted-ink: "hsl(240 5.5% 64.3%)"
+  indigo-focus: "hsl(243 75% 65%)"
+  indigo-focus-ink: "hsl(0 0% 100%)"
+  threadline-gold: "hsl(41.4 53.8% 54.1%)"
+  signal-red: "hsl(358.8 100% 69.6%)"
+  signal-red-ink: "hsl(0 0% 98%)"
+  amber-watch: "hsl(38 92% 55%)"
+  amber-watch-ink: "hsl(20 14% 4%)"
+  success-green: "hsl(142 71% 45%)"
+  success-green-ink: "hsl(0 0% 98%)"
+  urgency-critical: "hsl(358 75% 59%)"
+  urgency-critical-ink: "hsl(0 0% 8%)"
+  slate-neutral: "hsl(240 5% 65%)"
+  border-hairline: "hsl(0 0% 100% / 10%)"
+  ring-default: "hsl(240 4.2% 46.3%)"
+  series-github: "hsl(212.8 76.8% 56.1%)"
+  series-ado: "hsl(159.2 72.7% 35.9%)"
+  series-adhoc: "hsl(39.7 100% 39.4%)"
+typography:
+  title:
+    fontFamily: "Inter, ui-sans-serif, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 600
+    lineHeight: 1
+    letterSpacing: "-0.01em"
+  body:
+    fontFamily: "Inter, ui-sans-serif, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 500
+    lineHeight: 1.4
+  label:
+    fontFamily: "Inter, ui-sans-serif, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 500
+    lineHeight: 1.3
+  micro:
+    fontFamily: "Inter, ui-sans-serif, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 500
+    lineHeight: 1.3
+  mono:
+    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace"
+    fontSize: "0.6875rem"
+    fontWeight: 600
+    lineHeight: 1
+rounded:
+  sm: "0.25rem"
+  md: "0.375rem"
+  lg: "0.5rem"
+  xl: "0.75rem"
+spacing:
+  row-compact: "2.25rem"
+  row-comfortable: "2.75rem"
+  gap-sm: "0.5rem"
+  gap-md: "0.75rem"
+  gap-lg: "1.5rem"
+components:
+  button-primary:
+    backgroundColor: "{colors.indigo-focus}"
+    textColor: "{colors.indigo-focus-ink}"
+    rounded: "{rounded.md}"
+    padding: "0.5rem 1rem"
+    height: "2.25rem"
+  button-primary-hover:
+    backgroundColor: "{colors.indigo-focus}"
+  button-outline:
+    backgroundColor: "{colors.backdrop}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+    padding: "0.5rem 1rem"
+    height: "2.25rem"
+  button-ghost:
+    backgroundColor: "{colors.backdrop}"
+    textColor: "{colors.muted-ink}"
+    rounded: "{rounded.md}"
+    height: "2.25rem"
+  badge-outline:
+    backgroundColor: "{colors.backdrop}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+    padding: "0.125rem 0.625rem"
+  badge-critical:
+    backgroundColor: "{colors.urgency-critical}"
+    textColor: "{colors.urgency-critical-ink}"
+    rounded: "{rounded.md}"
+    padding: "0.125rem 0.625rem"
+  card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.xl}"
+    padding: "1.5rem"
+  input:
+    backgroundColor: "{colors.backdrop}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+    padding: "0.25rem 0.75rem"
+    height: "2.25rem"
+  score-chip:
+    rounded: "{rounded.sm}"
+    typography: "{typography.mono}"
+    height: "1.25rem"
+    width: "1.5rem"
+  disclosure-toggle:
+    backgroundColor: "{colors.backdrop}"
+    textColor: "{colors.muted-ink}"
+    typography: "{typography.micro}"
+    padding: "0.75rem 0 0.25rem"
+---
+
+# Design System: Ariadne
+
+## Overview
+
+**Creative North Star: "The Night Instrument Panel"**
+
+Ariadne reads like calm cockpit instrumentation, not a productivity app trying to earn a click. The surface sits in near-black by default (`enableSystem: false`, `defaultTheme: "dark"` — dark is not a preference toggle here, it is the intended resting state), so nothing on screen is competing for brightness. Precise mono numerals report scores, sprint counts, and elapsed time the way a gauge reports a reading: exact, tabular, unemotional. Color is an instrument, not decoration — indigo is reserved exclusively for things you can act on (buttons, links, focus), and a single warm gold thread, echoing the product's namesake myth, marks the thread you are on right now: identity, the running timer, and the day you have committed to. The type scale barely moves; hierarchy comes from weight and restraint, not size jumps, because a dense attention-triage surface earns its calm from what it refuses to shout about.
+
+This is a deliberate rejection of the SaaS-dashboard palette-soup default: no gradient hero, no rainbow of status colors, no drop shadows pretending the interface is a stack of physical cards. The instrument-panel read only works if the panel stays quiet almost everywhere so the two or three signals that matter (a critical urgency chip, a stale-sync warning) can actually read as urgent.
+
+**Key Characteristics:**
+- Dark-first, near-black backdrop as the default resting state, not an alternate theme
+- Indigo is interactive-only — it never appears as a status, urgency, or decorative color
+- One brand accent (Threadline Gold), reserved for identity and for "this is your thread, live right now" — never for a source-reported state
+- Mono, tabular-nums numerals for every instrument reading (scores, counts, elapsed time)
+- A flat scale: hierarchy comes from weight and color restraint, not dramatic size changes
+- Flat surfaces with barely-there shadows; depth exists only to separate stacked layers
+
+## Colors
+
+The palette reads as three tiers: a near-monochrome backdrop, one interactive hue, and a small, urgency-only accent set that only fires when something needs attention.
+
+### Primary
+- **Indigo Focus** (`hsl(243 75% 65%)` dark / `hsl(243 75% 59%)` light): The only interactive color in the system. Buttons' default variant, links, focus rings (`focus-visible:ring-ring`), and nothing else. Confirmed in code comments in `ScoreChip.tsx` and `ItemRow.tsx`: "Indigo never appears here — that channel is interactive-only." Never use it for a status pill, urgency chip, or any non-actionable signal.
+
+### Secondary
+- **Threadline Gold** (`hsl(41.4 53.8% 54.1%)`): The one constant brand accent, identical in light and dark mode (defined once on `:root`, never overridden). It carries two related jobs and no others, both versions of the same idea — the thread you are currently holding:
+  1. **Identity.** Baked into the brand lockup artwork (`public/brand/ariadne-banner.png` and the app icons), and the focus ring on the two pieces of chrome adjacent to identity (the logo link and the search trigger, `TopBar.tsx`). These are the only two focus rings in the app that are not the neutral ring.
+  2. **Your thread, live.** The pulsing dot on a running timer (`RunningTimerChip.tsx`, `ItemRow.tsx`), the left edge of the Today card (`TodaySection.tsx`), and the capacity figure for the day you have committed to (`TodaySection.tsx`, `PlanDayDialog.tsx`). The search-match highlight (`<mark>` in `ItemRow.tsx`, at 30% alpha) belongs here too: it marks the row you are currently looking for.
+
+  What unites the second group is that none of it is reported by GitHub or Azure DevOps. It is all local, present-tense, and yours: the timer that is running, the day you chose, the row you are hunting. Source-reported state never gets gold — that is what Amber Watch and Signal Red are for.
+
+### Tertiary
+- **Amber Watch** (`hsl(38 92% 55%)`): Warning, staleness, and the "high" urgency band. Shared value doubles as `--warning` and `--urgency-high` — one hue for "needs attention soon."
+- **Signal Red** (`hsl(358.8 100% 69.6%)` destructive / `hsl(358 75% 59%)` urgency-critical, distinct tunings of the same hue): Destructive actions and the "critical" urgency band.
+- **Success Green** (`hsl(142 71% 45%)`): Defined on the `Badge` component (`variant="success"`). Reserved for exactly one meaning: "this is saved or done and needs no action," never for a status that demands attention. It has two examined uses, each admitted against the Two-Band/color-scarcity rule below rather than by default:
+  1. The "Token saved" indicator per integration on the Settings page (`SettingsForm.tsx`). Settings is a low-traffic configuration surface, not the dashboard's attention-triage view, so a quiet affirmative marker there doesn't compete with or dilute the urgency bands' scarcity.
+  2. The settled check on the score chip (`ScoreChip.tsx`, driven by `lib/settled.ts`), which fires when the source system has finished an item that Ariadne, being read-only, still shows as open. This one does appear on the dashboard, and it is admitted anyway because it is the literal reserved meaning: the chip stops reporting a live urgency reading and reports "done, nothing left to do here." It cannot compete with the urgency bands because it replaces one — a row shows the check or a score, never both. The `gone` outcome (an ADO work item set to Removed) deliberately does **not** get the green: it left your plate without being finished, so it takes the neutral low-band treatment instead. Green here means you got it over the line.
+
+  A third use needs the same examination, and specifically needs to answer why it isn't competing with the urgency bands.
+
+- **Report series** (`hsl(212.8 76.8% 56.1%)` GitHub / `hsl(159.2 72.7% 35.9%)` Azure DevOps / `hsl(39.7 100% 39.4%)` ad-hoc): Three categorical hues, used only on the time-report charts (`ReportDashboard.tsx`, Recharts pie and bar). They identify a source, not a state, and they exist only on `/report` — a surface you go to deliberately rather than triage against. Keeping them off the dashboard is what stops the palette from reading as a rainbow where scarcity matters. Note the ad-hoc series sits close to Amber Watch in hue; that collision is tolerable only because the two never share a screen.
+
+### Neutral
+- **Backdrop** (`hsl(240 10% 3.9%)` dark / `hsl(0 0% 100%)` light): Page background.
+- **Ink** (`hsl(0 0% 98%)` dark / `hsl(240 10% 3.9%)` light): Primary text.
+- **Surface** (`hsl(240 5.9% 10%)` dark / `hsl(0 0% 100%)` light): Cards, popovers, dialogs — one step off the backdrop.
+- **Surface Raised** (`hsl(240 3.7% 15.9%)` dark): Secondary buttons, muted backgrounds, hover accents — one step further off the backdrop.
+- **Muted Ink** (`hsl(240 5.5% 64.3%)`): Secondary text, metadata, timestamps, and every disclosure control.
+- **Slate Neutral** (`hsl(240 5% 65%)` dark / `hsl(240 5% 45%)` light): The "medium" and "low" urgency bands, and the neutral status pill. Deliberately colorless so only the top two urgency bands compete for attention.
+- **Border Hairline** (`hsl(0 0% 100% / 10%)` dark / `hsl(240 5.9% 90%)` light): Row dividers, card borders. An alpha-over-ink hairline in dark mode, not a separate flat gray.
+
+### Named Rules
+**The Interactive-Only Rule.** Indigo Focus is the sole signal for "you can act on this." It never labels a state, a category, or an urgency level. If a new component needs a color for a clickable thing, it's this one; if it needs a color for a status, it's never this one.
+
+**The One Thread Rule.** Threadline Gold marks the thread you are on, and nothing else: the brand lockup and its two identity-adjacent focus rings, plus the four present-tense local signals (running-timer pulse, the Today card's edge, today's capacity figure, the search match). The test for a new gold element is one question: *is this fact local, present-tense, and mine?* A figure GitHub or Azure DevOps reported is never gold, however important. Nor is a generic interactive control — that is Indigo Focus's job.
+
+**The Two-Band Rule.** Of the four urgency bands, only Critical and High are filled with color; Medium is an outline in a neutral hue and Low has no border at all. Visual weight must always fall off in the same direction as the score. A design that fills all four bands with color has broken the thesis that attention should be scarce.
+
+## Typography
+
+**Body Font:** Inter (loaded via `next/font/google` as `--font-sans`, with the system sans-serif stack)
+**Mono/Numeral Font:** system monospace stack (`ui-monospace, SFMono-Regular, Menlo`)
+
+**Character:** All-Inter, all-sans. There is no display or serif face in the system: the Ariadne wordmark is not set in type at all, it ships as artwork inside the brand banner. Inter runs at a narrow weight range (500–600) doing all the hierarchy work through boldness and color, not scale.
+
+### Hierarchy
+- **Title** (600, 1.125rem/18px, leading-none, -0.01em tracking): Dialog and modal headings ("Mark complete", "Delete ad-hoc item?").
+- **Body** (500, 1rem/16px, leading 1.4): Item row titles and other primary content — the ambient default text size, not an explicit utility class.
+- **Label** (500, 0.875rem/14px, leading 1.3): Secondary UI text — descriptions, button labels, metadata lines, form labels.
+- **Micro** (400–500, 0.75rem/12px): Badge and pill text, hover-card fine print, source metadata, disclosure controls.
+- **Mono/Numeral** (600, 0.6875rem/11px, tabular-nums): The score chip's number, sprint counters ("4/17"), days-remaining, timer readouts, and every count carried by a disclosure control or a header pill. Always monospace, always tabular, never proportional — this is the "instrument reading" register and it must stay visually distinct from prose.
+
+### Named Rules
+**The Instrument Numeral Rule.** Any number that represents a live measurement (a score, a count, a duration) renders in the mono/tabular register, never in the body font. A count that looks like prose reads as a fact you already know; a count in mono digits reads as a live reading you should check. This is the rule most often broken by accident: a count interpolated into a sentence inherits the body font unless you wrap it.
+
+**The Single Face Rule.** Inter is the only typeface in the system. There is no display font, no serif, and no second sans. A new heading, stat, or hero moment does its work with weight and color, because introducing a second face would turn a deliberately flat scale into a conventional one.
+
+## Layout
+
+A single dense information surface, not a marketing-style spacious one. The dashboard is one continuous column of sections and rows inside a `max-w-6xl` centered container; the top bar spans full width with a fixed 4-column grid (logo / running-timer chip / search trigger / actions) at a 16px horizontal page gutter (`px-6`).
+
+Row density is a first-class, user-facing setting with exactly two states, both on a 4px grid: **comfortable** (2.75rem/44px = 11 × 4px) and **compact** (2.25rem/36px = 9 × 4px). Row height is fixed per mode so content can never reflow it; below the `sm` breakpoint (640px, the only breakpoint the system uses) rows wrap onto two lines instead of shrinking further. Sections stack vertically with `border-b` hairline dividers between rows rather than card gaps — the list itself is the container, individual rows are not cards.
+
+Responsive behavior is mobile-down, not mobile-up: the row-actions cluster is always visible on touch (`opacity-100`) but recedes to `opacity-60` on hover-capable pointers until hover or focus, since a hidden-until-hover affordance only makes sense where hovering is possible.
+
+Long lists are cut rather than scrolled: an obligation group renders its highest-scoring rows and collapses the remainder behind a disclosure control. The cut is a visual rule with a semantic constraint — see the Disclosure Control component and `lib/grouping.ts`.
+
+## Elevation & Depth
+
+Flat by default, with the barely-there `shadow-sm`/`shadow` values Tailwind ships out of the box — never a custom, more dramatic shadow. This is a deliberate extension of the instrument-panel thesis: surfaces don't pretend to be physical objects stacked on a desk, they're panels in the same plane, differentiated by the neutral color steps (Backdrop → Surface → Surface Raised) more than by shadow. Where a shadow does appear (cards, the default button, badges), it is there only to separate one flat layer from the one behind it, not to imply weight, hover lift, or tactility.
+
+### Shadow Vocabulary
+- **Surface separation** (Tailwind `shadow` / `shadow-sm`, unmodified defaults): Cards, the default button variant, and filled badges. Signals "this sits above the backdrop," nothing more.
+- **Drag lift** (Tailwind `shadow-lg`, plus an opaque `bg-background` and `z-10`, `SortableRows.tsx`): The one admitted exception to the flat rule, and the only place in the system that uses a shadow heavier than `shadow`. A row being dragged is the single moment where tactility is the literal truth rather than a metaphor: the row has genuinely left the plane of the list and needs to occlude what it passes over. It reverts to flat the instant the drag ends. Do not reach for this value for hover, focus, or emphasis.
+
+### Named Rules
+**The Flat-By-Default Rule.** Depth comes from the neutral color scale (Backdrop / Surface / Surface Raised), not from shadow intensity. A new component reaching for a heavier shadow to "lift" itself is fighting the instrument-panel read; reach for the next neutral step instead. The drag lift is the exception that proves it: it is allowed precisely because the element really is airborne.
+
+## Shapes
+
+A restrained two-step corner scale, deliberately not one uniform radius. Interactive controls (buttons, inputs, badges, the score chip) use the small end (`0.25–0.375rem`) so they read as precise, clickable instrumentation. Containers (cards, dialogs) use the larger `0.75rem` so they read as distinct panels holding that instrumentation, not as one more control. The score chip — the system's most "instrument-like" element — uses the smallest radius in the scale (`0.25rem`), reinforcing that it is a reading, not a button.
+
+Borders are hairline and low-contrast (`hsl(0 0% 100% / 10%)` in dark mode — an alpha-over-ink line, not a flat gray), used for row dividers and card outlines. There is no decorative border weight anywhere in the system; a border only ever marks a structural seam.
+
+## Components
+
+### Buttons
+- **Shape:** `0.375rem` radius (rounded-md), consistent across all variants.
+- **Primary:** Indigo Focus background, white text, subtle shadow, `hover:bg-primary/90`. Reserved for the one clearly-primary action per context (Complete, the command-palette invocation is a ghost button, not this).
+- **Outline / Ghost:** Transparent or backdrop background, Ink or Muted Ink text, hairline border on outline only. This is the default for row actions (Start, Complete on `ItemRow`) — deliberately not the filled Primary treatment, since every row's action competes with every other row's, and filling all of them would break the Two-Band attention gradient at the button level too.
+- **Sizes:** `h-9` default / `h-8` small / `h-10` large / `h-9 w-9` icon-only. Density mode can push a button to `h-11` inline (see comfortable row height).
+- **Not for disclosure.** A `Button` of any variant is the wrong primitive for expanding or collapsing a list; that has its own pattern below.
+
+### Score Chip (signature component)
+The system's most distinctive custom primitive, not a shadcn default. A small (`h-5`, `min-w-6`) mono, tabular-nums button, `0.25rem` radius, that opens a popover breakdown of exactly which scoring rules fired. Fill and border follow the Two-Band Rule: Low is borderless text, Medium is a neutral 2px outline, High and Critical are filled with Amber Watch / Signal Red respectively using dark ink (never white) as the foreground, per the paired `*-foreground` tokens. This is the component that makes "transparent, not opaque" a visible, clickable fact rather than a claim in the README.
+
+**Settled state.** When the source system has closed an item Ariadne still shows as open, the chip stops reporting a number and reports the outcome instead: a `Check` glyph on Success Green for `finished`, a `Minus` glyph in the neutral low-band treatment for `gone`. The score stays fully inspectable in the popover underneath. A row shows a reading or an outcome, never both.
+
+### Disclosure Control (signature pattern)
+The house grammar for "there is more here, and here is exactly how much." Used in three places — `Snoozed · 3` and a group's `Lower scoring · 4` in `SignalsBoard.tsx`, and `Paused · 2` in `ItemSection.tsx` — and it must be used for any fourth.
+
+- **Shape:** a bare `<button>`, never a `Button` component. Full width, `pt-3 pb-1`, no border, no background, no radius of its own.
+- **Type:** Micro (`text-xs font-medium`) in Muted Ink, rising to Ink on hover. It is subordinate to every row it sits under and must never carry the visual weight of the content it hides.
+- **Label:** a state, then an interpunct, then the count in the mono/tabular register: `Paused · 2`. The label names *what* the hidden rows are, not the act of revealing them. "Show more" is not a state and is not an acceptable label.
+- **Semantics:** `aria-expanded` plus `aria-controls` pointing at the wrapper `div` that holds the collapsed rows, which carries the matching `id`. Toggles both ways, always; a one-way expansion is a defect.
+- **Keyboard:** carries `data-row-nav` so `j`/`k` row navigation stops on it (`GlobalKeymapProvider.tsx`) rather than stepping over the rows it hides. Enter and Space activate it natively.
+- **The count is a promise.** A group's header pill shows the true total; the disclosure accounts for the difference. If a cut would separate two rows the ranking scores identically, the cut moves rather than the truth (`visibleCount()` in `lib/grouping.ts`) — hiding one row while showing its equal claims a rank the score does not have.
+
+### Badges / Pills
+- **Style:** `0.375rem` radius, `border`, `text-xs font-semibold`, one badge per row maximum (see `ItemRow`'s inline-badge precedence logic — extra reason pills move to a hover-card rather than piling up).
+- **State:** `outline` is the default/neutral treatment for reason pills (approved, mentioned, review-requested); filled variants (`destructive`, `warning`, `blocked`, `success`) are reserved for states that demand action or, for `success`, the one affirmative meaning documented under Success Green.
+
+### Cards / Containers
+- **Corner Style:** `0.75rem` radius (rounded-xl), the largest radius in the system.
+- **Background:** Surface, one step off the backdrop.
+- **Shadow Strategy:** Default Tailwind `shadow` only; see Elevation & Depth.
+- **Border:** Hairline, low-contrast. The Today card is the one card with a colored edge — a 2px Threadline Gold left border marking the day you committed to, per The One Thread Rule.
+- **Internal Padding:** `1.5rem` (p-6), trimmed to `1.5rem 1.5rem 0` between header and content.
+
+### Inputs / Fields
+- **Style:** `0.375rem` radius, hairline border, transparent/backdrop background, `shadow-sm`.
+- **Focus:** `ring-1 ring-ring` — the neutral focus ring, not Indigo Focus and not Threadline Gold; those two are reserved per the Named Rules above.
+- **Error:** Signal Red text below the field, not a red border on the field itself.
+
+### Segmented Control
+`SegmentedChoice.tsx`, the shared primitive for **a value the user sets by hand**, as opposed to one a source reported. A radiogroup of adjacent segments; the selected segment carries full opacity and the unselected ones drop to 60%, with an optional readout beside each label in the mono/tabular register. Selection is signalled by opacity and weight, not by a fill, so it stays visually quieter than any urgency band — the urgency channel belongs to the score chip, and a coloured control here would read as a fifth band and break the Two-Band Rule. One tab stop, arrow keys to move, per the radiogroup pattern.
+
+Three consumers, and the rationale is the same in all three:
+- **Priority** (`PrioritySegments.tsx`): the ad-hoc item's hand-set priority, `low`/`medium`/`high`, each showing its point contribution (`+0`, `+20`, `+40`). Clearable, because "I haven't decided" is a real state and the one every item starts in.
+- **Suggestion algorithm** (`SuggestPanel.tsx`): Urgency first / Quick wins / Balanced, no readout, filling the panel's width.
+- **Suggestion lean** (`SuggestPanel.tsx`): five notches, each stating the whole split it produces (`80/20` … `20/80`) rather than one side of it. A bare `20` sitting next to the "PRs" axis label reads as "pull requests get 20", which is the opposite of what that notch means, so the compact pair is the label and the spoken name spells it out in full.
+
+Equal-width segments are opt-in (`fill`), so a control sized by its content keeps its proportions when the primitive is reused.
+
+### Drag Handle
+`SortableRows.tsx`, used only in Today and step 3 of Plan the day, where the list is hand-ordered rather than score-ordered. A 16px `GripVertical` glyph in Muted Ink, `cursor-grab` becoming `cursor-grabbing`, `touch-none` so a touch drag doesn't scroll the page. The row it belongs to takes the Drag lift shadow while moving. A handle appears only where order is genuinely the user's to set; a score-ordered list must never show one.
+
+### Navigation (Top Bar)
+Sticky, full-bleed, `backdrop-blur` translucent over the backdrop color, hairline bottom border. Four-column grid: the Ariadne brand banner at 32px height (`public/brand/ariadne-banner.png`, a self-contained dark lockup that reads the same in light and dark mode), running-timer chip, `⌘K` search trigger, then icon-button actions (Report, Settings, theme toggle). The logo link and search trigger are the only two controls in the entire app whose focus ring is Threadline Gold instead of the neutral ring — a deliberate, small tell that these two controls are "about the product's identity," not just generic navigation.
+
+### Report Charts
+`ReportDashboard.tsx` only. A Recharts pie (time by source) and bar (daily series), colored from the three Report series hues and nothing else. Charts get no gridline decoration, no gradient fills, and no drop shadows; they are readings rendered large, consistent with the instrument-panel thesis. This is the only surface in the app that carries categorical color.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** keep Indigo Focus exclusively on things the user can click or activate.
+- **Do** render every live measurement (scores, counts, durations) in the mono/tabular-nums register, including counts that sit inside a label.
+- **Do** let visual weight fall off across the urgency scale — Critical and High filled, Medium outlined, Low borderless.
+- **Do** use the larger `0.75rem` radius only for containers (cards, dialogs) and the smaller `0.25–0.375rem` radii for controls and instrumentation.
+- **Do** treat dark mode as the default resting state when choosing new colors, not as a theme variant bolted on afterward.
+- **Do** use the Disclosure Control pattern for anything that hides rows, and give it a label that names a state (`Snoozed · 3`), `aria-expanded`, `aria-controls`, a two-way toggle, and `data-row-nav`.
+- **Do** ask of any proposed gold element: is this fact local, present-tense, and mine? If not, it is not gold.
+- **Do** reach for `SegmentedChoice` for any value the user sets by hand, and keep it quieter than any urgency band.
+- **Do** mark a number the tool worked out for the user, and leave a number the user set unmarked. The suggestion panel prefixes a derived duration with `~` in Muted Ink and states a real estimate plainly in Ink; a guess that looks like a commitment is the most misleading thing an inspectable ranking can do.
+
+### Don't:
+- **Don't** put Threadline Gold on anything a source system reported, on a report series, or on a generic interactive control. Identity and your live thread are its whole remit.
+- **Don't** add a fifth or sixth urgency color, or fill the Medium/Low bands — the scarcity of color is what makes Critical/High legible at a glance.
+- **Don't** bring the Report series hues onto the dashboard. Categorical color is confined to `/report`, and that confinement is what keeps the triage surface quiet.
+- **Don't** reach for a heavier or colored shadow to convey emphasis; use the neutral surface-step scale instead. `shadow-lg` belongs to an in-flight drag and nowhere else.
+- **Don't** introduce a second typeface of any kind. Inter carries everything; the wordmark is artwork.
+- **Don't** re-typeset or recolor the wordmark. The banner and icon PNGs in `public/` are the only approved lockups.
+- **Don't** stack more than one inline badge per row; additional context belongs in the hover-card, per the existing overflow pattern.
+- **Don't** use a `Button` component to expand or collapse a list, and don't label such a control "Show N more" — it names an action instead of a state, and it can claim a ranking the score does not have.
+- **Don't** treat `--chart-4`, `--chart-5`, or the eight `--sidebar-*` tokens as part of this system. They are unused shadcn scaffolding left in `globals.css` and `tailwind.config.ts`; nothing renders them, and new work should not start.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,156 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Primary user is Chris, a software engineer who works across GitHub and Azure
+DevOps day to day and also fields ad-hoc requests (face-to-face, email,
+Teams). He is currently the sole user and the tool is built around his
+personal workflow. Multi-user support is not ruled out as a future
+possibility, but nothing in the product today assumes or builds toward a
+second account — see Capabilities and Constraints.
+
+## Product Purpose
+
+Ariadne gives Chris a clear, at-a-glance overview of his work and the mental
+space to process it. It pulls GitHub (PRs, review requests, mentions), Azure
+DevOps (assigned work items, comments, sprint iterations), and ad-hoc
+requests into one ranked view, tracks sprint progress, and lets him pick
+what he's working on and log time against it. It is explicitly not trying
+to manage his calendar. It will propose a day when asked, and only when
+asked, with its reasoning shown and nothing written until he accepts; what
+it will not do is decide for him or arrange his time on its own.
+
+## Positioning
+
+"The anti-autopilot": a transparent, read-only thread through GitHub, Azure
+DevOps, and ad-hoc work signals, not an algorithm that runs the day. No
+other personal tool combines all three source types into one view. The
+category it's positioned against (deliberately unnamed as specific rivals
+in user-facing copy) is autoscheduling productivity tools like Motion,
+Reclaim.ai, Sunsama, and Akiflow, which auto-arrange calendars and rank
+work with opaque, ML-driven priority.
+
+## Operating Context
+
+- Runs as a single local Next.js app (frontend + API routes together),
+  either via `npm run dev`/`npm start` or self-hosted via Docker.
+- Data lives in a local SQLite file (`better-sqlite3`); no separate database
+  server, no cloud sync.
+- On first run, Chris adds GitHub and Azure DevOps personal access tokens
+  (read-only scopes) in Settings; tokens are stored in the SQLite `settings`
+  table in plaintext, the same trust model as a `.env` file.
+- Syncs automatically every 5 minutes while the dashboard is open, plus a
+  manual Refresh button.
+- Ariadne has no login of its own when run locally; exposing it beyond
+  loopback requires setting `ARIADNE_AUTH_TOKEN` for Basic Auth.
+- Day-to-day usage: reviewing the ranked dashboard, starting/completing
+  items (local-only status, cascades only touch Ariadne's own `items`
+  table), tracking sprint progress, and logging time via a timer/report
+  view.
+
+## Capabilities and Constraints
+
+- **Personal, local-only, single-user today.** SQLite file on the machine,
+  no account system, no multi-tenant backend. A second user/account is an
+  explicitly undecided future possibility, not a planned feature — do not
+  build toward it speculatively, but don't foreclose it either (e.g. avoid
+  hardcoding single-user assumptions in ways that would make later support
+  painful for no reason).
+- **Read-only against source systems, always.** Ariadne never writes back
+  to GitHub or Azure DevOps. Actions like Start/Complete, even when they
+  cascade to linked items, only ever touch Ariadne's own local `items`
+  table.
+- **Transparent, deterministic scoring, not AI-driven.** Urgency is a
+  visible point formula (own PR approved, mentioned, stale, due soon, ...)
+  in `lib/scoring.ts`, not an opaque ML ranking. Every score chip on the
+  dashboard opens to show exactly which rules fired and which didn't. One
+  term in the formula is set by hand rather than observed: an ad-hoc item's
+  priority (low/medium/high). It is shown under its own "what you set"
+  heading, separate from what the sources report, and it is the only such
+  term. Three non-point rules also affect ordering and must stay disclosed
+  wherever the scoring is explained: `sortByUrgency()` promotes every
+  in-progress item above everything else regardless of score,
+  `sortStarredFirst()` lifts starred items to the top of their group
+  whatever they score, and ad-hoc items are exempt from the attention
+  threshold. The suggestion rules (three selectable algorithms, how a
+  duration is resolved, what the preference cap does) are generated from the
+  same constants the engine reads and published in the same reference dialog
+  as the scoring rules, so neither can drift from the code.
+- **No auto-scheduling.** No auto-arranging of the calendar or the day.
+  Ariadne surfaces signals; Chris decides what to work on and when.
+  Planning rituals (e.g. a plan/wrap-up flow with capacity) support this
+  decision without making it for him. Suggestion is the one place Ariadne
+  proposes an answer. It runs only when asked, shows its reason for every
+  pick and the provenance of every duration, writes nothing until Chris
+  accepts, and never reorders or removes anything on its own. The score
+  itself is never adjusted to produce a suggestion: the preference control
+  is a cap on how much of the day each side of the work-item/pull-request
+  split can take, not a weight on any score. Where that cap holds something
+  back, the day is left with room in it rather than filled from the other
+  side, and the rows it held back are listed, so the cost of the setting is
+  visible rather than silent.
+- **Deliberately small surface.** A dashboard route, a time report, and
+  Settings. New features are scoped tightly; real tradeoffs (like plaintext
+  token storage) are accepted explicitly rather than hidden.
+- **Keyboard-first is a durable principle, not just a roadmap feature.**
+  Future surfaces should stay fast and usable via keyboard, not only mouse
+  driven — this motivates the existing keyboard-shortcut layer and Cmd+K
+  command palette work and should inform new UI beyond that specific
+  roadmap.
+- **Today and In-progress are independent axes, not one bucket each.**
+  Today reflects a day's plan (`today_date`/`plan_items`, unaffected by
+  status changes); In-progress reflects live work status. An item pinned to
+  today's plan stays visible in Today through Start/Pause/Complete and can
+  legitimately appear in both Today and In-progress at once. Signals stays
+  mutually exclusive of Today: an item exists in exactly one of Today /
+  Signals at a time (pinning to today is a move out of Signals, not a
+  copy). Preserve the Today/Signals exclusivity when touching item-state
+  logic; do not reintroduce it between Today and In-progress.
+
+## Brand Commitments
+
+- Name: **Ariadne**. Tagline: "the anti-autopilot: a transparent, read-only
+  thread through your GitHub, Azure DevOps, and ad-hoc work signals, not an
+  algorithm that runs your day."
+- Logo: the threaded-A mark. Brand lockup is `public/brand/ariadne-banner.png`
+  (used in the app's top bar and at the top of the README); app icons and
+  favicons are the `public/icon-*.png`, `public/favicon.ico`,
+  `public/apple-touch-icon.png`, and `public/android-chrome-*.png` set.
+- Voice: plain, declarative, calm, a little dry. No hype adjectives
+  ("revolutionary", "powerful", "seamless"). No em-dashes in any
+  user-facing or marketing copy. Never name competitor products in
+  user-facing copy (describe the category/behavior contrasted with
+  instead). Tone calibrated against well-known self-hosted/homelab OSS
+  READMEs (e.g. Octobox, Glance), not SaaS marketing copy.
+
+## Evidence on Hand
+
+- `docs/screenshot-dashboard.png` — dashboard showing Today, In progress,
+  and Signals grouped by GitHub, Azure DevOps, and ad-hoc.
+- `docs/screenshot-empty-state.png` — first-run empty state prompting to
+  add tokens in Settings or add an ad-hoc request.
+- `docs/wireframes/` — wireframes for the 5-phase Issue #15 UI/UX roadmap
+  (Foundation, Make the thesis visible, Speed and control, Shape of a day,
+  Finish), rendered from an external proposal doc.
+- No testimonials, benchmarks, pricing, or customer case studies exist;
+  none should be fabricated. This is a personal/self-hosted tool, not a
+  commercial product.
+
+## Product Principles
+
+- Give visibility and mental space, don't make decisions for the user.
+- A suggestion is a proposal, never a commitment. Nothing the tool worked out
+  for you becomes a number you own until you accept it.
+- Keep ranking legible: if a score exists, its rules must be inspectable.
+- Never write back to source systems; local state stays local.
+- Accept real tradeoffs explicitly instead of hiding them behind false
+  reassurance.
+- Keep the surface small; scope new features tightly rather than growing a
+  general-purpose work-management tool.
+- Stay fast for a keyboard-driven power user, not just a mouse-driven one.

--- a/app/api/suggest/route.ts
+++ b/app/api/suggest/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db-instance';
+import { listItems } from '@/lib/items-repo';
+import { getSetting } from '@/lib/settings-repo';
+import { sortByUrgency } from '@/lib/scoring';
+import { getPlan, getPlanItems, getLatestPriorEstimates } from '@/lib/plans-repo';
+import { medianMinutesByWorkType } from '@/lib/time-logs-repo';
+import { localDateString } from '@/lib/date';
+import { SETTINGS_KEYS, DEFAULT_SUGGEST_ALGORITHM } from '@/lib/config';
+import {
+  suggestDay,
+  isSuggestCandidate,
+  DEFAULT_LEAN,
+  type SuggestAlgorithm,
+  type LeanNotch,
+  type SuggestCandidate,
+  type SuggestionItem,
+} from '@/lib/suggest';
+
+const ALGORITHMS: SuggestAlgorithm[] = ['urgency', 'quick_wins', 'balanced'];
+
+function parseAlgorithm(raw: string | null, fallback: string | null): SuggestAlgorithm {
+  for (const value of [raw, fallback, DEFAULT_SUGGEST_ALGORITHM]) {
+    if (value && (ALGORITHMS as string[]).includes(value)) return value as SuggestAlgorithm;
+  }
+  return 'balanced';
+}
+
+function parseLean(raw: string | null, fallback: string | null): LeanNotch {
+  for (const value of [raw, fallback]) {
+    const notch = Number(value);
+    if (value !== null && value !== '' && Number.isInteger(notch) && notch >= 0 && notch <= 4) {
+      return notch as LeanNotch;
+    }
+  }
+  return DEFAULT_LEAN;
+}
+
+export async function GET(request: Request) {
+  const now = new Date();
+  const params = new URL(request.url).searchParams;
+  const today = localDateString(now);
+
+  const algorithm = parseAlgorithm(params.get('algorithm'), getSetting(db, SETTINGS_KEYS.suggestAlgorithm));
+  const lean = parseLean(params.get('lean'), getSetting(db, SETTINGS_KEYS.suggestLean));
+
+  const sprintEnd = getSetting(db, SETTINGS_KEYS.sprintEnd);
+  const items = listItems(db);
+  const scored = sortByUrgency(items.map((item) => ({ ...item, sprintEnd })), now);
+
+  const estimateByItemId = new Map(getPlanItems(db, today).map((pi) => [pi.itemId, pi.estimateMinutes]));
+
+  // Pool membership is isSuggestCandidate's job, so the rules stay unit
+  // tested rather than living in a route. pinnedTodayCount is counted
+  // separately because it is the only way the engine can tell "Signals is
+  // empty" apart from "you have already planned all of it".
+  const pool = scored.filter((item) => isSuggestCandidate(item, today, now));
+  const pinnedTodayCount = scored.filter(
+    (item) => item.todayDate === today && isSuggestCandidate({ ...item, todayDate: null }, today, now)
+  ).length;
+
+  const candidates: SuggestCandidate[] = pool.map((item) => ({
+    id: item.id,
+    source: item.source,
+    reason: item.reason,
+    status: item.status,
+    score: item.score,
+    rawUpdatedAt: item.rawUpdatedAt,
+    estimateMinutes: estimateByItemId.get(item.id) ?? null,
+  }));
+
+  const suggestion = suggestDay({
+    candidates,
+    capacityMinutes: getPlan(db, today).capacityMinutes,
+    algorithm,
+    lean,
+    medians: medianMinutesByWorkType(db),
+    priorEstimates: getLatestPriorEstimates(db, today),
+    pinnedTodayCount,
+    now,
+  });
+
+  // The rows the proposal references travel with it so the panel can render
+  // titles and score chips without a second request.
+  const referenced = new Set([
+    ...suggestion.picks.map((p) => p.itemId),
+    ...suggestion.didNotFit.map((c) => c.itemId),
+    ...suggestion.deferredByLean.map((c) => c.itemId),
+  ]);
+  const referencedItems: SuggestionItem[] = scored.filter((item) => referenced.has(item.id));
+
+  return NextResponse.json({ suggestion, items: referencedItems });
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,6 +2,9 @@ import Link from 'next/link';
 import SettingsForm from '@/components/SettingsForm';
 import { db } from '@/lib/db-instance';
 import { getRedactedSettings } from '@/lib/settings-repo';
+import { medianMinutesByWorkType } from '@/lib/time-logs-repo';
+import { WORK_TYPE_LABEL, type WorkType } from '@/lib/calibration';
+import { FALLBACK_MINUTES, MIN_SAMPLES_FOR_MEDIAN } from '@/lib/suggest';
 
 // GET has no dynamic API usage, so Next.js would statically bake this at
 // build time otherwise — same class of bug already fixed for `/` and
@@ -10,13 +13,29 @@ export const dynamic = 'force-dynamic';
 
 export default function SettingsPage() {
   const settings = getRedactedSettings(db);
+
+  // One row per work type in WORK_TYPE_LABEL order, so a bucket with no logs
+  // still appears with its fixed default rather than vanishing from the list.
+  const medians = medianMinutesByWorkType(db);
+  const learnedDurations = (Object.keys(WORK_TYPE_LABEL) as WorkType[]).map((workType) => {
+    const median = medians[workType];
+    const trusted = median !== undefined && median.sampleCount >= MIN_SAMPLES_FOR_MEDIAN;
+    return {
+      workType,
+      label: WORK_TYPE_LABEL[workType],
+      medianMinutes: trusted ? Math.round(median.medianMinutes) : null,
+      sampleCount: median?.sampleCount ?? 0,
+      fallbackMinutes: FALLBACK_MINUTES[workType],
+    };
+  });
+
   return (
     <main className="mx-auto max-w-lg space-y-6 p-6">
       <Link href="/" className="text-sm text-muted-foreground hover:underline">
         ← Back to dashboard
       </Link>
       <h1 className="text-lg font-semibold">Settings</h1>
-      <SettingsForm initialSettings={settings} />
+      <SettingsForm initialSettings={settings} learnedDurations={learnedDurations} />
     </main>
   );
 }

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from '@/components/ui/sonner';
 import { Accordion } from '@/components/ui/accordion';
@@ -54,7 +54,8 @@ import {
 import { isSnoozed, SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
 import { needsYou } from '@/lib/grouping';
 import { localDateString, addDays } from '@/lib/date';
-import { DEFAULT_CAPACITY_MINUTES } from '@/lib/config';
+import { DEFAULT_CAPACITY_MINUTES, DEFAULT_SUGGEST_ALGORITHM, SETTINGS_KEYS } from '@/lib/config';
+import { DEFAULT_LEAN, type LeanNotch, type SuggestAlgorithm, type Suggestion, type SuggestionItem } from '@/lib/suggest';
 import type { CalibrationEntry } from '@/lib/calibration';
 import type { ScoredItem } from '@/lib/dashboard';
 import type { SprintProgress } from '@/lib/sprint';
@@ -84,6 +85,21 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
   const [savedViews, setSavedViews] = useState<SavedView[]>([]);
   const [sourceStatuses, setSourceStatuses] = useState<SourceStatus[]>([]);
   const [planDayOpen, setPlanDayOpen] = useState(false);
+  // Which step and mode the wizard opens on. The two entry points differ:
+  // Plan the day starts at the carry-over step in All signals, Suggest a day
+  // jumps straight to the choose step with the proposal showing.
+  const [planInitial, setPlanInitial] = useState<{ step: 1 | 2; mode: 'suggested' | 'all' }>({
+    step: 1,
+    mode: 'all',
+  });
+  const [suggestion, setSuggestion] = useState<Suggestion | null>(null);
+  const [suggestItems, setSuggestItems] = useState<Map<number, SuggestionItem>>(new Map());
+  const [suggestLoading, setSuggestLoading] = useState(false);
+  const [suggestError, setSuggestError] = useState(false);
+  const [suggestAlgorithm, setSuggestAlgorithm] = useState<SuggestAlgorithm>(
+    DEFAULT_SUGGEST_ALGORITHM as SuggestAlgorithm
+  );
+  const [suggestLean, setSuggestLean] = useState<LeanNotch>(DEFAULT_LEAN);
   const { runningTimer, refreshRunningTimer } = useRunningTimer();
   const [switchTimerOpen, setSwitchTimerOpen] = useState(false);
   const [pendingStartId, setPendingStartId] = useState<number | null>(null);
@@ -248,6 +264,68 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
 
   async function handlePinToday(id: number) {
     await pinToday(id);
+    await refresh();
+  }
+
+  const loadSuggestion = useCallback(async (algorithm: SuggestAlgorithm, lean: LeanNotch) => {
+    setSuggestLoading(true);
+    setSuggestError(false);
+    try {
+      const res = await fetch(`/api/suggest?algorithm=${algorithm}&lean=${lean}`);
+      if (!res.ok) throw new Error('suggest failed');
+      const payload = (await res.json()) as { suggestion: Suggestion; items: SuggestionItem[] };
+      setSuggestion(payload.suggestion);
+      setSuggestItems(new Map(payload.items.map((item) => [item.id, item])));
+    } catch {
+      setSuggestError(true);
+    } finally {
+      setSuggestLoading(false);
+    }
+  }, []);
+
+  // The panel is where these are chosen, so the panel is where they persist.
+  // No duplicate control in Settings to keep in sync.
+  const persistSuggestSettings = useCallback((next: { algorithm?: SuggestAlgorithm; lean?: LeanNotch }) => {
+    const body: Record<string, string> = {};
+    if (next.algorithm) body[SETTINGS_KEYS.suggestAlgorithm] = next.algorithm;
+    if (next.lean !== undefined) body[SETTINGS_KEYS.suggestLean] = String(next.lean);
+    void fetch('/api/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }, []);
+
+  function openPlanDay() {
+    setPlanInitial({ step: 1, mode: 'all' });
+    setPlanDayOpen(true);
+  }
+
+  function openSuggestDay() {
+    setPlanInitial({ step: 2, mode: 'suggested' });
+    setPlanDayOpen(true);
+    void loadSuggestion(suggestAlgorithm, suggestLean);
+  }
+
+  function handleSuggestAlgorithmChange(algorithm: SuggestAlgorithm) {
+    setSuggestAlgorithm(algorithm);
+    persistSuggestSettings({ algorithm });
+    void loadSuggestion(algorithm, suggestLean);
+  }
+
+  function handleSuggestLeanChange(lean: LeanNotch) {
+    setSuggestLean(lean);
+    persistSuggestSettings({ lean });
+    void loadSuggestion(suggestAlgorithm, lean);
+  }
+
+  // Sequential, not parallel: addPlanItem derives sort_order from the current
+  // maximum, so concurrent calls would race the suggested order into an
+  // arbitrary one.
+  async function handlePinSuggested(itemIds: number[]) {
+    for (const id of itemIds) {
+      await pinToday(id);
+    }
     await refresh();
   }
 
@@ -421,7 +499,8 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
       onOpenHelp={() => setHelpOpen(true)}
       onGoToDashboard={() => router.push('/')}
       onGoToSettings={() => router.push('/settings')}
-      onPlanDay={() => setPlanDayOpen(true)}
+      onPlanDay={openPlanDay}
+      onSuggestDay={openSuggestDay}
       onQuickAdd={() => setQuickAddOpen(true)}
     >
     <main className="mx-auto max-w-6xl space-y-6 p-6">
@@ -453,7 +532,8 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
             onUnpark={handleUnpark}
             onUnpinToday={handleUnpinToday}
             onSetPriority={handleSetPriority}
-            onPlanDay={() => setPlanDayOpen(true)}
+            onPlanDay={openPlanDay}
+            onSuggestDay={openSuggestDay}
             onReorder={handleReorderToday}
             failingSources={failingSources}
             onOpenScoringReference={() => setScoringReferenceOpen(true)}
@@ -513,6 +593,20 @@ export default function Dashboard({ initialData, hasTokens }: { initialData: Das
       <PlanDayDialog
         open={planDayOpen}
         onOpenChange={setPlanDayOpen}
+        initialStep={planInitial.step}
+        initialStep2Mode={planInitial.mode}
+        suggest={{
+          suggestion,
+          itemsById: suggestItems,
+          loading: suggestLoading,
+          error: suggestError,
+          algorithm: suggestAlgorithm,
+          lean: suggestLean,
+          onAlgorithmChange: handleSuggestAlgorithmChange,
+          onLeanChange: handleSuggestLeanChange,
+          onRetry: () => void loadSuggestion(suggestAlgorithm, suggestLean),
+          onPin: handlePinSuggested,
+        }}
         today={data.today}
         signals={data.signals}
         yesterday={yesterdayItems}

--- a/components/GlobalKeymapProvider.tsx
+++ b/components/GlobalKeymapProvider.tsx
@@ -14,6 +14,7 @@ interface Props {
   onGoToDashboard: () => void;
   onGoToSettings: () => void;
   onPlanDay: () => void;
+  onSuggestDay: () => void;
   onQuickAdd: () => void;
 }
 
@@ -28,6 +29,7 @@ export default function GlobalKeymapProvider({
   onGoToDashboard,
   onGoToSettings,
   onPlanDay,
+  onSuggestDay,
   onQuickAdd,
 }: Props) {
   useEffect(() => {
@@ -104,6 +106,12 @@ export default function GlobalKeymapProvider({
         case 'p':
           onPlanDay();
           return;
+        // Not `s`, however much Suggest wants it: that letter is row-scope
+        // Star, and this switch does not bail when a row has focus, so both
+        // would fire. See the hazard note in lib/keymap.ts.
+        case 'i':
+          onSuggestDay();
+          return;
         case 'g':
           pendingG = true;
           pendingGTimeout = setTimeout(() => {
@@ -128,6 +136,7 @@ export default function GlobalKeymapProvider({
     onGoToDashboard,
     onGoToSettings,
     onPlanDay,
+    onSuggestDay,
     onQuickAdd,
   ]);
 

--- a/components/PlanDayDialog.tsx
+++ b/components/PlanDayDialog.tsx
@@ -11,6 +11,7 @@ import { formatCalibrationSentence, type CalibrationEntry } from '@/lib/calibrat
 import type { ScoredItem } from '@/lib/dashboard';
 import type { Item, Plan, PlanItem } from '@/lib/types';
 import type { SnoozeOption } from '@/lib/snooze';
+import { formatMinutes } from '@/lib/format-duration';
 
 type Step = 1 | 2 | 3 | 4;
 
@@ -32,14 +33,6 @@ interface Props {
   onSetCapacity: (minutes: number) => void;
   calibration: CalibrationEntry[];
   onOpenScoringReference: () => void;
-}
-
-function formatMinutes(minutes: number): string {
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  if (h === 0) return `${m}m`;
-  if (m === 0) return `${h}h`;
-  return `${h}h ${m}m`;
 }
 
 function parseDurationInput(raw: string): number | null {

--- a/components/PlanDayDialog.tsx
+++ b/components/PlanDayDialog.tsx
@@ -12,8 +12,36 @@ import type { ScoredItem } from '@/lib/dashboard';
 import type { Item, Plan, PlanItem } from '@/lib/types';
 import type { SnoozeOption } from '@/lib/snooze';
 import { formatMinutes } from '@/lib/format-duration';
+import SegmentedChoice, { type SegmentedOption } from './SegmentedChoice';
+import SuggestPanel from './SuggestPanel';
+import type { LeanNotch, SuggestAlgorithm, Suggestion, SuggestionItem } from '@/lib/suggest';
 
 type Step = 1 | 2 | 3 | 4;
+
+// Step 2 is already the "choose what to work on" step, and a suggestion is a
+// way of choosing rather than a separate act, so it is a second mode here
+// instead of a fifth step -- two lists to reconcile is what a dedicated step
+// would have produced. 'all' stays the default: the suggestion is a mode you
+// opt into.
+type Step2Mode = 'suggested' | 'all';
+
+const MODE_OPTIONS: SegmentedOption<Step2Mode>[] = [
+  { value: 'suggested', label: 'Suggested' },
+  { value: 'all', label: 'All signals' },
+];
+
+export interface SuggestBridge {
+  suggestion: Suggestion | null;
+  itemsById: Map<number, SuggestionItem>;
+  loading: boolean;
+  error: boolean;
+  algorithm: SuggestAlgorithm;
+  lean: LeanNotch;
+  onAlgorithmChange: (value: SuggestAlgorithm) => void;
+  onLeanChange: (value: LeanNotch) => void;
+  onRetry: () => void;
+  onPin: (itemIds: number[]) => void | Promise<void>;
+}
 
 interface Props {
   open: boolean;
@@ -33,6 +61,9 @@ interface Props {
   onSetCapacity: (minutes: number) => void;
   calibration: CalibrationEntry[];
   onOpenScoringReference: () => void;
+  initialStep?: 1 | 2;
+  initialStep2Mode?: Step2Mode;
+  suggest: SuggestBridge;
 }
 
 function parseDurationInput(raw: string): number | null {
@@ -62,15 +93,20 @@ export default function PlanDayDialog({
   onSetCapacity,
   calibration,
   onOpenScoringReference,
+  initialStep,
+  initialStep2Mode,
+  suggest,
 }: Props) {
-  const [step, setStep] = useState<Step>(1);
+  const [step, setStep] = useState<Step>(initialStep ?? 1);
+  const [mode, setMode] = useState<Step2Mode>(initialStep2Mode ?? 'all');
   const pickedIds = new Set(today.map((i) => i.id));
   const totalEstimateMinutes = today.reduce((sum, i) => sum + (i.estimateMinutes ?? 0), 0);
   const overMinutes = totalEstimateMinutes - plan.capacityMinutes;
 
   function close() {
     onOpenChange(false);
-    setStep(1);
+    setStep(initialStep ?? 1);
+    setMode(initialStep2Mode ?? 'all');
   }
 
   return (
@@ -119,55 +155,92 @@ export default function PlanDayDialog({
 
         {step === 2 && (
           <div className="flex min-h-0 flex-1 flex-col gap-3">
-            <div className="flex shrink-0 items-center justify-between text-sm text-muted-foreground">
-              <span>Ordered by score. Nothing is recommended.</span>
-              <span className="font-mono tabular-nums">{today.length} picked</span>
+            <div className="flex shrink-0 items-center justify-between gap-2">
+              <SegmentedChoice
+                options={MODE_OPTIONS}
+                value={mode}
+                onChange={(next) => next && setMode(next)}
+                ariaLabel="How to choose today's work"
+              />
+              {/* Two counts share this panel. This one is what is already in
+                  today's plan, in both modes; the Pin button counts checked
+                  rows, which is why it is phrased as an act. */}
+              <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                {today.length} picked
+              </span>
             </div>
-            <div className="min-h-0 flex-1 space-y-3 overflow-y-auto">
-              {GROUP_ORDER.map((group) => {
-                const groupItems = signals.filter((i) => groupOf(i) === group);
-                if (groupItems.length === 0) return null;
-                return (
-                  <div key={group}>
-                    <p className="mb-1 text-xs font-medium text-muted-foreground">
-                      {GROUP_LABEL[group]} · {groupItems.length}
-                    </p>
-                    {groupItems.map((item) => (
-                      <div key={item.id} className="flex items-center justify-between gap-2 py-1 text-sm">
-                        <span className="flex min-w-0 items-center gap-2">
-                          <ScoreChip
-                            source={item.source}
-                            score={item.score}
-                            scoreBreakdown={item.scoreBreakdown}
-                            notFired={item.notFired}
-                            keptVisible={false}
-                            open={false}
-                            onOpenChange={() => {}}
-                            onOpenScoringReference={onOpenScoringReference}
-                          />
-                          <span className="min-w-0 truncate">{item.title}</span>
-                        </span>
-                        {pickedIds.has(item.id) ? (
-                          <span className="shrink-0 text-xs text-muted-foreground">Pinned ✓</span>
-                        ) : (
-                          <Button type="button" size="sm" variant="outline" onClick={() => onAdd(item.id)}>
-                            Add <kbd className="ml-1 font-mono text-xs">t</kbd>
-                          </Button>
-                        )}
+
+            {mode === 'suggested' ? (
+              <SuggestPanel
+                suggestion={suggest.suggestion}
+                itemsById={suggest.itemsById}
+                loading={suggest.loading}
+                error={suggest.error}
+                algorithm={suggest.algorithm}
+                lean={suggest.lean}
+                onAlgorithmChange={suggest.onAlgorithmChange}
+                onLeanChange={suggest.onLeanChange}
+                onRetry={suggest.onRetry}
+                onPin={async (itemIds) => {
+                  await suggest.onPin(itemIds);
+                  setStep(3);
+                }}
+                onDismiss={close}
+                onOpenScoringReference={onOpenScoringReference}
+              />
+            ) : (
+              <>
+                {/* Unchanged, copy included. The claim only holds for this
+                    list, so it sits with this list rather than above a toggle
+                    that can show a recommendation. */}
+                <p className="shrink-0 text-sm text-muted-foreground">Ordered by score. Nothing is recommended.</p>
+                <div className="min-h-0 flex-1 space-y-3 overflow-y-auto">
+                  {GROUP_ORDER.map((group) => {
+                    const groupItems = signals.filter((i) => groupOf(i) === group);
+                    if (groupItems.length === 0) return null;
+                    return (
+                      <div key={group}>
+                        <p className="mb-1 text-xs font-medium text-muted-foreground">
+                          {GROUP_LABEL[group]} · {groupItems.length}
+                        </p>
+                        {groupItems.map((item) => (
+                          <div key={item.id} className="flex items-center justify-between gap-2 py-1 text-sm">
+                            <span className="flex min-w-0 items-center gap-2">
+                              <ScoreChip
+                                source={item.source}
+                                score={item.score}
+                                scoreBreakdown={item.scoreBreakdown}
+                                notFired={item.notFired}
+                                keptVisible={false}
+                                open={false}
+                                onOpenChange={() => {}}
+                                onOpenScoringReference={onOpenScoringReference}
+                              />
+                              <span className="min-w-0 truncate">{item.title}</span>
+                            </span>
+                            {pickedIds.has(item.id) ? (
+                              <span className="shrink-0 text-xs text-muted-foreground">Pinned ✓</span>
+                            ) : (
+                              <Button type="button" size="sm" variant="outline" onClick={() => onAdd(item.id)}>
+                                Add <kbd className="ml-1 font-mono text-xs">t</kbd>
+                              </Button>
+                            )}
+                          </div>
+                        ))}
                       </div>
-                    ))}
-                  </div>
-                );
-              })}
-            </div>
-            <div className="flex shrink-0 items-center justify-between pt-2">
-              <Button type="button" variant="ghost" onClick={() => setStep(1)}>
-                Back
-              </Button>
-              <Button type="button" onClick={() => setStep(3)}>
-                Next
-              </Button>
-            </div>
+                    );
+                  })}
+                </div>
+                <div className="flex shrink-0 items-center justify-between pt-2">
+                  <Button type="button" variant="ghost" onClick={() => setStep(1)}>
+                    Back
+                  </Button>
+                  <Button type="button" onClick={() => setStep(3)}>
+                    Next
+                  </Button>
+                </div>
+              </>
+            )}
           </div>
         )}
 

--- a/components/PlanDayDialog.tsx
+++ b/components/PlanDayDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -103,10 +103,19 @@ export default function PlanDayDialog({
   const totalEstimateMinutes = today.reduce((sum, i) => sum + (i.estimateMinutes ?? 0), 0);
   const overMinutes = totalEstimateMinutes - plan.capacityMinutes;
 
-  function close() {
-    onOpenChange(false);
+  // This dialog stays mounted with `open` gating visibility, so the initial
+  // step and mode cannot come from useState alone: it would only ever read
+  // them once, and every later open would land on whatever step the last
+  // visit left behind. Resetting on each open is also what makes the two
+  // entry points distinct, since they differ only in these two props.
+  useEffect(() => {
+    if (!open) return;
     setStep(initialStep ?? 1);
     setMode(initialStep2Mode ?? 'all');
+  }, [open, initialStep, initialStep2Mode]);
+
+  function close() {
+    onOpenChange(false);
   }
 
   return (

--- a/components/PlanDayDialog.tsx
+++ b/components/PlanDayDialog.tsx
@@ -103,6 +103,21 @@ export default function PlanDayDialog({
   const totalEstimateMinutes = today.reduce((sum, i) => sum + (i.estimateMinutes ?? 0), 0);
   const overMinutes = totalEstimateMinutes - plan.capacityMinutes;
 
+  // Durations the engine derived, keyed by item. Deliberately placeholders and
+  // not values: getCalibrationSummary() compares the user's estimate against
+  // actual logged time, so seeding it with the tool's own guesses would make
+  // the calibration loop measure itself and drift. A derived number becomes an
+  // estimate only when the user says so.
+  const roughMinutesByItemId = new Map(
+    (suggest.suggestion?.picks ?? [])
+      .filter((pick) => pick.durationSource === 'logged_median' || pick.durationSource === 'fallback')
+      .map((pick) => [pick.itemId, pick.durationMinutes])
+  );
+
+  const acceptableRough = today.filter(
+    (item) => item.estimateMinutes === null && roughMinutesByItemId.has(item.id)
+  );
+
   // This dialog stays mounted with `open` gating visibility, so the initial
   // step and mode cannot come from useState alone: it would only ever read
   // them once, and every later open would land on whatever step the last
@@ -269,13 +284,31 @@ export default function PlanDayDialog({
                     <span className="min-w-0 flex-1 truncate">{item.title}</span>
                     <Input
                       defaultValue={item.estimateMinutes ? formatMinutes(item.estimateMinutes) : ''}
-                      placeholder="e.g. 1h 30m"
+                      placeholder={
+                        roughMinutesByItemId.has(item.id)
+                          ? `~${formatMinutes(roughMinutesByItemId.get(item.id)!)}`
+                          : 'e.g. 1h 30m'
+                      }
                       className="h-8 w-28 shrink-0 text-right font-mono text-sm"
                       onBlur={(e) => onSetEstimate(item.id, parseDurationInput(e.target.value))}
                     />
                   </>
                 )}
               </SortableRows>
+              {acceptableRough.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    for (const item of acceptableRough) {
+                      onSetEstimate(item.id, roughMinutesByItemId.get(item.id)!);
+                    }
+                  }}
+                  className="pb-1 pt-3 text-left text-xs font-medium text-muted-foreground hover:text-foreground"
+                >
+                  Accept all rough durations{' '}
+                  <span className="font-mono tabular-nums">· {acceptableRough.length}</span>
+                </button>
+              )}
               {calibration.map((entry) => {
                 const sentence = formatCalibrationSentence(entry);
                 return sentence ? (

--- a/components/PrioritySegments.tsx
+++ b/components/PrioritySegments.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
-import { cn } from '@/lib/utils';
+import SegmentedChoice, { type SegmentedOption } from './SegmentedChoice';
 import { PRIORITY_LABEL, PRIORITY_ORDER, priorityPoints } from '@/lib/scoring';
 import type { Priority } from '@/lib/types';
 
@@ -9,7 +8,11 @@ import type { Priority } from '@/lib/types';
 // is high-first because the reference dialog lists the biggest number at the
 // top). Reading left-to-right as increasing weight is what a person expects
 // from a scale.
-const SEGMENTS: Priority[] = [...PRIORITY_ORDER].reverse();
+const OPTIONS: SegmentedOption<Priority>[] = [...PRIORITY_ORDER].reverse().map((priority) => ({
+  value: priority,
+  label: PRIORITY_LABEL[priority],
+  readout: `+${priorityPoints(priority)}`,
+}));
 
 interface Props {
   value: Priority | null;
@@ -19,88 +22,22 @@ interface Props {
 }
 
 /**
- * A three-value scale rendered as an instrument, not a colour code.
+ * The picker for an ad-hoc item's hand-set priority.
  *
- * Deliberately monochrome: the score chip owns the urgency colour channel,
- * and a red/amber/grey control here would read as a fifth urgency band and
- * break the Two-Band Rule in DESIGN.md. The weight of each option is carried
- * by its point contribution in the mono/tabular register instead, which also
- * means the control teaches the formula the first time you use it rather
- * than asking you to remember what "high" is worth.
- *
- * One tab stop, arrow keys to move, per the radiogroup pattern -- three
- * separate tab stops in the middle of a capture form is the kind of thing
- * that makes a keyboard user stop using the form.
+ * Clearable, because "I haven't decided" is a real state and the one every
+ * item starts in. Each option states its point contribution, so the control
+ * teaches the formula rather than asking you to remember what "high" is
+ * worth.
  */
 export default function PrioritySegments({ value, onChange, labelledBy, disabled }: Props) {
-  const refs = useRef<(HTMLButtonElement | null)[]>([]);
-
-  // With nothing selected the first segment holds the tab stop, so the group
-  // is always reachable in exactly one Tab press.
-  const focusIndex = value ? SEGMENTS.indexOf(value) : 0;
-
-  function move(delta: number) {
-    const next = (focusIndex + delta + SEGMENTS.length) % SEGMENTS.length;
-    onChange(SEGMENTS[next]);
-    refs.current[next]?.focus();
-  }
-
   return (
-    <div
-      role="radiogroup"
-      aria-labelledby={labelledBy}
-      className={cn(
-        'inline-flex h-9 overflow-hidden rounded-md border border-input',
-        disabled && 'pointer-events-none opacity-50'
-      )}
-      onKeyDown={(e) => {
-        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
-          e.preventDefault();
-          move(1);
-        } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-          e.preventDefault();
-          move(-1);
-        }
-      }}
-    >
-      {SEGMENTS.map((priority, i) => {
-        const selected = value === priority;
-        return (
-          <button
-            key={priority}
-            ref={(el) => {
-              refs.current[i] = el;
-            }}
-            type="button"
-            role="radio"
-            aria-checked={selected}
-            tabIndex={i === focusIndex ? 0 : -1}
-            disabled={disabled}
-            // Clicking the selected segment clears it. Without this there is
-            // no way back to "I haven't decided", which is a real state and
-            // the one every item starts in.
-            onClick={() => onChange(selected ? null : priority)}
-            className={cn(
-              'flex items-baseline gap-1.5 px-3 text-sm transition-colors',
-              'border-r border-input last:border-r-0',
-              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset',
-              // The selected state has to be readable at a glance without
-              // reaching for a new colour: the urgency channel belongs to the
-              // score chip. So the gap is widened with weight and dimming
-              // instead -- Surface Raised fill, Ink text at semibold, against
-              // deliberately quieter unselected segments.
-              selected
-                ? 'bg-accent font-semibold text-accent-foreground'
-                : 'text-muted-foreground/80 hover:text-foreground'
-            )}
-          >
-            <span>{PRIORITY_LABEL[priority]}</span>
-            <span className={cn('font-mono text-[11px] tabular-nums', selected ? 'opacity-100' : 'opacity-60')}>
-              +{priorityPoints(priority)}
-            </span>
-          </button>
-        );
-      })}
-    </div>
+    <SegmentedChoice
+      options={OPTIONS}
+      value={value}
+      onChange={onChange}
+      clearable
+      labelledBy={labelledBy}
+      disabled={disabled}
+    />
   );
 }

--- a/components/ScoringReferenceDialog.tsx
+++ b/components/ScoringReferenceDialog.tsx
@@ -2,6 +2,9 @@
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { getScoringReference } from '@/lib/scoring';
+import { getSuggestionReference } from '@/lib/suggest';
+import { WORK_TYPE_LABEL, type WorkType } from '@/lib/calibration';
+import { formatMinutes } from '@/lib/format-duration';
 
 interface Props {
   open: boolean;
@@ -10,12 +13,15 @@ interface Props {
 
 export default function ScoringReferenceDialog({ open, onOpenChange }: Props) {
   const ref = getScoringReference();
+  // Two generated halves, composed here rather than in either lib, so
+  // lib/scoring.ts keeps no dependency on the suggestion feature.
+  const suggest = getSuggestionReference();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] max-w-lg overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>How urgency is scored</DialogTitle>
+          <DialogTitle>How urgency is scored, and how a day is suggested</DialogTitle>
         </DialogHeader>
         <div className="space-y-4 text-sm">
           <p className="text-muted-foreground">
@@ -102,9 +108,73 @@ export default function ScoringReferenceDialog({ open, onOpenChange }: Props) {
               </p>
             ))}
           </div>
+
+          <div className="space-y-4 border-t pt-3">
+            <div>
+              <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+                Suggesting a day · you pick one of three
+              </p>
+              <div className="space-y-1.5">
+                {suggest.algorithms.map((algorithm) => (
+                  <div key={algorithm.key}>
+                    <p>{algorithm.label}</p>
+                    <p className="text-xs text-muted-foreground">{algorithm.description}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+                How long it thinks something takes · first of these that applies
+              </p>
+              <ol className="space-y-1">
+                {suggest.durationOrder.map((step, i) => (
+                  <li key={step} className="flex gap-2 text-xs text-muted-foreground">
+                    <span className="font-mono tabular-nums">{i + 1}.</span>
+                    <span>{step}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            <div>
+              <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+                The fixed defaults, used until there are enough logs
+              </p>
+              <div className="space-y-1">
+                {(Object.keys(suggest.fallbackMinutes) as WorkType[]).map((workType) => (
+                  <div key={workType} className="flex items-center justify-between gap-3">
+                    <span>{WORK_TYPE_LABEL[workType]}</span>
+                    <span className="font-mono tabular-nums text-muted-foreground">
+                      {formatMinutes(suggest.fallbackMinutes[workType])}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+                The lean · share of the day work items may take
+              </p>
+              <p className="font-mono text-xs tabular-nums text-muted-foreground">
+                {suggest.leanShares.map((share) => `${Math.round(share * 100)}%`).join(' · ')}
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">What a suggestion will never do</p>
+              {suggest.nonPointRules.map((rule) => (
+                <p key={rule} className="text-xs text-muted-foreground">
+                  {rule}
+                </p>
+              ))}
+            </div>
+          </div>
         </div>
         <DialogFooter className="sm:justify-between">
-          <span className="text-xs text-muted-foreground">generated from lib/scoring.ts</span>
+          <span className="text-xs text-muted-foreground">generated from lib/scoring.ts and lib/suggest.ts</span>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/components/SegmentedChoice.tsx
+++ b/components/SegmentedChoice.tsx
@@ -7,6 +7,9 @@ export interface SegmentedOption<T extends string | number> {
   value: T;
   label: string;
   readout?: string;
+  // Spoken name, when the visible label is a compact form a screen reader
+  // would read as noise ("80/20").
+  ariaLabel?: string;
 }
 
 interface Props<T extends string | number> {
@@ -93,6 +96,7 @@ export default function SegmentedChoice<T extends string | number>({
             type="button"
             role="radio"
             aria-checked={selected}
+            aria-label={option.ariaLabel}
             tabIndex={i === focusIndex ? 0 : -1}
             disabled={disabled}
             onClick={() => onChange(selected && clearable ? null : option.value)}

--- a/components/SegmentedChoice.tsx
+++ b/components/SegmentedChoice.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useRef } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface SegmentedOption<T extends string | number> {
+  value: T;
+  label: string;
+  readout?: string;
+}
+
+interface Props<T extends string | number> {
+  options: SegmentedOption<T>[];
+  value: T | null;
+  onChange: (value: T | null) => void;
+  clearable?: boolean;
+  // Segments share the container's width equally instead of being sized by
+  // their content. Opt-in, so an existing content-sized control keeps its
+  // exact proportions when this primitive is reused.
+  fill?: boolean;
+  labelledBy?: string;
+  ariaLabel?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * The house control for a value the user sets, as opposed to one a source
+ * reported.
+ *
+ * Deliberately monochrome: the score chip owns the urgency colour channel,
+ * and a coloured control here would read as another urgency band and break
+ * the Two-Band Rule in DESIGN.md. Weight and dimming carry the selected
+ * state instead, and an optional mono readout carries the option's magnitude
+ * so the control teaches its own scale the first time you use it.
+ *
+ * One tab stop, arrow keys to move, per the radiogroup pattern. Several tab
+ * stops in a row is the kind of thing that makes a keyboard user stop using
+ * a form.
+ */
+export default function SegmentedChoice<T extends string | number>({
+  options,
+  value,
+  onChange,
+  clearable = false,
+  fill = false,
+  labelledBy,
+  ariaLabel,
+  disabled,
+  className,
+}: Props<T>) {
+  const refs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // With nothing selected the first segment holds the tab stop, so the group
+  // is always reachable in exactly one Tab press.
+  const selectedIndex = options.findIndex((option) => option.value === value);
+  const focusIndex = selectedIndex === -1 ? 0 : selectedIndex;
+
+  function move(delta: number) {
+    const next = (focusIndex + delta + options.length) % options.length;
+    onChange(options[next].value);
+    refs.current[next]?.focus();
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-labelledby={labelledBy}
+      aria-label={ariaLabel}
+      className={cn(
+        'inline-flex h-9 overflow-hidden rounded-md border border-input',
+        disabled && 'pointer-events-none opacity-50',
+        className
+      )}
+      onKeyDown={(e) => {
+        if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+          e.preventDefault();
+          move(1);
+        } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+          e.preventDefault();
+          move(-1);
+        }
+      }}
+    >
+      {options.map((option, i) => {
+        const selected = option.value === value;
+        return (
+          <button
+            key={option.value}
+            ref={(el) => {
+              refs.current[i] = el;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            tabIndex={i === focusIndex ? 0 : -1}
+            disabled={disabled}
+            onClick={() => onChange(selected && clearable ? null : option.value)}
+            className={cn(
+              'flex items-baseline gap-1.5 px-3 text-sm transition-colors',
+              fill && 'flex-1 justify-center',
+              'border-r border-input last:border-r-0',
+              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset',
+              selected
+                ? 'bg-accent font-semibold text-accent-foreground'
+                : 'text-muted-foreground/80 hover:text-foreground'
+            )}
+          >
+            <span>{option.label}</span>
+            {option.readout && (
+              <span className={cn('font-mono text-[11px] tabular-nums', selected ? 'opacity-100' : 'opacity-60')}>
+                {option.readout}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/SettingsForm.tsx
+++ b/components/SettingsForm.tsx
@@ -12,6 +12,17 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { SETTINGS_KEYS, DEFAULT_STALE_DAYS, DEFAULT_DENSITY } from '@/lib/config';
 import SettingsScoringLink from './SettingsScoringLink';
+import { formatMinutes } from '@/lib/format-duration';
+import type { WorkType } from '@/lib/calibration';
+
+export interface LearnedDuration {
+  workType: WorkType;
+  label: string;
+  // The median from the logs, or null when there are too few to trust.
+  medianMinutes: number | null;
+  sampleCount: number;
+  fallbackMinutes: number;
+}
 
 // "Token saved", not "Connected" — this only reflects that a PAT is stored,
 // never that it's valid against GitHub/ADO, so the label shouldn't claim more.
@@ -40,9 +51,10 @@ type SettingsValues = z.infer<typeof settingsSchema>;
 
 interface Props {
   initialSettings: Record<string, string>;
+  learnedDurations: LearnedDuration[];
 }
 
-export default function SettingsForm({ initialSettings }: Props) {
+export default function SettingsForm({ initialSettings, learnedDurations }: Props) {
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState(false);
   const [githubPatIsSet, setGithubPatIsSet] = useState(
@@ -211,6 +223,48 @@ export default function SettingsForm({ initialSettings }: Props) {
                 )}
               />
               <SettingsScoringLink />
+            </div>
+
+            {/* Read-only on purpose. The algorithm and the lean are set in the
+                suggestion itself, so there is no second copy of them here to
+                drift out of sync, and the durations are shown rather than
+                tuned: an override is a later decision, not a default. */}
+            <div className="space-y-4 border-b pb-6">
+              <h2 className="text-base font-semibold">Suggestions</h2>
+              <p className="text-sm text-muted-foreground">
+                When an item has no estimate, a suggestion sizes it from the time you have actually logged on that
+                kind of work. Below <span className="font-mono tabular-nums">3</span> logs it uses a fixed default
+                instead.
+              </p>
+              <div className="space-y-1">
+                {learnedDurations.map((row) => (
+                  <div key={row.workType} className="flex items-baseline justify-between gap-3 text-sm">
+                    <span>{row.label}</span>
+                    {row.medianMinutes === null ? (
+                      <span className="text-xs text-muted-foreground">
+                        <span className="font-mono tabular-nums">{formatMinutes(row.fallbackMinutes)}</span> default
+                        {row.sampleCount > 0 && (
+                          <>
+                            {' '}
+                            · <span className="font-mono tabular-nums">{row.sampleCount}</span> log
+                            {row.sampleCount === 1 ? '' : 's'} so far
+                          </>
+                        )}
+                      </span>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">
+                        <span className="font-mono tabular-nums text-foreground">
+                          {formatMinutes(row.medianMinutes)}
+                        </span>{' '}
+                        median · <span className="font-mono tabular-nums">{row.sampleCount}</span> logs
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                The algorithm and the lean are set in the suggestion itself, not here.
+              </p>
             </div>
 
             <div className="space-y-4 border-b pb-6">

--- a/components/ShutdownDialog.tsx
+++ b/components/ShutdownDialog.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/api-client';
 import { SNOOZE_LABEL, type SnoozeOption } from '@/lib/snooze';
 import { formatCalibrationSentence, type CalibrationEntry } from '@/lib/calibration';
+import { formatMinutes } from '@/lib/format-duration';
 
 interface Props {
   open: boolean;
@@ -27,14 +28,6 @@ interface Props {
   onSnooze: (id: number, option: SnoozeOption) => void;
   onDrop: (id: number) => void;
   calibration?: CalibrationEntry[];
-}
-
-function formatMinutes(minutes: number): string {
-  const h = Math.floor(minutes / 60);
-  const m = Math.round(minutes % 60);
-  if (h === 0) return `${m}m`;
-  if (m === 0) return `${h}h`;
-  return `${h}h ${m}m`;
 }
 
 function formatWrapUpDate(dateStr: string): string {

--- a/components/SuggestPanel.tsx
+++ b/components/SuggestPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, type KeyboardEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import ScoreChip from './ScoreChip';
 import SegmentedChoice, { type SegmentedOption } from './SegmentedChoice';
@@ -25,10 +25,18 @@ const ALGORITHM_OPTIONS: SegmentedOption<SuggestAlgorithm>[] = [
 
 const LEAN_NOTCHES: LeanNotch[] = [0, 1, 2, 3, 4];
 
-const LEAN_OPTIONS: SegmentedOption<LeanNotch>[] = LEAN_NOTCHES.map((notch) => ({
-  value: notch,
-  label: `${Math.round(LEAN_WORK_ITEM_SHARE[notch] * 100)}`,
-}));
+// Each notch states the whole split rather than one side of it. A bare "20"
+// sitting next to the "PRs" axis label reads as "pull requests get 20", which
+// is the opposite of what that notch means.
+const LEAN_OPTIONS: SegmentedOption<LeanNotch>[] = LEAN_NOTCHES.map((notch) => {
+  const workItems = Math.round(LEAN_WORK_ITEM_SHARE[notch] * 100);
+  const prs = 100 - workItems;
+  return {
+    value: notch,
+    label: `${prs}/${workItems}`,
+    ariaLabel: `${prs}% pull requests, ${workItems}% work items`,
+  };
+});
 
 const PICK_REASON_LABEL: Record<PickReason, string> = {
   anchor: 'anchor, top item over an hour',
@@ -88,12 +96,57 @@ export default function SuggestPanel({
   const [openDisclosure, setOpenDisclosure] = useState<'did_not_fit' | 'deferred' | null>(null);
   const [openChipId, setOpenChipId] = useState<number | null>(null);
 
+  // The shortcuts read live state through a ref so the document listener can
+  // be registered once instead of being torn down on every keystroke.
+  const keyStateRef = useRef({ onAlgorithmChange, onPin, checkedIds: [] as number[] });
+
   // A fresh proposal arrives fully checked: the fastest path through a good
   // suggestion is one keystroke, and unchecking is cheaper than checking four
   // rows by hand. Nothing is written until Pin is pressed either way.
   useEffect(() => {
     setChecked(new Set(suggestion?.picks.map((pick) => pick.itemId) ?? []));
   }, [suggestion]);
+
+  keyStateRef.current = {
+    onAlgorithmChange,
+    onPin,
+    checkedIds: (suggestion?.picks ?? []).filter((pick) => checked.has(pick.itemId)).map((pick) => pick.itemId),
+  };
+
+  // 1/2/3 pick an algorithm and Enter accepts, so a suggestion can be taken
+  // without reaching for the mouse. Keyboard-first is a durable principle
+  // here, not a roadmap item.
+  //
+  // Document-level, not a container onKeyDown: this panel renders inside a
+  // dialog whose initial focus lands on the dialog shell, so a container
+  // handler would silently ignore every keystroke until the user tabbed in.
+  // Scoping is automatic anyway, since the panel is only mounted while it is
+  // the visible step. Space on a row is the native checkbox behaviour and the
+  // arrow keys belong to SegmentedChoice, so neither is handled here.
+  useEffect(() => {
+    function onKeyDown(e: globalThis.KeyboardEvent) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isTypingTarget(e.target)) return;
+
+      const index = ['1', '2', '3'].indexOf(e.key);
+      if (index !== -1) {
+        e.preventDefault();
+        keyStateRef.current.onAlgorithmChange(ALGORITHM_OPTIONS[index].value);
+        return;
+      }
+
+      // Enter on a control is that control's own business; only a bare Enter
+      // means accept, so a focused Dismiss still dismisses.
+      if (e.key === 'Enter' && !(e.target as HTMLElement | null)?.closest?.('button, input, label, [role="radio"]')) {
+        const { checkedIds, onPin: pin } = keyStateRef.current;
+        if (checkedIds.length === 0) return;
+        e.preventDefault();
+        void pin(checkedIds);
+      }
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
 
   if (error) {
     return (
@@ -121,7 +174,6 @@ export default function SuggestPanel({
     ? Math.min(100, Math.round((checkedMinutes / suggestion.capacityMinutes) * 100))
     : 0;
   const anyDerived = checkedPicks.some((pick) => isDerived(pick.durationSource));
-  const workItemPct = Math.round(LEAN_WORK_ITEM_SHARE[lean] * 100);
 
   function toggle(itemId: number) {
     setChecked((prev) => {
@@ -130,27 +182,6 @@ export default function SuggestPanel({
       else next.add(itemId);
       return next;
     });
-  }
-
-  // 1/2/3 pick an algorithm and Enter accepts, so a suggestion can be taken
-  // without reaching for the mouse. Keyboard-first is a durable principle
-  // here, not a roadmap item. Space on a row is the native checkbox
-  // behaviour and the arrow keys belong to SegmentedChoice, so neither is
-  // handled again here.
-  function onPanelKeyDown(e: KeyboardEvent<HTMLDivElement>) {
-    if (isTypingTarget(e.target)) return;
-    const index = ['1', '2', '3'].indexOf(e.key);
-    if (index !== -1) {
-      e.preventDefault();
-      onAlgorithmChange(ALGORITHM_OPTIONS[index].value);
-      return;
-    }
-    // Enter on a control is that control's own business; only a bare Enter
-    // in the panel means accept.
-    if (e.key === 'Enter' && !(e.target as HTMLElement).closest('button, input, label')) {
-      e.preventDefault();
-      if (checkedPicks.length > 0) void onPin(checkedPicks.map((pick) => pick.itemId));
-    }
   }
 
   function renderExcluded(kind: 'did_not_fit' | 'deferred') {
@@ -191,7 +222,7 @@ export default function SuggestPanel({
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3" onKeyDown={onPanelKeyDown}>
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
       <div className="shrink-0 space-y-2">
         <SegmentedChoice
           options={ALGORITHM_OPTIONS}
@@ -208,11 +239,10 @@ export default function SuggestPanel({
             value={lean}
             onChange={(value) => value !== null && onLeanChange(value)}
             ariaLabel="Lean toward pull requests or work items"
+            fill
+            className="flex-1"
           />
           <span className="shrink-0 text-xs text-muted-foreground">work items</span>
-          <span className="ml-auto shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
-            {100 - workItemPct} / {workItemPct}
-          </span>
         </div>
       </div>
 

--- a/components/SuggestPanel.tsx
+++ b/components/SuggestPanel.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import { useEffect, useState, type KeyboardEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import ScoreChip from './ScoreChip';
+import SegmentedChoice, { type SegmentedOption } from './SegmentedChoice';
+import { cn } from '@/lib/utils';
+import { formatMinutes } from '@/lib/format-duration';
+import { isTypingTarget } from '@/lib/keymap';
+import {
+  LEAN_WORK_ITEM_SHARE,
+  type DurationSource,
+  type LeanNotch,
+  type PickReason,
+  type SuggestAlgorithm,
+  type Suggestion,
+  type SuggestionItem,
+} from '@/lib/suggest';
+
+const ALGORITHM_OPTIONS: SegmentedOption<SuggestAlgorithm>[] = [
+  { value: 'urgency', label: 'Urgency first' },
+  { value: 'quick_wins', label: 'Quick wins' },
+  { value: 'balanced', label: 'Balanced' },
+];
+
+const LEAN_NOTCHES: LeanNotch[] = [0, 1, 2, 3, 4];
+
+const LEAN_OPTIONS: SegmentedOption<LeanNotch>[] = LEAN_NOTCHES.map((notch) => ({
+  value: notch,
+  label: `${Math.round(LEAN_WORK_ITEM_SHARE[notch] * 100)}`,
+}));
+
+const PICK_REASON_LABEL: Record<PickReason, string> = {
+  anchor: 'anchor, top item over an hour',
+  top_urgency: 'highest urgency that fits',
+  best_value: 'best value per minute',
+  fills_room: 'fills the remaining room',
+};
+
+// Only a number the user set is stated plainly. Everything else is marked, so
+// a guess can never read as a commitment.
+const DURATION_PROVENANCE: Record<DurationSource, string> = {
+  plan_estimate: 'you set this',
+  prior_estimate: 'you set this earlier',
+  logged_median: 'typically, from your logs',
+  fallback: 'rough default',
+};
+
+function isDerived(source: DurationSource): boolean {
+  return source === 'logged_median' || source === 'fallback';
+}
+
+const EMPTY_NOTE_COPY = {
+  signals_empty: 'Nothing to suggest. Signals is empty.',
+  all_pinned: "Everything on the list is already in today's plan.",
+} as const;
+
+interface Props {
+  suggestion: Suggestion | null;
+  itemsById: Map<number, SuggestionItem>;
+  loading: boolean;
+  error: boolean;
+  algorithm: SuggestAlgorithm;
+  lean: LeanNotch;
+  onAlgorithmChange: (value: SuggestAlgorithm) => void;
+  onLeanChange: (value: LeanNotch) => void;
+  onRetry: () => void;
+  onPin: (itemIds: number[]) => void | Promise<void>;
+  onDismiss: () => void;
+  onOpenScoringReference: () => void;
+}
+
+export default function SuggestPanel({
+  suggestion,
+  itemsById,
+  loading,
+  error,
+  algorithm,
+  lean,
+  onAlgorithmChange,
+  onLeanChange,
+  onRetry,
+  onPin,
+  onDismiss,
+  onOpenScoringReference,
+}: Props) {
+  const [checked, setChecked] = useState<Set<number>>(new Set());
+  const [openDisclosure, setOpenDisclosure] = useState<'did_not_fit' | 'deferred' | null>(null);
+  const [openChipId, setOpenChipId] = useState<number | null>(null);
+
+  // A fresh proposal arrives fully checked: the fastest path through a good
+  // suggestion is one keystroke, and unchecking is cheaper than checking four
+  // rows by hand. Nothing is written until Pin is pressed either way.
+  useEffect(() => {
+    setChecked(new Set(suggestion?.picks.map((pick) => pick.itemId) ?? []));
+  }, [suggestion]);
+
+  if (error) {
+    return (
+      <div className="space-y-3 py-6 text-sm">
+        <p>Could not build a suggestion. Try again, or pick from All signals.</p>
+        <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  if (!suggestion) {
+    return <p className="py-6 text-sm text-muted-foreground">Working out a suggestion.</p>;
+  }
+
+  if (suggestion.note === 'signals_empty' || suggestion.note === 'all_pinned') {
+    return <p className="py-6 text-sm text-muted-foreground">{EMPTY_NOTE_COPY[suggestion.note]}</p>;
+  }
+
+  const checkedPicks = suggestion.picks.filter((pick) => checked.has(pick.itemId));
+  const checkedMinutes = checkedPicks.reduce((sum, pick) => sum + pick.durationMinutes, 0);
+  const overCapacity = checkedMinutes > suggestion.capacityMinutes;
+  const fillPct = suggestion.capacityMinutes
+    ? Math.min(100, Math.round((checkedMinutes / suggestion.capacityMinutes) * 100))
+    : 0;
+  const anyDerived = checkedPicks.some((pick) => isDerived(pick.durationSource));
+  const workItemPct = Math.round(LEAN_WORK_ITEM_SHARE[lean] * 100);
+
+  function toggle(itemId: number) {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(itemId)) next.delete(itemId);
+      else next.add(itemId);
+      return next;
+    });
+  }
+
+  // 1/2/3 pick an algorithm and Enter accepts, so a suggestion can be taken
+  // without reaching for the mouse. Keyboard-first is a durable principle
+  // here, not a roadmap item. Space on a row is the native checkbox
+  // behaviour and the arrow keys belong to SegmentedChoice, so neither is
+  // handled again here.
+  function onPanelKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (isTypingTarget(e.target)) return;
+    const index = ['1', '2', '3'].indexOf(e.key);
+    if (index !== -1) {
+      e.preventDefault();
+      onAlgorithmChange(ALGORITHM_OPTIONS[index].value);
+      return;
+    }
+    // Enter on a control is that control's own business; only a bare Enter
+    // in the panel means accept.
+    if (e.key === 'Enter' && !(e.target as HTMLElement).closest('button, input, label')) {
+      e.preventDefault();
+      if (checkedPicks.length > 0) void onPin(checkedPicks.map((pick) => pick.itemId));
+    }
+  }
+
+  function renderExcluded(kind: 'did_not_fit' | 'deferred') {
+    const rows = kind === 'did_not_fit' ? suggestion!.didNotFit : suggestion!.deferredByLean;
+    if (rows.length === 0) return null;
+    const label = kind === 'did_not_fit' ? "Didn't fit" : 'Deferred by your lean';
+    const id = `suggest-excluded-${kind}`;
+    const expanded = openDisclosure === kind;
+    return (
+      <div>
+        <button
+          type="button"
+          data-row-nav
+          aria-expanded={expanded}
+          aria-controls={id}
+          onClick={() => setOpenDisclosure(expanded ? null : kind)}
+          className="w-full pb-1 pt-3 text-left text-xs font-medium text-muted-foreground hover:text-foreground"
+        >
+          {label} <span className="font-mono tabular-nums">· {rows.length}</span>
+        </button>
+        <div id={id} hidden={!expanded} className="space-y-1">
+          {rows.map((row) => {
+            const item = itemsById.get(row.itemId);
+            if (!item) return null;
+            return (
+              <div key={row.itemId} className="flex items-center justify-between gap-2 text-sm">
+                <span className="min-w-0 truncate text-muted-foreground">{item.title}</span>
+                <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                  {isDerived(row.durationSource) ? '~' : ''}
+                  {formatMinutes(row.durationMinutes)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3" onKeyDown={onPanelKeyDown}>
+      <div className="shrink-0 space-y-2">
+        <SegmentedChoice
+          options={ALGORITHM_OPTIONS}
+          value={algorithm}
+          onChange={(value) => value && onAlgorithmChange(value)}
+          ariaLabel="Suggestion algorithm"
+          fill
+          className="w-full"
+        />
+        <div className="flex items-center gap-2">
+          <span className="shrink-0 text-xs text-muted-foreground">PRs</span>
+          <SegmentedChoice
+            options={LEAN_OPTIONS}
+            value={lean}
+            onChange={(value) => value !== null && onLeanChange(value)}
+            ariaLabel="Lean toward pull requests or work items"
+          />
+          <span className="shrink-0 text-xs text-muted-foreground">work items</span>
+          <span className="ml-auto shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+            {100 - workItemPct} / {workItemPct}
+          </span>
+        </div>
+      </div>
+
+      {/* A re-fetch settles rather than flashing: the rows stay in place at
+          reduced opacity instead of unmounting. 120ms, and none at all for a
+          viewer who asked for no motion. */}
+      <div
+        className={cn(
+          'min-h-0 flex-1 space-y-2 overflow-y-auto transition-opacity duration-[120ms] motion-reduce:transition-none',
+          loading && 'opacity-60'
+        )}
+      >
+        {suggestion.degradedToQuickWins && (
+          <p className="text-xs text-muted-foreground">
+            Nothing on the list runs over an hour, so this is the quick wins order.
+          </p>
+        )}
+        {suggestion.note === 'capacity_too_small' && (
+          <p className="text-sm text-muted-foreground">
+            Nothing on the list fits your{' '}
+            <span className="font-mono tabular-nums">{formatMinutes(suggestion.capacityMinutes)}</span> capacity. Raise
+            it in step 4, or pin something anyway from All signals.
+          </p>
+        )}
+
+        {suggestion.picks.map((pick) => {
+          const item = itemsById.get(pick.itemId);
+          if (!item) return null;
+          const derived = isDerived(pick.durationSource);
+          return (
+            <div key={pick.itemId} data-row-nav className="flex items-start gap-2 border-b pb-2 text-sm last:border-b-0">
+              <input
+                type="checkbox"
+                id={`suggest-pick-${pick.itemId}`}
+                checked={checked.has(pick.itemId)}
+                onChange={() => toggle(pick.itemId)}
+                className="mt-1.5 shrink-0 accent-[hsl(var(--primary))]"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <ScoreChip
+                    source={item.source}
+                    score={item.score}
+                    scoreBreakdown={item.scoreBreakdown}
+                    notFired={item.notFired}
+                    keptVisible={false}
+                    open={openChipId === pick.itemId}
+                    onOpenChange={(next) => setOpenChipId(next ? pick.itemId : null)}
+                    onOpenScoringReference={onOpenScoringReference}
+                  />
+                  <label htmlFor={`suggest-pick-${pick.itemId}`} className="min-w-0 flex-1 cursor-pointer truncate">
+                    {item.title}
+                  </label>
+                  <span
+                    className={cn(
+                      'shrink-0 font-mono text-xs tabular-nums',
+                      derived ? 'text-muted-foreground' : 'text-foreground'
+                    )}
+                  >
+                    {derived ? '~' : ''}
+                    {formatMinutes(pick.durationMinutes)}
+                  </span>
+                </div>
+                <div className="mt-0.5 flex items-baseline justify-between gap-2 text-xs text-muted-foreground">
+                  <span className="min-w-0 truncate">{PICK_REASON_LABEL[pick.pickReason]}</span>
+                  <span className="shrink-0">{DURATION_PROVENANCE[pick.durationSource]}</span>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+
+        {renderExcluded('deferred')}
+        {renderExcluded('did_not_fit')}
+
+        {suggestion.note === 'nothing_else_fits' && (
+          <p className="pt-1 text-xs text-muted-foreground">
+            Nothing else fits the remaining{' '}
+            <span className="font-mono tabular-nums">
+              {formatMinutes(suggestion.capacityMinutes - suggestion.suggestedMinutes)}
+            </span>
+            .
+          </p>
+        )}
+      </div>
+
+      <div className="shrink-0 space-y-2 pt-2">
+        <div className="flex items-baseline justify-between text-sm">
+          {/* The proposal is not gold. Capacity is a number the user committed
+              to; a suggestion is not one yet. Gold arrives on pinning. */}
+          <span className="font-mono tabular-nums text-muted-foreground">
+            {anyDerived ? '~' : ''}
+            {formatMinutes(checkedMinutes)} suggested
+          </span>
+          <span className="text-xs text-muted-foreground">
+            of{' '}
+            <span className="font-mono tabular-nums text-[hsl(var(--brand-gold))]">
+              {formatMinutes(suggestion.capacityMinutes)}
+            </span>{' '}
+            capacity
+          </span>
+        </div>
+        <div className="h-1 w-full overflow-hidden rounded-sm bg-muted" aria-hidden>
+          <div
+            className={cn('h-full', overCapacity ? 'bg-[hsl(var(--warning))]' : 'bg-muted-foreground')}
+            style={{ width: `${overCapacity ? 100 : fillPct}%` }}
+          />
+        </div>
+        {suggestion.durationsAreRough && (
+          <p className="text-xs text-muted-foreground">
+            Durations are rough defaults until you have logged some time.
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground">
+          Rough durations are marked ~.{' '}
+          <button type="button" onClick={onOpenScoringReference} className="underline hover:text-foreground">
+            Why these?
+          </button>
+        </p>
+        <div className="flex items-center justify-between">
+          <Button type="button" variant="ghost" onClick={onDismiss}>
+            Dismiss
+          </Button>
+          <Button
+            type="button"
+            disabled={checkedPicks.length === 0}
+            onClick={() => onPin(checkedPicks.map((pick) => pick.itemId))}
+          >
+            Pin <span className="mx-1 font-mono tabular-nums">{checkedPicks.length}</span> to today
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -22,6 +22,7 @@ interface Props {
   onUnpark?: (id: number) => void;
   onUnpinToday?: (id: number) => void;
   onPlanDay: () => void;
+  onSuggestDay: () => void;
   onReorder: (orderedItemIds: number[]) => void | Promise<void>;
   failingSources?: Set<Item['source']>;
   onOpenScoringReference: () => void;
@@ -41,6 +42,7 @@ export default function TodaySection({
   onUnpark,
   onUnpinToday,
   onPlanDay,
+  onSuggestDay,
   onReorder,
   failingSources,
   onOpenScoringReference,
@@ -63,9 +65,16 @@ export default function TodaySection({
         {items.length === 0 ? (
           <div className="space-y-3 py-2">
             <p className="text-sm text-muted-foreground">Nothing chosen yet.</p>
-            <Button type="button" size="lg" className="h-11" onClick={onPlanDay}>
-              Plan the day <kbd className="ml-2 font-mono text-xs opacity-70">P</kbd>
-            </Button>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button type="button" size="lg" className="h-11" onClick={onPlanDay}>
+                Plan the day <kbd className="ml-2 font-mono text-xs opacity-70">P</kbd>
+              </Button>
+              {/* Outline, not primary: one clearly-primary action per
+                  context, and planning by hand is still the default path. */}
+              <Button type="button" size="lg" variant="outline" className="h-11" onClick={onSuggestDay}>
+                Suggest a day <kbd className="ml-2 font-mono text-xs opacity-70">i</kbd>
+              </Button>
+            </div>
             <p className="text-xs text-muted-foreground">
               or pin anything below with <kbd className="font-mono">t</kbd>
             </p>

--- a/components/TodaySection.tsx
+++ b/components/TodaySection.tsx
@@ -6,6 +6,7 @@ import ItemRow from './ItemRow';
 import SortableRows from './SortableRows';
 import type { ScoredItem } from '@/lib/dashboard';
 import type { Item, Priority } from '@/lib/types';
+import { formatMinutes } from '@/lib/format-duration';
 
 interface Props {
   items: ScoredItem[];
@@ -24,14 +25,6 @@ interface Props {
   onReorder: (orderedItemIds: number[]) => void | Promise<void>;
   failingSources?: Set<Item['source']>;
   onOpenScoringReference: () => void;
-}
-
-function formatMinutes(minutes: number): string {
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  if (h === 0) return `${m}m`;
-  if (m === 0) return `${h}h`;
-  return `${h}h ${m}m`;
 }
 
 export default function TodaySection({

--- a/e2e/suggest.spec.ts
+++ b/e2e/suggest.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Page } from '@playwright/test';
+import { createItem, hideExistingItems } from './helpers';
+
+// Ad-hoc items are the only source an e2e run can create, so these specs
+// cover the surface and the accept path. The lean is exercised in
+// lib/suggest.test.ts instead: it only acts on the pull-request/work-item
+// split, and ad-hoc rows are exempt from it by design.
+async function seedPool(request: Parameters<typeof createItem>[0], stamp: number): Promise<string[]> {
+  await hideExistingItems(request);
+  const titles = [1, 2, 3, 4].map((n) => `Suggest candidate ${n} ${stamp}`);
+  for (const title of titles) {
+    await createItem(request, title);
+  }
+  return titles;
+}
+
+function pinButton(page: Page) {
+  return page.getByRole('dialog').getByRole('button', { name: /Pin \d+ to today/ });
+}
+
+async function pinCount(page: Page): Promise<number> {
+  return Number((await pinButton(page).textContent())!.match(/\d+/)![0]);
+}
+
+test('suggests a day, then pins only what the user keeps', async ({ page, request }) => {
+  const titles = await seedPool(request, Date.now());
+
+  await page.goto('/');
+  // Keyboard entry, since keyboard-first is a durable principle here. Not
+  // 'S': that letter is row-scope Star (see lib/keymap.ts).
+  await page.keyboard.press('i');
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toContainText('step 2 of 4');
+  await expect(dialog.getByRole('radio', { name: 'Suggested' })).toHaveAttribute('aria-checked', 'true');
+  await expect(dialog.getByRole('radio', { name: 'Balanced' })).toHaveAttribute('aria-checked', 'true');
+
+  await expect(pinButton(page)).toBeEnabled();
+  await expect(pinButton(page)).toContainText(String(titles.length));
+
+  // With no logged time yet, every duration is a fixed default and the panel
+  // has to say so rather than presenting a guess as a measurement.
+  await expect(dialog).toContainText('Durations are rough defaults');
+
+  // Switching algorithm keeps the panel in place rather than emptying it.
+  await page.keyboard.press('2');
+  await expect(dialog.getByRole('radio', { name: 'Quick wins' })).toHaveAttribute('aria-checked', 'true');
+  await expect(pinButton(page)).toBeEnabled();
+
+  // Unchecking drops the count on the button, and nothing is written yet.
+  const before = await pinCount(page);
+  await dialog.locator('input[type="checkbox"]').first().uncheck();
+  await expect(pinButton(page)).toContainText(String(before - 1));
+
+  await pinButton(page).click();
+
+  // Accepting lands on the estimate step, where the durations it worked out
+  // are offered as placeholders rather than written as estimates.
+  await expect(dialog).toContainText('step 3 of 4');
+  const accept = dialog.getByRole('button', { name: /Accept all rough durations/ });
+  await expect(accept).toBeVisible();
+  const roughInputs = dialog.locator('input[placeholder^="~"]');
+  await expect(roughInputs.first()).toHaveValue('');
+  expect(await roughInputs.count()).toBe(before - 1);
+
+  await accept.click();
+  await expect(accept).toHaveCount(0);
+  await expect(roughInputs.first()).not.toHaveValue('');
+});
+
+test('dismissing a suggestion leaves the day exactly as it was', async ({ page, request }) => {
+  await seedPool(request, Date.now());
+
+  await page.goto('/');
+  const grips = page.locator('button[aria-label^="Reorder "]');
+  const before = await grips.count();
+
+  await page.keyboard.press('i');
+  const dialog = page.getByRole('dialog');
+  await expect(pinButton(page)).toBeEnabled();
+  await dialog.getByRole('button', { name: 'Dismiss' }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(grips).toHaveCount(before);
+});
+
+test('All signals stays the default mode and keeps its own copy', async ({ page, request }) => {
+  await seedPool(request, Date.now());
+
+  await page.goto('/');
+  await page.keyboard.press('p');
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toContainText('step 1 of 4');
+  await dialog.getByRole('button', { name: 'Next' }).click();
+
+  await expect(dialog).toContainText('step 2 of 4');
+  await expect(dialog.getByRole('radio', { name: 'All signals' })).toHaveAttribute('aria-checked', 'true');
+  // The claim belongs to this list, and must not appear over a suggestion.
+  await expect(dialog).toContainText('Ordered by score. Nothing is recommended.');
+
+  await dialog.getByRole('radio', { name: 'Suggested' }).click();
+  await expect(dialog).not.toContainText('Ordered by score. Nothing is recommended.');
+});

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -14,12 +14,20 @@ export const SETTINGS_KEYS = {
   savedViews: 'ui.savedViews',
   dailyCapacityMinutes: 'plan.dailyCapacityMinutes',
   longRunNudgeHours: 'plan.longRunNudgeHours',
+  suggestAlgorithm: 'suggest.algorithm',
+  suggestLean: 'suggest.lean',
 } as const;
 
 export const DEFAULT_STALE_DAYS = 3;
 export const NEEDS_ATTENTION_THRESHOLD = 25;
 export const DEFAULT_CAPACITY_MINUTES = 360; // 6h, per the wireframe's default
 export const DEFAULT_LONG_RUN_NUDGE_HOURS = 2;
+
+// Balanced is the default because it is the only one of the three that both
+// protects a block for real work and clears the small stuff. Urgency first is
+// the honest fallback, but on a day with one big overdue item it produces a
+// plan with a single row in it.
+export const DEFAULT_SUGGEST_ALGORITHM = 'balanced';
 
 export type Density = 'comfortable' | 'compact';
 

--- a/lib/format-duration.test.ts
+++ b/lib/format-duration.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { formatMinutes } from './format-duration';
+
+describe('formatMinutes', () => {
+  it('renders minutes alone under an hour', () => {
+    expect(formatMinutes(45)).toBe('45m');
+    expect(formatMinutes(0)).toBe('0m');
+  });
+
+  it('drops the minutes on a whole hour', () => {
+    expect(formatMinutes(60)).toBe('1h');
+    expect(formatMinutes(360)).toBe('6h');
+  });
+
+  it('renders both parts otherwise', () => {
+    expect(formatMinutes(90)).toBe('1h 30m');
+    expect(formatMinutes(125)).toBe('2h 5m');
+  });
+
+  it('rounds a fractional total rather than its remainder', () => {
+    // Rounding the remainder alone would render this as "1h 60m".
+    expect(formatMinutes(119.6)).toBe('2h');
+    expect(formatMinutes(45.4)).toBe('45m');
+    expect(formatMinutes(89.5)).toBe('1h 30m');
+  });
+});

--- a/lib/format-duration.ts
+++ b/lib/format-duration.ts
@@ -1,0 +1,16 @@
+// Zero-dependency helper (see lib/elapsed.ts) so it can be imported from a
+// 'use client' component. One copy, because a duration rendered as "1h 30m"
+// in one panel and "90m" in the next reads as two different facts.
+//
+// The total is rounded before it is split, not after. Callers pass minutes
+// derived from logged hours, so a fractional value is normal; rounding the
+// remainder alone renders 119.6 as "1h 60m", which is what two of the three
+// copies this replaced would have done.
+export function formatMinutes(minutes: number): string {
+  const total = Math.round(minutes);
+  const h = Math.floor(total / 60);
+  const m = total % 60;
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}

--- a/lib/keymap.test.ts
+++ b/lib/keymap.test.ts
@@ -16,6 +16,13 @@ describe('KEYMAP', () => {
     }
   });
 
+  it('binds Suggest a day to a letter no row binding claims', () => {
+    const suggest = KEYMAP.find((entry) => entry.keys === 'i');
+    expect(suggest).toMatchObject({ description: 'Suggest a day', scope: 'global' });
+    const rowLetters = KEYMAP.filter((entry) => entry.scope === 'row').map((entry) => entry.keys);
+    expect(rowLetters).not.toContain('i');
+  });
+
   it('declares the row-scoped complete binding wired up in ItemRow', () => {
     const complete = KEYMAP.find((binding) => binding.keys === 'c');
     expect(complete).toEqual({ keys: 'c', description: 'Complete the focused item', scope: 'row' });

--- a/lib/keymap.ts
+++ b/lib/keymap.ts
@@ -23,9 +23,10 @@ export interface KeyBinding {
 //
 // A row binding must not reuse a letter the global switch also matches:
 // GlobalKeymapProvider does not bail when a row has focus, so both handlers
-// would fire. That switch currently matches `/ ? r w p g` case-insensitively
+// would fire. That switch currently matches `/ ? r w p g i` case-insensitively
 // even though `P`/`R`/`W` are declared uppercase here, which is why the
-// priority cycle is `f` (for the flag icon it carries) and not `p`.
+// priority cycle is `f` (for the flag icon it carries) and not `p`, and why
+// Suggest a day is `i` and not the `S` it wants to be -- `s` is Star.
 //
 // Deliberately NOT included yet: `space` (start/stop timer) -- it triggers a
 // Phase 3 feature that doesn't exist in this codebase yet. Declaring a
@@ -46,6 +47,7 @@ export const KEYMAP: KeyBinding[] = [
   { keys: 'a', description: 'Add an ad-hoc item', scope: 'global' },
   { keys: '/', description: 'Focus the query bar', scope: 'global' },
   { keys: 'P', description: 'Plan the day', scope: 'global' },
+  { keys: 'i', description: 'Suggest a day', scope: 'global' },
   { keys: '⌘K / Ctrl+K', description: 'Search or jump to', scope: 'global' },
   { keys: '⌘Z', description: 'Undo the last triage action', scope: 'global' },
   { keys: 'g d', description: 'Go to the dashboard', scope: 'global' },

--- a/lib/plans-repo.test.ts
+++ b/lib/plans-repo.test.ts
@@ -9,6 +9,7 @@ import {
   removePlanItem,
   setPlanItemEstimate,
   reorderPlanItems,
+  getLatestPriorEstimates,
 } from './plans-repo';
 import { DEFAULT_CAPACITY_MINUTES } from './config';
 import type Database from 'better-sqlite3';
@@ -99,5 +100,41 @@ describe('reorderPlanItems', () => {
     const reordered = reorderPlanItems(db, DATE, [c.id, a.id, b.id]);
     expect(reordered.map((i) => i.itemId)).toEqual([c.id, a.id, b.id]);
     expect(reordered.map((i) => i.sortOrder)).toEqual([0, 1, 2]);
+  });
+});
+
+describe('getLatestPriorEstimates', () => {
+  it('returns nothing when no earlier plan carried an estimate', () => {
+    expect(getLatestPriorEstimates(db, DATE)).toEqual(new Map());
+  });
+
+  it('returns the most recent estimate before the given date', () => {
+    const item = createAdhocItem(db, { title: 'Carried over' });
+    addPlanItem(db, '2026-08-10', item.id);
+    setPlanItemEstimate(db, '2026-08-10', item.id, 30);
+    addPlanItem(db, '2026-08-12', item.id);
+    setPlanItemEstimate(db, '2026-08-12', item.id, 90);
+    expect(getLatestPriorEstimates(db, DATE)).toEqual(new Map([[item.id, 90]]));
+  });
+
+  it('ignores the given date itself and anything after it', () => {
+    const item = createAdhocItem(db, { title: 'Today only' });
+    addPlanItem(db, DATE, item.id);
+    setPlanItemEstimate(db, DATE, item.id, 45);
+    expect(getLatestPriorEstimates(db, DATE)).toEqual(new Map());
+  });
+
+  it('skips a plan row that never got an estimate', () => {
+    const item = createAdhocItem(db, { title: 'Never sized' });
+    addPlanItem(db, '2026-08-10', item.id);
+    expect(getLatestPriorEstimates(db, DATE)).toEqual(new Map());
+  });
+
+  it('falls back to the most recent row that does carry an estimate', () => {
+    const item = createAdhocItem(db, { title: 'Sized once' });
+    addPlanItem(db, '2026-08-10', item.id);
+    setPlanItemEstimate(db, '2026-08-10', item.id, 30);
+    addPlanItem(db, '2026-08-12', item.id);
+    expect(getLatestPriorEstimates(db, DATE)).toEqual(new Map([[item.id, 30]]));
   });
 });

--- a/lib/plans-repo.ts
+++ b/lib/plans-repo.ts
@@ -75,3 +75,25 @@ export function reorderPlanItems(db: Database.Database, date: string, orderedIte
   orderedItemIds.forEach((itemId, index) => update.run(index, date, itemId));
   return getPlanItems(db, date);
 }
+
+// The last size the user gave an item on any earlier day. Carried-over work
+// should keep the number the user chose rather than being re-guessed from a
+// bucket average, so this beats the logged median in resolveDuration's order.
+// Rows with no estimate are skipped rather than treated as zero: never sized
+// is not the same fact as sized at nothing.
+export function getLatestPriorEstimates(db: Database.Database, beforeDate: string): Map<number, number> {
+  const rows = db
+    .prepare(
+      `SELECT item_id as itemId, estimate_minutes as estimateMinutes
+       FROM plan_items
+       WHERE plan_date < ? AND estimate_minutes IS NOT NULL
+       ORDER BY plan_date ASC`
+    )
+    .all(beforeDate) as { itemId: number; estimateMinutes: number }[];
+
+  // Ascending order means a later row overwrites an earlier one, leaving the
+  // most recent estimate per item.
+  const byItem = new Map<number, number>();
+  for (const row of rows) byItem.set(row.itemId, row.estimateMinutes);
+  return byItem;
+}

--- a/lib/suggest.test.ts
+++ b/lib/suggest.test.ts
@@ -3,6 +3,7 @@ import {
   resolveDuration,
   suggestDay,
   isSuggestCandidate,
+  getSuggestionReference,
   leanCaps,
   ANCHOR_MIN_MINUTES,
   DEFAULT_LEAN,
@@ -437,5 +438,29 @@ describe('isSuggestCandidate', () => {
 
   it("accepts an item left over from an earlier day's plan", () => {
     expect(isSuggestCandidate(eligibleItem({ todayDate: '2026-09-02' }), TODAY, NOW)).toBe(true);
+  });
+});
+
+describe('getSuggestionReference', () => {
+  it('names all three algorithms', () => {
+    const ref = getSuggestionReference();
+    expect(ref.algorithms.map((a) => a.key)).toEqual(['urgency', 'quick_wins', 'balanced']);
+    expect(ref.algorithms.every((a) => a.description.length > 0)).toBe(true);
+  });
+
+  it('states the duration resolution order, one entry per resolution step', () => {
+    expect(getSuggestionReference().durationOrder).toHaveLength(4);
+  });
+
+  it('generates its numbers from the engine rather than restating them', () => {
+    const ref = getSuggestionReference();
+    expect(ref.anchorMinMinutes).toBe(ANCHOR_MIN_MINUTES);
+    expect(ref.minSamplesForMedian).toBe(MIN_SAMPLES_FOR_MEDIAN);
+    expect(ref.fallbackMinutes).toEqual(FALLBACK_MINUTES);
+    expect(ref.leanShares).toEqual(Object.values(LEAN_WORK_ITEM_SHARE));
+  });
+
+  it('states that the score is never adjusted to produce a suggestion', () => {
+    expect(getSuggestionReference().nonPointRules.join(' ')).toContain('never adjusts a score');
   });
 });

--- a/lib/suggest.test.ts
+++ b/lib/suggest.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   resolveDuration,
   suggestDay,
+  leanCaps,
   ANCHOR_MIN_MINUTES,
+  DEFAULT_LEAN,
+  LEAN_WORK_ITEM_SHARE,
   FALLBACK_MINUTES,
   MIN_SAMPLES_FOR_MEDIAN,
   type SuggestCandidate,
@@ -236,5 +239,130 @@ describe('suggestDay', () => {
   it('echoes the algorithm, lean, and capacity it was asked for', () => {
     const result = suggestDay(input({ algorithm: 'quick_wins', lean: 4, capacityMinutes: 240 }));
     expect(result).toMatchObject({ algorithm: 'quick_wins', lean: 4, capacityMinutes: 240 });
+  });
+});
+
+function pr(id: number, score: number, minutes: number) {
+  return sized(id, score, minutes, { source: 'github_pr', reason: 'review_requested' });
+}
+
+function workItem(id: number, score: number, minutes: number) {
+  return sized(id, score, minutes, { source: 'ado_workitem', reason: 'assigned' });
+}
+
+function adhoc(id: number, score: number, minutes: number) {
+  return sized(id, score, minutes, { source: 'adhoc', reason: 'manual' });
+}
+
+describe('leanCaps', () => {
+  it('splits capacity by the notch, and the two caps always sum to capacity', () => {
+    expect(leanCaps(600, 4)).toEqual({ work_item: 480, pr: 120 });
+    expect(leanCaps(600, 0)).toEqual({ work_item: 120, pr: 480 });
+    for (const notch of [0, 1, 2, 3, 4] as const) {
+      const caps = leanCaps(600, notch);
+      expect(caps.pr + caps.work_item).toBe(600);
+    }
+  });
+
+  it('is neutral at the default notch', () => {
+    expect(LEAN_WORK_ITEM_SHARE[DEFAULT_LEAN]).toBe(0.5);
+    expect(leanCaps(600, DEFAULT_LEAN)).toEqual({ work_item: 300, pr: 300 });
+  });
+});
+
+describe('suggestDay lean', () => {
+  it('defers a pull request past its cap while a work item is still waiting', () => {
+    const result = suggestDay(
+      input({
+        capacityMinutes: 200,
+        lean: 4, // prCap = 40, workItemCap = 160
+        candidates: [pr(1, 65, 60), workItem(2, 45, 60)],
+      })
+    );
+    expect(result.picks.map((p) => p.itemId)).toEqual([2]);
+    expect(result.deferredByLean.map((c) => c.itemId)).toEqual([1]);
+    expect(result.deferredByLean[0].exclusionReason).toBe('deferred_by_lean');
+  });
+
+  it('leaves the room the lean cost visible rather than reclaiming it', () => {
+    const result = suggestDay(
+      input({
+        capacityMinutes: 200,
+        lean: 4,
+        candidates: [pr(1, 65, 60), workItem(2, 45, 60)],
+      })
+    );
+    // 140 minutes of the day are unspent, and the deferred list is why. That
+    // pairing is the whole disclosure; a retry would erase it.
+    expect(result.suggestedMinutes).toBe(60);
+    expect(result.deferredByLean).toHaveLength(1);
+    expect(result.note).toBeNull();
+  });
+
+  it('lifts the cap when the other side has nothing left to offer', () => {
+    const result = suggestDay(
+      input({
+        capacityMinutes: 100,
+        lean: 4, // prCap = 20
+        candidates: [pr(1, 65, 60), pr(2, 45, 30)],
+      })
+    );
+    // No work item anywhere, so the cap never blocks anything.
+    expect(result.picks.map((p) => p.itemId)).toEqual([1, 2]);
+    expect(result.deferredByLean).toEqual([]);
+  });
+
+  it('reports a deferred candidate as did_not_fit once the room is gone', () => {
+    const result = suggestDay(
+      input({
+        capacityMinutes: 60,
+        lean: 4, // prCap = 12
+        candidates: [pr(1, 65, 60), workItem(2, 45, 60)],
+      })
+    );
+    expect(result.picks.map((p) => p.itemId)).toEqual([2]);
+    expect(result.didNotFit.map((c) => c.itemId)).toEqual([1]);
+    expect(result.deferredByLean).toEqual([]);
+  });
+
+  it('applies a cap only while the other side has a later candidate that fits', () => {
+    const result = suggestDay(
+      input({
+        capacityMinutes: 200,
+        lean: 4, // prCap = 40
+        // The work item is longer than the whole day, so the look-ahead finds
+        // no alternative on the other side and the cap does not apply.
+        candidates: [pr(1, 65, 60), workItem(2, 45, 250)],
+      })
+    );
+    expect(result.picks.map((p) => p.itemId)).toEqual([1]);
+    expect(result.deferredByLean).toEqual([]);
+    expect(result.didNotFit.map((c) => c.itemId)).toEqual([2]);
+  });
+
+  it('exempts ad-hoc items from both caps and counts them toward neither side', () => {
+    const result = suggestDay(
+      input({
+        capacityMinutes: 300,
+        lean: 4, // prCap = 60
+        candidates: [adhoc(1, 65, 240), pr(2, 45, 60)],
+      })
+    );
+    // The ad-hoc item consumed 240 of the day without touching either cap, so
+    // the pull request is still inside its 60 minute allowance.
+    expect(result.picks.map((p) => p.itemId)).toEqual([1, 2]);
+    expect(result.deferredByLean).toEqual([]);
+  });
+
+  it('holds nothing back at the neutral notch on a balanced pool', () => {
+    const result = suggestDay(
+      input({
+        capacityMinutes: 300,
+        lean: DEFAULT_LEAN,
+        candidates: [pr(1, 65, 60), workItem(2, 45, 60), pr(3, 40, 60)],
+      })
+    );
+    expect(result.deferredByLean).toEqual([]);
+    expect(result.picks).toHaveLength(3);
   });
 });

--- a/lib/suggest.test.ts
+++ b/lib/suggest.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDuration, FALLBACK_MINUTES, MIN_SAMPLES_FOR_MEDIAN, type SuggestCandidate } from './suggest';
+
+function candidate(overrides: Partial<SuggestCandidate> = {}): SuggestCandidate {
+  return {
+    id: 1,
+    source: 'github_pr',
+    reason: 'review_requested',
+    status: 'inbox',
+    score: 40,
+    rawUpdatedAt: '2026-09-01T09:00:00.000Z',
+    estimateMinutes: null,
+    ...overrides,
+  };
+}
+
+describe('resolveDuration', () => {
+  it("uses today's estimate when the item has one", () => {
+    expect(resolveDuration(candidate({ estimateMinutes: 90 }), {}, new Map())).toEqual({
+      minutes: 90,
+      source: 'plan_estimate',
+    });
+  });
+
+  it('falls back to an estimate the item carried on an earlier plan date', () => {
+    expect(resolveDuration(candidate(), {}, new Map([[1, 75]]))).toEqual({
+      minutes: 75,
+      source: 'prior_estimate',
+    });
+  });
+
+  it("prefers today's estimate over an earlier one", () => {
+    expect(resolveDuration(candidate({ estimateMinutes: 90 }), {}, new Map([[1, 75]]))).toEqual({
+      minutes: 90,
+      source: 'plan_estimate',
+    });
+  });
+
+  it('uses the logged median for the work type once there are enough samples', () => {
+    const medians = { review: { medianMinutes: 37, sampleCount: MIN_SAMPLES_FOR_MEDIAN } };
+    expect(resolveDuration(candidate(), medians, new Map())).toEqual({
+      minutes: 37,
+      source: 'logged_median',
+    });
+  });
+
+  it('ignores a median below the sample floor and uses the fallback', () => {
+    const medians = { review: { medianMinutes: 37, sampleCount: MIN_SAMPLES_FOR_MEDIAN - 1 } };
+    expect(resolveDuration(candidate(), medians, new Map())).toEqual({
+      minutes: FALLBACK_MINUTES.review,
+      source: 'fallback',
+    });
+  });
+
+  it('prefers an earlier estimate over the logged median', () => {
+    const medians = { review: { medianMinutes: 37, sampleCount: 10 } };
+    expect(resolveDuration(candidate(), medians, new Map([[1, 75]]))).toEqual({
+      minutes: 75,
+      source: 'prior_estimate',
+    });
+  });
+
+  it('rounds a fractional median to whole minutes', () => {
+    const medians = { review: { medianMinutes: 37.6, sampleCount: 5 } };
+    expect(resolveDuration(candidate(), medians, new Map()).minutes).toBe(38);
+  });
+
+  it('classifies an ad-hoc item into the ad_hoc fallback', () => {
+    const adhoc = candidate({ source: 'adhoc', reason: 'manual' });
+    expect(resolveDuration(adhoc, {}, new Map())).toEqual({
+      minutes: FALLBACK_MINUTES.ad_hoc,
+      source: 'fallback',
+    });
+  });
+});

--- a/lib/suggest.test.ts
+++ b/lib/suggest.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   resolveDuration,
   suggestDay,
+  isSuggestCandidate,
   leanCaps,
   ANCHOR_MIN_MINUTES,
   DEFAULT_LEAN,
@@ -11,6 +12,7 @@ import {
   type SuggestCandidate,
   type SuggestInput,
 } from './suggest';
+import type { Item } from './types';
 
 function candidate(overrides: Partial<SuggestCandidate> = {}): SuggestCandidate {
   return {
@@ -364,5 +366,76 @@ describe('suggestDay lean', () => {
     );
     expect(result.deferredByLean).toEqual([]);
     expect(result.picks).toHaveLength(3);
+  });
+});
+
+const TODAY = '2026-09-03';
+
+function eligibleItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 1,
+    source: 'github_pr',
+    externalId: 'pr-1',
+    title: 'A pull request',
+    url: null,
+    reason: 'review_requested',
+    category: null,
+    dueDate: null,
+    sprintIteration: null,
+    rawUpdatedAt: null,
+    status: 'inbox',
+    createdAt: '2026-09-01T09:00:00.000Z',
+    completedAt: null,
+    adoStatus: null,
+    prStatus: null,
+    repo: 'org/repo',
+    hasUnresolvedConversations: false,
+    parked: false,
+    todayDate: null,
+    starred: false,
+    snoozedUntil: null,
+    triageState: 'none',
+    wokeEarly: false,
+    priority: null,
+    prioritySetAt: null,
+    ...overrides,
+  };
+}
+
+describe('isSuggestCandidate', () => {
+  it('accepts an inbox item', () => {
+    expect(isSuggestCandidate(eligibleItem(), TODAY, NOW)).toBe(true);
+  });
+
+  it("accepts an in-progress item that is not in today's plan, because Today and In-progress are independent axes", () => {
+    expect(isSuggestCandidate(eligibleItem({ status: 'in_progress' }), TODAY, NOW)).toBe(true);
+  });
+
+  it('rejects a parked item', () => {
+    expect(isSuggestCandidate(eligibleItem({ status: 'in_progress', parked: true }), TODAY, NOW)).toBe(false);
+  });
+
+  it('rejects a completed item', () => {
+    expect(isSuggestCandidate(eligibleItem({ status: 'done' }), TODAY, NOW)).toBe(false);
+  });
+
+  it('rejects an item snoozed into the future', () => {
+    expect(isSuggestCandidate(eligibleItem({ snoozedUntil: '2026-09-10T09:00:00.000Z' }), TODAY, NOW)).toBe(false);
+  });
+
+  it('accepts an item whose snooze has already elapsed', () => {
+    expect(isSuggestCandidate(eligibleItem({ snoozedUntil: '2026-09-01T09:00:00.000Z' }), TODAY, NOW)).toBe(true);
+  });
+
+  it('rejects an item already marked triage done', () => {
+    expect(isSuggestCandidate(eligibleItem({ triageState: 'done' }), TODAY, NOW)).toBe(false);
+  });
+
+  it("rejects an item already in today's plan", () => {
+    expect(isSuggestCandidate(eligibleItem({ todayDate: TODAY }), TODAY, NOW)).toBe(false);
+  });
+
+  it("accepts an item left over from an earlier day's plan", () => {
+    expect(isSuggestCandidate(eligibleItem({ todayDate: '2026-09-02' }), TODAY, NOW)).toBe(true);
   });
 });

--- a/lib/suggest.test.ts
+++ b/lib/suggest.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { resolveDuration, FALLBACK_MINUTES, MIN_SAMPLES_FOR_MEDIAN, type SuggestCandidate } from './suggest';
+import {
+  resolveDuration,
+  suggestDay,
+  ANCHOR_MIN_MINUTES,
+  FALLBACK_MINUTES,
+  MIN_SAMPLES_FOR_MEDIAN,
+  type SuggestCandidate,
+  type SuggestInput,
+} from './suggest';
 
 function candidate(overrides: Partial<SuggestCandidate> = {}): SuggestCandidate {
   return {
@@ -71,5 +79,162 @@ describe('resolveDuration', () => {
       minutes: FALLBACK_MINUTES.ad_hoc,
       source: 'fallback',
     });
+  });
+});
+
+const NOW = new Date('2026-09-03T09:00:00.000Z');
+
+function input(overrides: Partial<SuggestInput> = {}): SuggestInput {
+  return {
+    candidates: [],
+    capacityMinutes: 360,
+    algorithm: 'urgency',
+    lean: 2,
+    medians: {},
+    priorEstimates: new Map(),
+    pinnedTodayCount: 0,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+// Every candidate carries an explicit estimate so these tests exercise the
+// strategies rather than the duration fallbacks, which the resolveDuration
+// tests already cover.
+function sized(id: number, score: number, minutes: number, overrides: Partial<SuggestCandidate> = {}) {
+  return candidate({ id, score, estimateMinutes: minutes, ...overrides });
+}
+
+describe('suggestDay', () => {
+  it('reports an empty Signals list when there is nothing to suggest', () => {
+    const result = suggestDay(input());
+    expect(result.picks).toEqual([]);
+    expect(result.note).toBe('signals_empty');
+  });
+
+  it('reports that everything is already planned when the pool is empty but items are pinned', () => {
+    expect(suggestDay(input({ pinnedTodayCount: 3 })).note).toBe('all_pinned');
+  });
+
+  it('takes candidates in the given order for urgency, and never overfills', () => {
+    const result = suggestDay(
+      input({
+        capacityMinutes: 120,
+        candidates: [sized(1, 65, 90), sized(2, 45, 60), sized(3, 40, 30)],
+      })
+    );
+    expect(result.picks.map((p) => p.itemId)).toEqual([1, 3]);
+    expect(result.suggestedMinutes).toBe(120);
+    expect(result.picks.every((p) => p.pickReason === 'top_urgency')).toBe(true);
+  });
+
+  it('reports an item that did not fit', () => {
+    const result = suggestDay(
+      input({ capacityMinutes: 60, candidates: [sized(1, 65, 90), sized(2, 45, 60)] })
+    );
+    expect(result.picks.map((p) => p.itemId)).toEqual([2]);
+    expect(result.didNotFit.map((c) => c.itemId)).toEqual([1]);
+    expect(result.didNotFit[0].exclusionReason).toBe('did_not_fit');
+  });
+
+  it('orders quick wins by score per minute', () => {
+    const result = suggestDay(
+      input({
+        algorithm: 'quick_wins',
+        capacityMinutes: 600,
+        // Densities: 65/120 = 0.54, 45/30 = 1.5, 40/45 = 0.89
+        candidates: [sized(1, 65, 120), sized(2, 45, 30), sized(3, 40, 45)],
+      })
+    );
+    expect(result.picks.map((p) => p.itemId)).toEqual([2, 3, 1]);
+    expect(result.picks.every((p) => p.pickReason === 'best_value')).toBe(true);
+  });
+
+  it('breaks a density tie by score, then by oldest activity first', () => {
+    const result = suggestDay(
+      input({
+        algorithm: 'quick_wins',
+        capacityMinutes: 600,
+        candidates: [
+          sized(1, 40, 40, { rawUpdatedAt: '2026-09-02T09:00:00.000Z' }),
+          sized(2, 40, 40, { rawUpdatedAt: '2026-08-20T09:00:00.000Z' }),
+          sized(3, 60, 60),
+        ],
+      })
+    );
+    // All three sit at density 1.0, so score wins first, then the older row.
+    expect(result.picks.map((p) => p.itemId)).toEqual([3, 2, 1]);
+  });
+
+  it('anchors balanced on the highest-scoring long item, then fills with quick wins', () => {
+    const result = suggestDay(
+      input({
+        algorithm: 'balanced',
+        capacityMinutes: 300,
+        candidates: [sized(1, 45, 30), sized(2, 65, 120), sized(3, 40, 45)],
+      })
+    );
+    expect(result.picks[0]).toMatchObject({ itemId: 2, pickReason: 'anchor' });
+    expect(result.picks.slice(1).map((p) => p.itemId)).toEqual([1, 3]);
+    expect(result.picks.slice(1).every((p) => p.pickReason === 'fills_room')).toBe(true);
+    expect(result.degradedToQuickWins).toBe(false);
+  });
+
+  it('degrades balanced to quick wins when nothing is long enough to anchor', () => {
+    const result = suggestDay(
+      input({
+        algorithm: 'balanced',
+        capacityMinutes: 300,
+        candidates: [sized(1, 45, ANCHOR_MIN_MINUTES - 1), sized(2, 65, 30)],
+      })
+    );
+    expect(result.degradedToQuickWins).toBe(true);
+    expect(result.picks.every((p) => p.pickReason === 'best_value')).toBe(true);
+  });
+
+  it('takes no anchor when the only long item does not fit capacity', () => {
+    const result = suggestDay(
+      input({
+        algorithm: 'balanced',
+        capacityMinutes: 60,
+        candidates: [sized(1, 65, 240), sized(2, 40, 30)],
+      })
+    );
+    expect(result.degradedToQuickWins).toBe(true);
+    expect(result.picks.map((p) => p.itemId)).toEqual([2]);
+  });
+
+  it('reports capacity too small when nothing at all fits', () => {
+    const result = suggestDay(input({ capacityMinutes: 15, candidates: [sized(1, 65, 90)] }));
+    expect(result.picks).toEqual([]);
+    expect(result.note).toBe('capacity_too_small');
+  });
+
+  it('reports that nothing else fits when room is left over', () => {
+    const result = suggestDay(
+      input({ capacityMinutes: 100, candidates: [sized(1, 65, 60), sized(2, 45, 90)] })
+    );
+    expect(result.picks.map((p) => p.itemId)).toEqual([1]);
+    expect(result.note).toBe('nothing_else_fits');
+  });
+
+  it('leaves the note unset when capacity is spent exactly', () => {
+    const result = suggestDay(input({ capacityMinutes: 60, candidates: [sized(1, 65, 60)] }));
+    expect(result.note).toBeNull();
+  });
+
+  it('flags rough durations only when no work type reaches the sample floor', () => {
+    const candidates = [sized(1, 65, 60)];
+    expect(suggestDay(input({ candidates })).durationsAreRough).toBe(true);
+    expect(
+      suggestDay(
+        input({ candidates, medians: { review: { medianMinutes: 30, sampleCount: MIN_SAMPLES_FOR_MEDIAN } } })
+      ).durationsAreRough
+    ).toBe(false);
+  });
+
+  it('echoes the algorithm, lean, and capacity it was asked for', () => {
+    const result = suggestDay(input({ algorithm: 'quick_wins', lean: 4, capacityMinutes: 240 }));
+    expect(result).toMatchObject({ algorithm: 'quick_wins', lean: 4, capacityMinutes: 240 });
   });
 });

--- a/lib/suggest.ts
+++ b/lib/suggest.ts
@@ -378,3 +378,25 @@ export function suggestDay(input: SuggestInput): Suggestion {
     note,
   };
 }
+
+/**
+ * Whether an item can be suggested for a given day.
+ *
+ * A pure predicate rather than an inline filter in the API route, so the pool
+ * rules are unit-testable alongside every other rule in the engine. An item
+ * silently missing from a proposal is the hardest kind of bug to notice.
+ *
+ * Note the in-progress case: an in-progress item that is not in today's plan
+ * is a legitimate candidate, because Today and In-progress are independent
+ * axes in this product, not one bucket each.
+ */
+export function isSuggestCandidate(item: Item, today: string, now: Date): boolean {
+  if (item.status === 'done') return false;
+  if (item.status === 'in_progress' && item.parked) return false;
+  if (item.triageState === 'done') return false;
+  if (item.snoozedUntil !== null && item.snoozedUntil > now.toISOString()) return false;
+  // Already planned for today, so re-suggesting it would propose work the
+  // user has already committed to.
+  if (item.todayDate === today) return false;
+  return true;
+}

--- a/lib/suggest.ts
+++ b/lib/suggest.ts
@@ -1,0 +1,99 @@
+import { classifyWorkType, type WorkType } from './calibration';
+import type { ScoreBreakdownEntry } from './scoring';
+import type { Item, Reason, Source, Status } from './types';
+
+export type SuggestAlgorithm = 'urgency' | 'quick_wins' | 'balanced';
+
+// 0 leans hardest toward pull requests, 4 hardest toward work items, 2 is
+// neutral. Discrete notches rather than a continuous value because the
+// mechanism is a soft cap, and a slider would imply a precision it does not
+// have.
+export type LeanNotch = 0 | 1 | 2 | 3 | 4;
+
+export type DurationSource = 'plan_estimate' | 'prior_estimate' | 'logged_median' | 'fallback';
+
+export type PickReason = 'anchor' | 'top_urgency' | 'best_value' | 'fills_room';
+
+export type ExclusionReason = 'did_not_fit' | 'deferred_by_lean';
+
+export type SuggestionNote = 'signals_empty' | 'all_pinned' | 'capacity_too_small' | 'nothing_else_fits';
+
+// Which side of the pull-request / work-item split an item sits on. Ad-hoc
+// items sit on neither and are exempt from the lean entirely.
+export type LeanSide = 'pr' | 'work_item';
+
+// What the panel needs to render a row: an item plus the three fields
+// sortByUrgency() adds. Deliberately narrower than dashboard.ts's ScoredItem,
+// which also carries links, estimates, and logged time the panel never reads.
+export type SuggestionItem = Item & {
+  score: number;
+  scoreBreakdown: ScoreBreakdownEntry[];
+  notFired: string[];
+};
+
+export interface SuggestCandidate {
+  id: number;
+  source: Source;
+  reason: Reason;
+  status: Status;
+  score: number;
+  rawUpdatedAt: string | null;
+  estimateMinutes: number | null;
+}
+
+export interface WorkTypeDuration {
+  medianMinutes: number;
+  sampleCount: number;
+}
+
+export interface ResolvedDuration {
+  minutes: number;
+  source: DurationSource;
+}
+
+// Below this many logged samples a work type's median is noise, so the fixed
+// default is the more honest number.
+export const MIN_SAMPLES_FOR_MEDIAN = 3;
+
+export const FALLBACK_MINUTES: Record<WorkType, number> = {
+  review: 30,
+  own_work: 90,
+  assigned: 120,
+  ad_hoc: 45,
+};
+
+// What counts as "a long item" for the Balanced anchor.
+export const ANCHOR_MIN_MINUTES = 60;
+
+/**
+ * How long this item is likely to take, and where that number came from.
+ *
+ * Provenance travels with the number because the panel renders the two kinds
+ * differently: a duration the user set is stated plainly, a derived one is
+ * marked. A guessed number that looks like a stated one is the single most
+ * misleading thing this feature could do.
+ */
+export function resolveDuration(
+  candidate: SuggestCandidate,
+  medians: Partial<Record<WorkType, WorkTypeDuration>>,
+  priorEstimates: Map<number, number>
+): ResolvedDuration {
+  if (candidate.estimateMinutes !== null && candidate.estimateMinutes > 0) {
+    return { minutes: candidate.estimateMinutes, source: 'plan_estimate' };
+  }
+
+  // Carried-over work keeps the size the user already gave it, rather than
+  // being re-guessed from a bucket average.
+  const prior = priorEstimates.get(candidate.id);
+  if (prior !== undefined && prior > 0) {
+    return { minutes: prior, source: 'prior_estimate' };
+  }
+
+  const workType = classifyWorkType(candidate.reason);
+  const median = medians[workType];
+  if (median && median.sampleCount >= MIN_SAMPLES_FOR_MEDIAN && median.medianMinutes > 0) {
+    return { minutes: Math.round(median.medianMinutes), source: 'logged_median' };
+  }
+
+  return { minutes: FALLBACK_MINUTES[workType], source: 'fallback' };
+}

--- a/lib/suggest.ts
+++ b/lib/suggest.ts
@@ -400,3 +400,70 @@ export function isSuggestCandidate(item: Item, today: string, now: Date): boolea
   if (item.todayDate === today) return false;
   return true;
 }
+
+export interface SuggestionAlgorithmReference {
+  key: SuggestAlgorithm;
+  label: string;
+  description: string;
+}
+
+export interface SuggestionReference {
+  algorithms: SuggestionAlgorithmReference[];
+  durationOrder: string[];
+  anchorMinMinutes: number;
+  minSamplesForMedian: number;
+  fallbackMinutes: Record<WorkType, number>;
+  leanShares: number[];
+  nonPointRules: string[];
+}
+
+/**
+ * The suggestion half of the user-facing rules reference, generated from the
+ * same constants suggestDay() reads.
+ *
+ * It lives here rather than inside getScoringReference() so lib/scoring.ts,
+ * the module every other ranking decision hangs off, keeps no dependency on
+ * this feature. ScoringReferenceDialog composes the two, which is where
+ * composition for display belongs. Generated rather than hand-written for the
+ * same reason the scoring reference is: a copied number is a number that will
+ * eventually disagree with the code.
+ */
+export function getSuggestionReference(): SuggestionReference {
+  return {
+    algorithms: [
+      {
+        key: 'urgency',
+        label: 'Urgency first',
+        description: 'Highest score first, taken while it still fits the day.',
+      },
+      {
+        key: 'quick_wins',
+        label: 'Quick wins',
+        description: 'Best score per minute first, so small things clear out.',
+      },
+      {
+        key: 'balanced',
+        label: 'Balanced',
+        description: `The top-scoring item over ${ANCHOR_MIN_MINUTES} minutes is taken first, then quick wins fill what is left.`,
+      },
+    ],
+    durationOrder: [
+      'An estimate you set for today.',
+      'The last estimate you gave this item on an earlier day.',
+      `The median time you have actually logged on this kind of work, once there are ${MIN_SAMPLES_FOR_MEDIAN} logs to go on.`,
+      'A fixed default for this kind of work.',
+    ],
+    anchorMinMinutes: ANCHOR_MIN_MINUTES,
+    minSamplesForMedian: MIN_SAMPLES_FOR_MEDIAN,
+    fallbackMinutes: FALLBACK_MINUTES,
+    leanShares: Object.values(LEAN_WORK_ITEM_SHARE),
+    nonPointRules: [
+      'A suggestion never adjusts a score. The number on a row means the same thing here as everywhere else.',
+      'The lean is a cap on how much of the day each side can take, not a weight on any score. It lifts on its own when one side runs out of work.',
+      'Ad-hoc requests are exempt from the lean and count toward neither side of the split.',
+      'A suggestion writes nothing until you pin it, and it never reorders or removes anything on its own.',
+      'A duration the tool worked out for you never becomes an estimate until you accept it.',
+      'Where the lean holds something back, the day is left with room in it rather than filled from the other side. The rows it held back are listed, so the cost is visible.',
+    ],
+  };
+}

--- a/lib/suggest.ts
+++ b/lib/suggest.ts
@@ -97,3 +97,224 @@ export function resolveDuration(
 
   return { minutes: FALLBACK_MINUTES[workType], source: 'fallback' };
 }
+
+export interface SuggestedPick {
+  itemId: number;
+  durationMinutes: number;
+  durationSource: DurationSource;
+  pickReason: PickReason;
+}
+
+export interface ExcludedCandidate {
+  itemId: number;
+  durationMinutes: number;
+  durationSource: DurationSource;
+  exclusionReason: ExclusionReason;
+}
+
+export interface SuggestInput {
+  // Already in sortByUrgency() order. suggestDay never re-sorts for 'urgency'.
+  candidates: SuggestCandidate[];
+  capacityMinutes: number;
+  algorithm: SuggestAlgorithm;
+  lean: LeanNotch;
+  medians: Partial<Record<WorkType, WorkTypeDuration>>;
+  priorEstimates: Map<number, number>;
+  // How many items the caller excluded from the pool solely because they are
+  // already in today's plan. The only way to tell "Signals is empty" apart
+  // from "you have already planned all of it" without re-querying.
+  pinnedTodayCount: number;
+  now: Date;
+}
+
+export interface Suggestion {
+  algorithm: SuggestAlgorithm;
+  lean: LeanNotch;
+  capacityMinutes: number;
+  suggestedMinutes: number;
+  picks: SuggestedPick[];
+  didNotFit: ExcludedCandidate[];
+  deferredByLean: ExcludedCandidate[];
+  degradedToQuickWins: boolean;
+  durationsAreRough: boolean;
+  note: SuggestionNote | null;
+}
+
+interface Sized extends SuggestCandidate {
+  durationMinutes: number;
+  durationSource: DurationSource;
+}
+
+interface PassState {
+  remaining: number;
+  committed: Record<LeanSide, number>;
+  picks: SuggestedPick[];
+  deferred: Sized[];
+  didNotFit: Sized[];
+}
+
+// Ad-hoc items return null: they are exempt from the lean and are never
+// counted toward either side of the split.
+function leanSide(source: Source): LeanSide | null {
+  if (source === 'github_pr') return 'pr';
+  if (source === 'ado_workitem') return 'work_item';
+  return null;
+}
+
+// Ties break by score, then by oldest activity first, matching
+// sortByUrgency()'s tiebreak so two equal candidates never reorder between
+// the Suggested and All signals views. Rows with no activity timestamp carry
+// no staleness signal and sort last.
+function byValueDensity(a: Sized, b: Sized): number {
+  const densityA = a.score / a.durationMinutes;
+  const densityB = b.score / b.durationMinutes;
+  if (densityB !== densityA) return densityB - densityA;
+  if (b.score !== a.score) return b.score - a.score;
+  const timeA = a.rawUpdatedAt ? new Date(a.rawUpdatedAt).getTime() : Number.POSITIVE_INFINITY;
+  const timeB = b.rawUpdatedAt ? new Date(b.rawUpdatedAt).getTime() : Number.POSITIVE_INFINITY;
+  return timeA - timeB;
+}
+
+function take(state: PassState, item: Sized, pickReason: PickReason): void {
+  state.picks.push({
+    itemId: item.id,
+    durationMinutes: item.durationMinutes,
+    durationSource: item.durationSource,
+    pickReason,
+  });
+  state.remaining -= item.durationMinutes;
+  const side = leanSide(item.source);
+  if (side) state.committed[side] += item.durationMinutes;
+}
+
+function excluded(item: Sized, exclusionReason: ExclusionReason): ExcludedCandidate {
+  return {
+    itemId: item.id,
+    durationMinutes: item.durationMinutes,
+    durationSource: item.durationSource,
+    exclusionReason,
+  };
+}
+
+// One greedy pass over an ordering. A candidate is taken whenever it fits.
+function runPass(state: PassState, order: Sized[], pickReason: PickReason): void {
+  order.forEach((item) => {
+    if (item.durationMinutes > state.remaining) {
+      state.didNotFit.push(item);
+      return;
+    }
+    take(state, item, pickReason);
+  });
+}
+
+// The highest-scoring candidate long enough to be a day's anchor, provided it
+// fits. Scans in the caller's order so a score tie resolves the same way
+// sortByUrgency() already resolved it.
+function pickAnchor(order: Sized[], capacityMinutes: number): Sized | null {
+  let best: Sized | null = null;
+  for (const item of order) {
+    if (item.durationMinutes < ANCHOR_MIN_MINUTES) continue;
+    if (item.durationMinutes > capacityMinutes) continue;
+    if (!best || item.score > best.score) best = item;
+  }
+  return best;
+}
+
+/**
+ * Propose a day. Pure, and deliberately so: every rule here is a unit test
+ * away from being checked, which is the only reason a feature that recommends
+ * work belongs in a product whose thesis is that its ranking is inspectable.
+ *
+ * Never overfills. The returned picks always sum to at most capacityMinutes.
+ */
+export function suggestDay(input: SuggestInput): Suggestion {
+  const { candidates, capacityMinutes, algorithm, lean, medians, priorEstimates, pinnedTodayCount } = input;
+
+  const sizedCandidates: Sized[] = candidates.map((item) => {
+    const { minutes, source } = resolveDuration(item, medians, priorEstimates);
+    return { ...item, durationMinutes: minutes, durationSource: source };
+  });
+
+  const durationsAreRough = !Object.values(medians).some(
+    (median) => median !== undefined && median.sampleCount >= MIN_SAMPLES_FOR_MEDIAN
+  );
+
+  const empty: Suggestion = {
+    algorithm,
+    lean,
+    capacityMinutes,
+    suggestedMinutes: 0,
+    picks: [],
+    didNotFit: [],
+    deferredByLean: [],
+    degradedToQuickWins: false,
+    durationsAreRough,
+    note: null,
+  };
+
+  if (sizedCandidates.length === 0) {
+    return { ...empty, note: pinnedTodayCount > 0 ? 'all_pinned' : 'signals_empty' };
+  }
+
+  const state: PassState = {
+    remaining: capacityMinutes,
+    committed: { pr: 0, work_item: 0 },
+    picks: [],
+    deferred: [],
+    didNotFit: [],
+  };
+
+  let degradedToQuickWins = false;
+
+  if (algorithm === 'urgency') {
+    runPass(state, sizedCandidates, 'top_urgency');
+  } else if (algorithm === 'quick_wins') {
+    runPass(state, [...sizedCandidates].sort(byValueDensity), 'best_value');
+  } else {
+    const anchor = pickAnchor(sizedCandidates, capacityMinutes);
+    if (anchor) {
+      take(state, anchor, 'anchor');
+      const rest = sizedCandidates.filter((item) => item.id !== anchor.id).sort(byValueDensity);
+      runPass(state, rest, 'fills_room');
+    } else {
+      // No long item on the list, so this genuinely ran quick wins. Say so
+      // rather than presenting it as an anchored plan.
+      degradedToQuickWins = true;
+      runPass(state, [...sizedCandidates].sort(byValueDensity), 'best_value');
+    }
+  }
+
+  const didNotFit = state.didNotFit.map((item) => excluded(item, 'did_not_fit'));
+  const deferredByLean: ExcludedCandidate[] = [];
+  for (const item of state.deferred) {
+    // There was room and the lean is the only reason it is not on the list.
+    // Anything that no longer fits is reported for what it is instead.
+    if (item.durationMinutes <= state.remaining) {
+      deferredByLean.push(excluded(item, 'deferred_by_lean'));
+    } else {
+      didNotFit.push(excluded(item, 'did_not_fit'));
+    }
+  }
+
+  const suggestedMinutes = state.picks.reduce((sum, pick) => sum + pick.durationMinutes, 0);
+
+  let note: SuggestionNote | null = null;
+  if (state.picks.length === 0) {
+    note = 'capacity_too_small';
+  } else if (state.remaining > 0 && didNotFit.length > 0 && deferredByLean.length === 0) {
+    note = 'nothing_else_fits';
+  }
+
+  return {
+    algorithm,
+    lean,
+    capacityMinutes,
+    suggestedMinutes,
+    picks: state.picks,
+    didNotFit,
+    deferredByLean,
+    degradedToQuickWins,
+    durationsAreRough,
+    note,
+  };
+}

--- a/lib/suggest.ts
+++ b/lib/suggest.ts
@@ -65,6 +65,25 @@ export const FALLBACK_MINUTES: Record<WorkType, number> = {
 // What counts as "a long item" for the Balanced anchor.
 export const ANCHOR_MIN_MINUTES = 60;
 
+// Target share of capacity for Azure DevOps work items. The control the user
+// sees is this table, nothing more: no score is ever multiplied to produce a
+// suggestion, because a ranking number that disagreed with the score chip on
+// the same row would break the one promise this product actually makes.
+export const LEAN_WORK_ITEM_SHARE: Record<LeanNotch, number> = {
+  0: 0.2,
+  1: 0.35,
+  2: 0.5,
+  3: 0.65,
+  4: 0.8,
+};
+
+export const DEFAULT_LEAN: LeanNotch = 2;
+
+export function leanCaps(capacityMinutes: number, lean: LeanNotch): Record<LeanSide, number> {
+  const workItem = Math.round(capacityMinutes * LEAN_WORK_ITEM_SHARE[lean]);
+  return { work_item: workItem, pr: capacityMinutes - workItem };
+}
+
 /**
  * How long this item is likely to take, and where that number came from.
  *
@@ -196,13 +215,49 @@ function excluded(item: Sized, exclusionReason: ExclusionReason): ExcludedCandid
   };
 }
 
-// One greedy pass over an ordering. A candidate is taken whenever it fits.
-function runPass(state: PassState, order: Sized[], pickReason: PickReason): void {
-  order.forEach((item) => {
+// True when a later entry in this ordering sits on the other side of the
+// split and would fit the room that is left. This look-ahead is what makes a
+// cap self-lifting: the lean should shape a mix, never leave the day empty
+// because one side ran out of work.
+function otherSideStillHasAFit(order: Sized[], fromIndex: number, side: LeanSide, remaining: number): boolean {
+  for (let i = fromIndex; i < order.length; i += 1) {
+    const other = leanSide(order[i].source);
+    if (other && other !== side && order[i].durationMinutes <= remaining) return true;
+  }
+  return false;
+}
+
+// One greedy pass over an ordering, applying the lean as a soft cap.
+// Candidates the cap holds back land in state.deferred, and stay there: one
+// pass, no retry. Deferring can leave part of the day unspent, and the
+// instinct is to reclaim it, but unspent capacity sitting next to a
+// "Deferred by your lean" disclosure is the clearest possible report of what
+// the control just did. A retry that took the candidate anyway would make
+// that list almost always empty, and the lean would feel inert. The lean is
+// allowed to cost the user some minutes; it is not allowed to do so
+// invisibly.
+function runPass(
+  state: PassState,
+  order: Sized[],
+  pickReason: PickReason,
+  caps: Record<LeanSide, number>
+): void {
+  order.forEach((item, index) => {
     if (item.durationMinutes > state.remaining) {
       state.didNotFit.push(item);
       return;
     }
+
+    const side = leanSide(item.source);
+    if (
+      side &&
+      state.committed[side] + item.durationMinutes > caps[side] &&
+      otherSideStillHasAFit(order, index + 1, side, state.remaining)
+    ) {
+      state.deferred.push(item);
+      return;
+    }
+
     take(state, item, pickReason);
   });
 }
@@ -264,23 +319,28 @@ export function suggestDay(input: SuggestInput): Suggestion {
     didNotFit: [],
   };
 
+  const caps = leanCaps(capacityMinutes, lean);
+
   let degradedToQuickWins = false;
 
   if (algorithm === 'urgency') {
-    runPass(state, sizedCandidates, 'top_urgency');
+    runPass(state, sizedCandidates, 'top_urgency', caps);
   } else if (algorithm === 'quick_wins') {
-    runPass(state, [...sizedCandidates].sort(byValueDensity), 'best_value');
+    runPass(state, [...sizedCandidates].sort(byValueDensity), 'best_value', caps);
   } else {
     const anchor = pickAnchor(sizedCandidates, capacityMinutes);
     if (anchor) {
+      // The anchor takes no cap check by design: it is the one pick this
+      // strategy is named for, and capping it away would leave Balanced with
+      // nothing to anchor on.
       take(state, anchor, 'anchor');
       const rest = sizedCandidates.filter((item) => item.id !== anchor.id).sort(byValueDensity);
-      runPass(state, rest, 'fills_room');
+      runPass(state, rest, 'fills_room', caps);
     } else {
       // No long item on the list, so this genuinely ran quick wins. Say so
       // rather than presenting it as an anchored plan.
       degradedToQuickWins = true;
-      runPass(state, [...sizedCandidates].sort(byValueDensity), 'best_value');
+      runPass(state, [...sizedCandidates].sort(byValueDensity), 'best_value', caps);
     }
   }
 

--- a/lib/time-logs-repo.test.ts
+++ b/lib/time-logs-repo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { openDb } from './db';
-import { createAdhocItem } from './items-repo';
+import { createAdhocItem, upsertSyncedItem } from './items-repo';
 import { localDateString } from './date';
 import {
   startTimer,
@@ -13,6 +13,7 @@ import {
   sumHoursLoggedOnByItem,
   stopTimer,
   getRunningTimer,
+  medianMinutesByWorkType,
 } from './time-logs-repo';
 
 let db: Database.Database;
@@ -177,5 +178,67 @@ describe('getRunningTimer', () => {
     startTimer(db, item.id);
     stopTimer(db, item.id);
     expect(getRunningTimer(db)).toBeNull();
+  });
+});
+
+// duration_hours is what the schema stores; the engine wants minutes, so
+// these helpers write hours and assert on minutes deliberately.
+function logHours(database: Database.Database, id: number, hours: number) {
+  database
+    .prepare(
+      "INSERT INTO time_logs (item_id, started_at, ended_at, duration_hours) VALUES (?, '2026-09-01T09:00:00.000Z', '2026-09-01T10:00:00.000Z', ?)"
+    )
+    .run(id, hours);
+}
+
+function syncedItem(database: Database.Database, externalId: string, reason: 'review_requested' | 'authored') {
+  return upsertSyncedItem(database, {
+    source: 'github_pr',
+    externalId,
+    title: `PR ${externalId}`,
+    url: null,
+    reason,
+    dueDate: null,
+    sprintIteration: null,
+    rawUpdatedAt: null,
+    repo: 'org/repo',
+  });
+}
+
+describe('medianMinutesByWorkType', () => {
+  it('returns nothing when there are no logs', () => {
+    expect(medianMinutesByWorkType(db)).toEqual({});
+  });
+
+  it('takes the middle value for an odd number of samples', () => {
+    const item = syncedItem(db, 'pr-1', 'review_requested');
+    logHours(db, item.id, 0.5);
+    logHours(db, item.id, 1);
+    logHours(db, item.id, 3);
+    expect(medianMinutesByWorkType(db).review).toEqual({ medianMinutes: 60, sampleCount: 3 });
+  });
+
+  it('averages the two middle values for an even number of samples', () => {
+    const item = createAdhocItem(db, { title: 'A favour' });
+    logHours(db, item.id, 0.5);
+    logHours(db, item.id, 1.5);
+    expect(medianMinutesByWorkType(db).ad_hoc).toEqual({ medianMinutes: 60, sampleCount: 2 });
+  });
+
+  it('ignores a log with no recorded duration', () => {
+    const item = createAdhocItem(db, { title: 'A favour' });
+    logHours(db, item.id, 1);
+    db.prepare("INSERT INTO time_logs (item_id, started_at) VALUES (?, '2026-09-01T09:00:00.000Z')").run(item.id);
+    expect(medianMinutesByWorkType(db).ad_hoc).toEqual({ medianMinutes: 60, sampleCount: 1 });
+  });
+
+  it('groups by work type rather than by source', () => {
+    const review = syncedItem(db, 'pr-1', 'review_requested');
+    const ownWork = syncedItem(db, 'pr-2', 'authored');
+    logHours(db, review.id, 0.5);
+    logHours(db, ownWork.id, 2);
+    const medians = medianMinutesByWorkType(db);
+    expect(medians.review).toEqual({ medianMinutes: 30, sampleCount: 1 });
+    expect(medians.own_work).toEqual({ medianMinutes: 120, sampleCount: 1 });
   });
 });

--- a/lib/time-logs-repo.ts
+++ b/lib/time-logs-repo.ts
@@ -1,6 +1,8 @@
 import type Database from 'better-sqlite3';
-import type { TimeLog } from './types';
+import type { Reason, TimeLog } from './types';
 import { localDateString } from './date';
+import { classifyWorkType, type WorkType } from './calibration';
+import type { WorkTypeDuration } from './suggest';
 
 function rowToLog(row: any): TimeLog {
   return {
@@ -145,4 +147,36 @@ export function sumHoursLoggedOn(db: Database.Database, date: string): number {
   let total = 0;
   for (const hours of sumHoursLoggedOnByItem(db, date).values()) total += hours;
   return total;
+}
+
+// Median, not mean: one afternoon lost to a single work item should not
+// reprice the whole bucket for every future suggestion. Grouped by work type
+// rather than by source, so it lines up with the calibration report the user
+// already reads instead of being a second, competing classification.
+export function medianMinutesByWorkType(db: Database.Database): Partial<Record<WorkType, WorkTypeDuration>> {
+  const rows = db
+    .prepare(
+      `SELECT i.reason as reason, tl.duration_hours as durationHours
+       FROM time_logs tl JOIN items i ON i.id = tl.item_id
+       WHERE tl.duration_hours IS NOT NULL`
+    )
+    .all() as { reason: Reason; durationHours: number }[];
+
+  const byType = new Map<WorkType, number[]>();
+  for (const row of rows) {
+    const workType = classifyWorkType(row.reason);
+    const bucket = byType.get(workType) ?? [];
+    bucket.push(row.durationHours * 60);
+    byType.set(workType, bucket);
+  }
+
+  const result: Partial<Record<WorkType, WorkTypeDuration>> = {};
+  for (const [workType, minutes] of byType) {
+    minutes.sort((a, b) => a - b);
+    const middle = Math.floor(minutes.length / 2);
+    const medianMinutes =
+      minutes.length % 2 === 1 ? minutes[middle] : (minutes[middle - 1] + minutes[middle]) / 2;
+    result[workType] = { medianMinutes, sampleCount: minutes.length };
+  }
+  return result;
 }


### PR DESCRIPTION
Adds a "Suggest a day" surface to the plan ritual. It proposes a shortlist that fits the day's capacity, explains every pick, and writes nothing until you accept.

Spec and plan are in `docs/superpowers/` (gitignored).

## What it does

- **Three algorithms.** Urgency first (score order, greedy fit), Quick wins (best score per minute), Balanced (anchor on the top-scoring item over an hour, then fill with quick wins). Balanced with nothing long enough says so rather than pretending it anchored something.
- **A PRs-versus-work-items lean**, five notches from 80/20 to 20/80. It is a cap on how much of the day each side may take, never a weight on a score, so no number in the panel disagrees with the score chip on the same row. Ad-hoc items are exempt and count toward neither side.
- **Durations learned from your own logs.** Median actual minutes per work type, using the same four buckets `lib/calibration.ts` already defines, with a sample floor of 3 and fixed defaults below it. Resolution order: today's estimate, then the last estimate you gave the item, then the logged median, then the default.
- **Nothing is written until you press Pin.** Rows arrive checked, uncheck what you do not want. Dismiss changes nothing.
- **Derived durations never become estimates on their own.** They arrive in step 3 as placeholders plus one "Accept all rough durations" control. `getCalibrationSummary()` compares your estimate against actual logged time, so seeding it with the tool's own guesses would make the calibration loop measure itself.

## Where it lives

Step 2 of the existing wizard gains two modes, `Suggested` and `All signals`, rather than becoming a fifth step. Step 2 is already the choose step and a suggestion is a way of choosing; a separate step would have produced two lists to reconcile. `All signals` stays the default mode with its copy intact, and the entry points are a secondary button beside `Plan the day` plus the `i` shortcut.

## Three decisions worth a look

**The lean leaves the day short on purpose.** When the cap holds something back, the panel shows unspent capacity next to a `Deferred by your lean · N` list rather than filling the gap from the other side. A retry pass was written and then removed: it made that list almost always empty, which made the control feel inert. The lean is allowed to cost you minutes, it is not allowed to do so invisibly.

**`i`, not `S`.** `S` was the obvious mnemonic and is unusable. `GlobalKeymapProvider` lowercases the pressed key and `s` is row-scope Star, so both handlers would fire. `lib/keymap.ts` already documents that hazard, and it is why the priority cycle is `f` rather than `p`.

**`PRODUCT.md` moves a line.** The document said Ariadne never proposes an answer, and now it does, once asked. The `No auto-scheduling` constraint gains a clause covering what suggestion may and may not do, rather than being left quietly contradicted by the code.

## Also in here

Two pieces of adjacent cleanup the feature needed:

- `SegmentedChoice`, extracted from the grammar `PrioritySegments` established, now with three consumers. Equal-width segments are opt-in so the priority control keeps its exact proportions.
- `formatMinutes` was copied verbatim into three components and this would have been the fourth. The shared copy rounds the total before splitting it, so a fractional 119.6 minutes renders as `2h` rather than the `1h 60m` two of those copies produced.

`lib/scoring.ts` is untouched apart from nothing at all: the generated suggestion reference lives in `lib/suggest.ts` and `ScoringReferenceDialog` composes the two halves, so the module every ranking decision hangs off keeps no dependency on this feature.

## Testing

- 634 unit tests, 61 files. `lib/suggest.test.ts` covers the three strategies, the fit and capacity rules, every lean branch including the self-lifting cap, duration resolution and its fallbacks, the pool predicate, and each empty-state note.
- 32 e2e tests including three new ones: suggest and pin what you keep, dismiss changes nothing, and All signals keeps its own copy.
- Production build clean.
- Verified by hand against a copy of a real database: all three algorithms produce different plans, and at the work-item extreme PRs drop from 215 to 65 minutes with six rows deferred.
